### PR TITLE
Fix/Workaround for new lines when using the verbose flag

### DIFF
--- a/lark/common.py
+++ b/lark/common.py
@@ -94,7 +94,12 @@ class PatternStr(Pattern):
 
 class PatternRE(Pattern):
     def to_regexp(self):
-        return self._get_flags(self.value)
+        regexp = self._get_flags(self.value)
+        regexp = regexp.replace('\f', '\\f')
+        regexp = regexp.replace('\t', '\\t')
+        regexp = regexp.replace('\r', '\\r')
+        regexp = regexp.replace('\n', '\\n')
+        return regexp
 
     @property
     def min_width(self):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -691,7 +691,6 @@ def _make_parser_test(LEXER, PARSER):
                       """)
             x = g.parse('\n')
 
-
         def test_backslash2(self):
             g = _Lark(r"""start: "\"" "-"
                       """)
@@ -803,6 +802,13 @@ def _make_parser_test(LEXER, PARSER):
             tree = l.parse('aA')
             self.assertEqual(tree.children, ['a', 'A'])
 
+        def test_token_flags_verbose(self):
+            g = _Lark(r"""start: NL | ABC
+                          ABC: / [a-z] /x
+                          NL: /\n/
+                      """)
+            x = g.parse('a')
+            self.assertEqual(x.children, ['a'])
 
         @unittest.skipIf(PARSER == 'cyk', "No empty rules")
         def test_twice_empty(self):


### PR DESCRIPTION
The underlying problem is that previous to Python 3.6 setting flags in a regexp affects the whole pattern even if they are part of a capturing group.

From https://docs.python.org/3/library/re.html (emphasis mine):
> (?aiLmsux)
    (One or more letters from the set 'a', 'i', 'L', 'm', 's', 'u', 'x'.) The group matches the empty string; the letters set the corresponding flags: re.A (ASCII-only matching), re.I (ignore case), re.L (locale dependent), re.M (multi-line), re.S (dot matches all), re.U (Unicode matching), and re.X (verbose), **for the entire regular expression**. (The flags are described in Module Contents.) This is useful if you wish to include the flags as part of the regular expression, instead of passing a flag argument to the re.compile() function. Flags should be used first in the expression string.

As far as I can tell the lexer does not take this into account when building the tokens patterns and just mixes tokens with different modifiers into a single pattern.

These changes are for a specific use case where using the `/x` modifier (verbose mode) was breaking the parser since the generated expression was something like `u'(?P<NEWLINE>\n)|(?P<VERBOSE>(?x)  foo  )'`. When Python evaluates the string the `x` flag applies to the whole pattern and the `\n` has been converted to an actual new line, hence white space and ignored, producing a zero-width match for any input.

While this solves that specific use case it doesn't fixes all the issues of the underlying problem though. Short of pre-processing the patterns to convert them to the sum of all modes I think the parser should error out if it needs to bundle patterns with different sets of flags.