### PR TITLE
Make the Earley parser closer to the spec and add a complete SPPF forest implementation.

### DIFF
--- a/lark/common.py
+++ b/lark/common.py
@@ -8,7 +8,7 @@ Py36 = (sys.version_info[:2] >= (3, 6))
 
 ###{standalone
 def is_terminal(sym):
-    return sym.isupper()
+    return sym.isupper() if sym is not None else False
 
 class GrammarError(Exception):
     pass

--- a/lark/lark.py
+++ b/lark/lark.py
@@ -58,7 +58,6 @@ class LarkOptions(object):
         self.profile = o.pop('profile', False)
         self.ambiguity = o.pop('ambiguity', 'auto')
         self.propagate_positions = o.pop('propagate_positions', False)
-        self.earley__predict_all = o.pop('earley__predict_all', False)
         self.lexer_callbacks = o.pop('lexer_callbacks', {})
 
         assert self.parser in ('earley', 'lalr', 'cyk', None)
@@ -172,7 +171,8 @@ class Lark:
     def _build_parser(self):
         self.parser_class = get_frontend(self.options.parser, self.options.lexer)
 
-        self._parse_tree_builder = ParseTreeBuilder(self.rules, self.options.tree_class, self.options.propagate_positions, self.options.keep_all_tokens)
+        ambiguity = self.options.ambiguity == 'explicit'
+        self._parse_tree_builder = ParseTreeBuilder(self.rules, self.options.tree_class, self.options.propagate_positions, self.options.keep_all_tokens, ambiguity)
         callback = self._parse_tree_builder.create_callback(self.options.transformer)
         if self.profiler:
             for f in dir(callback):

--- a/lark/parse_tree_builder.py
+++ b/lark/parse_tree_builder.py
@@ -4,6 +4,7 @@ from .common import is_terminal, GrammarError
 from .utils import suppress
 from .lexer import Token
 from .grammar import Rule
+from itertools import repeat, product
 
 ###{standalone
 
@@ -79,15 +80,37 @@ def maybe_create_child_filter(expansion, filter_out):
     if len(to_include) < len(expansion) or any(to_expand for i, to_expand in to_include):
         return partial(ChildFilter, to_include)
 
+class AmbiguousExpander:
+    def __init__(self, to_expand, tree_class, node_builder):
+        self.node_builder = node_builder
+        self.tree_class = tree_class
+        self.to_expand = to_expand
+
+    def __call__(self, children):
+        def _is_ambig_tree(child):
+            return hasattr(child, 'data') and child.data == '_ambig'
+
+        ambiguous = [i for i in self.to_expand if _is_ambig_tree(children[i])]
+        if ambiguous:
+            expand = [iter(child.children) if i in ambiguous else repeat(child) for i, child in enumerate(children)]
+            return self.tree_class('_ambig', [self.node_builder(list(f[0])) for f in product(zip(*expand))])
+        return self.node_builder(children)
+
+def maybe_create_ambiguous_expander(tree_class, expansion, filter_out):
+    to_expand = [i for i, sym in enumerate(expansion) if sym not in filter_out and _should_expand(sym)]
+
+    if to_expand:
+        return partial(AmbiguousExpander, to_expand, tree_class)
 
 class Callback(object):
     pass
 
 class ParseTreeBuilder:
-    def __init__(self, rules, tree_class, propagate_positions=False, keep_all_tokens=False):
+    def __init__(self, rules, tree_class, propagate_positions=False, keep_all_tokens=False, ambiguity=False):
         self.tree_class = tree_class
         self.propagate_positions = propagate_positions
         self.always_keep_all_tokens = keep_all_tokens
+        self.ambiguity = ambiguity
 
         self.rule_builders = list(self._init_builders(rules))
 
@@ -103,12 +126,14 @@ class ParseTreeBuilder:
             keep_all_tokens = self.always_keep_all_tokens or (options.keep_all_tokens if options else False)
             expand_single_child = options.expand1 if options else False
             create_token = options.create_token if options else False
