### PR TITLE
interpreter: default behavior changed to return the values

### DIFF
--- a/lark/tree.py
+++ b/lark/tree.py
@@ -195,7 +195,7 @@ class Interpreter(object):
         return self.__default__
 
     def __default__(self, tree):
-        self.visit_children(tree)
+        return self.visit_children(tree)
 
 
 class Transformer_NoRecurse(Transformer):

--- a/tests/test_trees.py
+++ b/tests/test_trees.py
@@ -49,6 +49,14 @@ class TestTrees(TestCase):
 
         self.assertEqual(Interp2().visit(t), list('BCde'))
 
+        class Interp3(Interpreter):
+            def b(self, tree):
+                return 'B'
+
+            def c(self, tree):
+                return 'C'
+
+        self.assertEqual(Interp3().visit(t), list('BCd'))
 
 
 


### PR DESCRIPTION
this behavior seems to be almost always the preferred one, now you don't need to define a handler for nodes that just visit all their children and return all values