+            ambiguity = self.ambiguity
 
             wrapper_chain = filter(None, [
                 create_token and partial(CreateToken, create_token),
                 (expand_single_child and not rule.alias) and ExpandSingleChild,
                 maybe_create_child_filter(rule.expansion, () if keep_all_tokens else filter_out),
                 self.propagate_positions and PropagatePositions,
+                ambiguity and maybe_create_ambiguous_expander(self.tree_class, rule.expansion, () if keep_all_tokens else filter_out),
             ])
 
             yield rule, wrapper_chain

--- a/lark/parser_frontends.py
+++ b/lark/parser_frontends.py
@@ -113,7 +113,6 @@ class XEarley:
                                     self.match,
                                     resolve_ambiguity=get_ambiguity_resolver(options),
                                     ignore=lexer_conf.ignore,
-                                    predict_all=options.earley__predict_all
                                     )
 
     def match(self, term, text, index=0):

--- a/lark/parsers/earley_common.py
+++ b/lark/parsers/earley_common.py
@@ -1,0 +1,127 @@
+"This module implements an Earley Parser"
+
+# The parser uses a parse-forest to keep track of derivations and ambiguations.
+# When the parse ends successfully, a disambiguation stage resolves all ambiguity
+# (right now ambiguity resolution is not developed beyond the needs of lark)
+# Afterwards the parse tree is reduced (transformed) according to user callbacks.
+# I use the no-recursion version of Transformer, because the tree might be
+# deeper than Python's recursion limit (a bit absurd, but that's life)
+#
+# The algorithm keeps track of each state set, using a corresponding Column instance.
+# Column keeps track of new items using NewsList instances.
+#
+# Author: Erez Shinan (2017)
+# Email : erezshin@gmail.com
+
+## for recursive repr
+from ..tree import Tree
+
+class Derivation(Tree):
+    def __init__(self, rule, children=None):
+        Tree.__init__(self, 'drv', children if children is not None else [])
+        self.rule = rule
+
+    def __repr__(self, indent = 0):
+        return 'Derivation(%s, %s, %s)' % (self.data, self.rule.origin, '...')
+
+    def __hash__(self):
+        return hash((self.data, tuple(self.children)))
+
+class LR0(object):
+    def __init__(self, rule, ptr):
+        self.rule = rule
+        self.ptr = ptr
+
+    @property
+    def expect(self):
+        if self.ptr >= len(self.rule.expansion):
+            return None
+        return self.rule.expansion[self.ptr]
+
+    @property
+    def previous(self):
+        if self.ptr <= 0:
+            return None
+        return self.rule.expansion[self.ptr - 1]
+
+    @property
+    def is_complete(self):
+        return self.ptr >= len(self.rule.expansion)
+
+    @property
+    def before(self):
+        return list(map(str, self.rule.expansion[:self.ptr]))
+
+    @property
+    def after(self):
+        return list(map(str, self.rule.expansion[self.ptr:]))
+
+    def advance(self):
+        assert self.ptr < len(self.rule.expansion), "LR0 being advanced past end of production"
+        return self.__class__(self.rule, self.ptr + 1)
+
+    def __eq__(self, other):
+        if not isinstance(other, LR0):
+            return False
+        if self is other:
+            return True
+        if self.is_complete and other.is_complete:
+            return self.rule.origin == other.rule.origin
+        return self.rule == other.rule and self.ptr == other.ptr
+
+    def __hash__(self):
+        if self.is_complete:
+            return hash(self.rule.origin)
+        else:
+            return hash((self.rule, self.ptr))
+
+    def __repr__(self):
+        if self.is_complete:
+            return '<%s>' % (self.rule.origin)
+        else:
+            return '<%s -> %s * %s>' % (self.rule.origin, ' '.join(self.before), ' '.join(self.after))
+
+class Item(object):
+    "An Earley Item, the atom of the algorithm."
+
+    def __init__(self, s, start, node = None):
+        self.s = s          # lr0
+        self.start = start  # j
+        self.node = node    # w
+
+    def advance(self):
+        return self.__class__(self.s.advance(), self.start, self.node)
+
+    @property
+    def is_complete(self):
+        return self.s.is_complete
+
+    def __eq__(self, other):
+        if not isinstance(other, Item):
+            return False
+        return self is other or (self.s == other.s and self.start.i == other.start.i)
+
+    def __hash__(self):
+        return hash((self.s, self.start.i))
+
+    def __repr__(self):
+        return '%s (%d)' % (repr(self.s), self.start.i)
+
+class Column:
+    "An entry in the table, aka Earley Chart. Contains lists of items."
+    def __init__(self, i, FIRST):
+        self.i = i
+        self.items = list()
+        self.FIRST = FIRST
+
+    def add(self, item):
+        """Sort items into scan/predict/reduce newslists
+
+        Makes sure only unique items are added.
+        """
+        self.items.append(item)
+
+    def __bool__(self):
+        return bool(self.items)
+
+    __nonzero__ = __bool__  # Py2 backwards-compatibility

--- a/lark/parsers/earley_forest.py
+++ b/lark/parsers/earley_forest.py
@@ -1,0 +1,268 @@
+from ..lexer import Token
+from ..tree import Tree
+from ..utils import convert_camelcase
+from ..common import ParseError
+from .earley_common import Column, Derivation, LR0
+from collections import Iterator
+
+class PackedNode(object):
+    def __init__(self, parent, s, start, left, right):
+        assert isinstance(parent, (SymbolNode, IntermediateNode))
+        assert isinstance(s, LR0)
+        assert isinstance(start, Column)
+        assert isinstance(left, (TokenNode, SymbolNode, IntermediateNode)) or left is None
+        assert isinstance(right, (TokenNode, SymbolNode, IntermediateNode)) or right is None
+        self.parent = parent
+        self.s = s
+        self.start = start
+        self.left = left
+        self.right = right
+        self.priority = 0
+
+    def __eq__(self, other):
+        if not isinstance(other, PackedNode):
+            return False
+        return self is other or (self.s == other.s and self.start == other.start and self.left == other.left and self.right == other.right)
+
+    def __hash__(self):
+        return hash((hash(self.s), self.start.i, hash(self.left), hash(self.right)))
+
+    def __repr__(self):
+        return "{%s, %d, %s, %s}" % (self.s, self.start.i, self.left, self.right)
+
+class IntermediateNode(object):
+    def __init__(self, s, start, end):
+        assert isinstance(s, LR0)
+        assert isinstance(start, Column)
+        assert isinstance(end, Column)
+        self.s = s
+        self.start = start
+        self.end = end
+        self.children = None
+        self.priority = 0
+
+    def add_family(self, lr0, start, left, right):
+        packed_node = PackedNode(self, lr0, start, left, right)
+        if self.children is None:
+            self.children = [ packed_node ]
+        if packed_node not in self.children:
+            self.children.append(packed_node)
+
+    @property
+    def is_ambiguous(self):
+        return len(self.children) > 1
+
+    def __eq__(self, other):
+        if not isinstance(other, IntermediateNode):
+            return False
+        return self is other or (self.s == other.s and self.start == other.start and self.end == other.end)
+
+    def __hash__(self):
+        return hash((hash(self.s), self.start.i, self.end.i))
+
+    def __repr__(self):
+        return "[%s, %d, %d]" % (self.s, self.start.i, self.end.i)
+
+class SymbolNode(object):
+    def __init__(self, s, start, end):
+        assert isinstance(s, LR0)
+        assert isinstance(start, Column)
+        assert isinstance(end, Column)
+        self.s = s
+        self.start = start
+        self.end = end
+        self.children = None
+        self.priority = 0
+
+    def add_family(self, lr0, start, left, right):
+        # Note which production is responsible for this subtree,
+        # to help navigate the tree in case of ambiguity
+        packed_node = PackedNode(self, lr0, start, left, right)
+        if self.children is None:
+            self.children = [ packed_node ]
+        if packed_node not in self.children:
+            self.children.append(packed_node)
+
+    @property
+    def is_ambiguous(self):
+        return len(self.children) > 1
+
+    def __eq__(self, other):
+        if not isinstance(other, SymbolNode):
+            return False
+        return self is other or (self.s == other.s and self.start == other.start and self.end == other.end)
+
+    def __hash__(self):
+        return hash((hash(self.s), self.start.i, self.end.i))
+
+    def __repr__(self):
+        return "(%s, %d, %d)" % (self.s.rule.origin, self.start.i, self.end.i)
+
+
+class TokenNode(object):
+    def __init__(self, token, start, end):
+        assert isinstance(token, Token)
+        assert isinstance(start, Column)
+        assert isinstance(end, Column)
+        self.token = token
+        self.start = start
+        self.end = end
+
+    def __eq__(self, other):
+        if not isinstance(other, TokenNode):
+            return False
+        return self is other or (self.token == other.token and self.start == other.start and self.end == other.end)
+
+    def __hash__(self):
+        return hash((self.token, self.start.i, self.end.i))
+
+    def __repr__(self):
+        return "(%s, %s, %s)" % (self.token, self.start.i, self.end.i)
+
+class Forest(object):
+    def __init__(self):
+        self.node_cache = {}
+        self.token_cache = {}
+
+    def reset(self):
+        pass
+
+    def make_intermediate_or_symbol_node(self, lr0, start, end):
+        assert isinstance(lr0, LR0)
+        assert isinstance(start, Column)
+        assert isinstance(end, Column)
+        if lr0.is_complete:
+            label = (lr0.rule.origin, start.i, end.i)
+            node = self.node_cache.setdefault(label, SymbolNode(lr0, start, end))
+        else:
+            label = (lr0, start.i, end.i)
+            node = self.node_cache.setdefault(label, IntermediateNode(lr0, start, end))
+        return node
+
+    def make_token_node(self, token, start, end):
+        assert isinstance(token, Token)
+        assert isinstance(start, Column)
+        assert isinstance(end, Column)
+        label = (token, start.i, end.i)
+        return self.token_cache.setdefault(label, TokenNode(token, start, end))
+
+    def make_null_node(self, lr0, column):
+        assert isinstance(lr0, LR0)
+        assert isinstance(column, Column)
+        if lr0.is_complete:
+            label = (lr0.rule.origin, column.i, column.i)
+            node = self.node_cache.setdefault(label, SymbolNode(lr0, column, column))
+        else:
+            label = (lr0, column.i, column.i)
+            node = self.node_cache.setdefault(label, IntermediateNode(lr0, column, column))
+        node.add_family(lr0, column, None, None)
+        return node
+
+class ForestVisitor(object):
+    def __init__(self, forest, root):
+        self.forest = forest
+        self.root = root
+
+    def go(self):
+        visiting = set([])
+        input_stack = [self.root]
+        while input_stack:
+            current = next(reversed(input_stack))
+
+            if isinstance(current, Iterator):
+                try:
+                    next_node = next(current)
+                except StopIteration:
+                    input_stack.pop()
+                else:
+                    if next_node is None:
+                        continue
+
+                    if id(next_node) in visiting:
+                        raise ParseError("Infinite recursion in grammar!")
+
+                    input_stack.append(next_node)
+                continue
+            elif current == None:
+                input_stack.pop()
+                continue
+
+            function_name = "visit_" + convert_camelcase(current.__class__.__name__)
+            if id(current) in visiting:
+                function_name += "_out"
+            else:
+                function_name += "_in"
+
+            f = None
+            try:
+                f = getattr(self, function_name)
+            except AttributeError:
+                pass
+
+            if id(current) in visiting:
+                if f:
+                    f(current)
+                input_stack.pop()
+                visiting.remove(id(current))
+                continue
+            else:
+                visiting.add(id(current))
+                if f:
+                    next_node = f(current)
+                    if next_node is None:
+                        continue
+
+                    if id(next_node) in visiting:
+                        raise ParseError("Infinite recursion in grammar!")
+
+                    input_stack.append(next_node)
+                continue
+
+        return self.result
+
+class ForestToTreeVisitor(ForestVisitor):
+    def __init__(self, forest, root):
+        super(ForestToTreeVisitor, self).__init__(forest, root)
+        self.output_stack = []
+        self.result = None
+
+    def visit_token_node_in(self, node):
+        if self.output_stack:
+            self.output_stack[-1].children.append(node.token)
+        return None
+
+    def visit_symbol_node_in(self, node):
+        if node.is_ambiguous:
+            ambiguous = Tree('_ambig', [])
+            if self.output_stack:
+                self.output_stack[-1].children.append(ambiguous)
+            self.output_stack.append(ambiguous)
+        else:
+            drv = Derivation(node.s.rule, [])
+            if self.output_stack:
+                self.output_stack[-1].children.append(drv)
+            self.output_stack.append(drv)
+        return iter(node.children)
+
+    def visit_symbol_node_out(self, node):
+        self.result = self.output_stack.pop()
+
+    def visit_intermediate_node_in(self, node):
+        return iter(node.children)
+
+    def visit_packed_node_in(self, node):
+        if node.parent.is_ambiguous:
+            drv = Derivation(node.s.rule, [])
+            if self.output_stack:
+                if isinstance(node.parent, SymbolNode):
+                    self.output_stack[-1].children.append(drv)
+                ### Special case: ambiguous intermediates should layer their derivation under the parent's _ambig, not the parent drv
+                else:
+                    self.output_stack[-2].children.append(drv)
+            self.output_stack.append(drv)
+        return iter([node.left, node.right])
+
+    def visit_packed_node_out(self, node):
+        if node.parent.is_ambiguous:
+            drv = self.output_stack.pop()
+            drv.priority = node.priority

--- a/lark/parsers/resolve_ambig.py
+++ b/lark/parsers/resolve_ambig.py
@@ -14,6 +14,9 @@ def _compare_rules(rule1, rule2):
         c = -c
     return c
 
+def _compare_empty(tree1, tree2):
+    c = -compare(not bool(len(tree1.children)), not bool(len(tree2.children)))
+    return c
 
 def _sum_priority(tree):
     p = 0
@@ -42,6 +45,11 @@ def _compare_drv(tree1, tree2):
 
     assert tree1.data != '_ambig'
     assert tree2.data != '_ambig'
+
+    # Ranged rules ("A"0..4) can match empty and items at the same time, depreference the empty
+    c = _compare_empty(tree1, tree2)
+    if c:
+        return c
 
     p1 = _sum_priority(tree1)
     p2 = _sum_priority(tree2)

--- a/lark/utils.py
+++ b/lark/utils.py
@@ -50,6 +50,7 @@ except NameError:   # Python 3
 
 import types
 import functools
+import re
 from contextlib import contextmanager
 
 Str = type(u'')
@@ -101,6 +102,10 @@ except ImportError:
             yield
         except excs:
             pass
+
+def convert_camelcase(name):
+    s1 = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
+    return re.sub('([a-z0-9])([A-Z])', r'\1_\2', s1).lower()
 
 ###}
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -254,6 +254,28 @@ def _make_full_earley_test(LEXER):
             assert x.data == '_ambig', x
             assert len(x.children) == 2
 
+        @unittest.skipIf(LEXER==None, "Scanless doesn't support regular expressions")
+        def test_ambiguity2(self):
+            grammar = """
+            ANY:  /[a-zA-Z0-9 ]+/
+            a.2: "A" b+
+            b.2: "B" 
+            c:   ANY
+
+            start: (a|c)*
+            """
+            l = Lark(grammar, parser='earley', lexer=LEXER)
+            res = l.parse('ABX')
+            expected = Tree('start', [
+                    Tree('a', [
+                        Tree('b', [])
+                    ]),
+                    Tree('c', [
+                        'X'
+                    ])
+                ])
+            self.assertEqual(res, expected)
+
         @unittest.skipIf(LEXER==None, "BUG in scanless parsing!")  # TODO fix bug!
         def test_fruitflies_ambig(self):
             grammar = """


### PR DESCRIPTION
Key changes:
Add Items to the current Column and ensure unique *before* adding derivations
  - Ensures all derivations get added to the same unique items.

Add rudimentary SPPF type implementation to derivations, indexed on start and end, end as per:
  - https://www.sciencedirect.com/science/article/pii/S1571066108001497
  - This was required after with fixed _ambig detection.

Remove earley__predict_all property.
  - No longer needed after the above two changes.