### PR TITLE
adding importer and related tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ python:
   - "pypy"  # PyPy2 5.8.0
   - "pypy3" # Pypy3 5.8.0-beta0
 script:
-  - pip install -r nearley-requirements.txt
+  - pip install -r nearley-requirements.txt filefinder2
   - python -m tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - "3.6"
   - "pypy"  # PyPy2 5.8.0
   - "pypy3" # Pypy3 5.8.0-beta0
-install: pip install tox-travis filefinder
+install: pip install tox-travis filefinder2
 script:
   - pip install filefinder2
   - tox

--- a/lark/importer/__init__.py
+++ b/lark/importer/__init__.py
@@ -23,7 +23,10 @@ class LarkImporter:
         self._lfh = LarkFinder.path_hook((LarkLoader, self.extensions), )
 
         if self._lfh not in sys.path_hooks:
-            sys.path_hooks.insert(filefinder2.get_filefinder_index_in_path_hooks(), self._lfh)
+            if filefinder2.ff_path_hook in sys.path_hooks:
+                sys.path_hooks.insert(sys.path_hooks.index(filefinder2.ff_path_hook), self._lfh)
+            else:
+                sys.path_hooks.append(self._lfh)
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         # CAREFUL : Even though we remove the path from sys.path,

--- a/lark/importer/__init__.py
+++ b/lark/importer/__init__.py
@@ -1,0 +1,37 @@
+import sys
+import filefinder2
+
+from .finder import LarkFinder
+from .loader import LarkLoader
+
+
+class LarkImporter:
+    """
+    Context manager for activating/deactivating *.lark imports
+    """
+    def __init__(self, extensions=None):
+        self.extensions = extensions or ['.lark']
+        pass
+
+    def __enter__(self):
+        # Resetting sys.path_importer_cache to get rid of previous importers
+        sys.path_importer_cache.clear()
+        # TODO : investigate BUG here, sometime debugger (pycharm) needs to have a break here to actually drop his importer_cache
+        # This can lead to finder not being called if Python's FileFinder is already cached (for current dir for example)
+
+        # we hook the grammar customized loader
+        self._lfh = LarkFinder.path_hook((LarkLoader, self.extensions), )
+
+        if self._lfh not in sys.path_hooks:
+            sys.path_hooks.insert(filefinder2.get_filefinder_index_in_path_hooks(), self._lfh)
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        # CAREFUL : Even though we remove the path from sys.path,
+        # initialized finders will remain in sys.path_importer_cache
+
+        # removing path_hook
+        sys.path_hooks.pop(sys.path_hooks.index(self._lfh))
+
+        # Resetting sys.path_importer_cache to get rid of previous cached importers
+        sys.path_importer_cache.clear()
+

--- a/lark/importer/_utils.py
+++ b/lark/importer/_utils.py
@@ -1,0 +1,24 @@
+from __future__ import absolute_import, print_function
+
+import sys
+
+
+def _verbose_message(message, *args, **kwargs):
+    """Print the message to stderr if -v/PYTHONVERBOSE is turned on."""
+    verbosity = kwargs.pop('verbosity', 1)
+    if sys.flags.verbose >= verbosity:
+        if not message.startswith(('#', 'import ')):
+            message = '# ' + message
+        print(message.format(*args), file=sys.stderr)
+
+
+try:
+    ImportError('msg', name='name', path='path')
+except TypeError:
+    class _ImportError(ImportError):
+        def __init__(self, *args, **kwargs):
+            self.name = kwargs.pop('name', None)
+            self.path = kwargs.pop('path', None)
+            super(_ImportError, self).__init__(*args, **kwargs)
+else:
+    _ImportError = ImportError

--- a/lark/importer/finder.py
+++ b/lark/importer/finder.py
@@ -1,0 +1,74 @@
+"""
+A module to find and setup custom loader for .lark files
+Upon import, it will first find the .lark file, then instantiate and use the custom loader for it.
+"""
+
+# We need to be extra careful with python versions
+# Ref : https://docs.python.org/dev/library/importlib.html#importlib.import_module
+
+import os
+import logging
+
+from ._utils import _ImportError, _verbose_message
+
+import filefinder2.machinery
+
+from._utils import _verbose_message
+
+
+class LarkFinder(filefinder2.machinery.FileFinder):
+    """PathEntryFinder to handle finding Lark grammars"""
+
+    def __init__(self, path, *loader_details):
+        super(LarkFinder, self).__init__(path, *loader_details)
+
+    def __repr__(self):
+        return 'LarkFinder({!r})'.format(self.path)
+
+    @classmethod
+    def path_hook(cls, *loader_details):
+        """A class method which returns a closure to use on sys.path_hook
+        which will return an instance using the specified loaders and the path
+        called on the closure.
+
+        If the path called on the closure is not a directory, or doesnt contain
+         any files with the supported extension, ImportError is raised.
+
+         This is different from default python behavior
+         but prevent polluting the cache with custom finders
+        """
+        def path_hook_for_LarkFinder(path):
+            """Path hook for importlib.machinery.FileFinder."""
+
+            if not (os.path.isdir(path)):
+                raise _ImportError('only directories are supported')
+
+            exts = [x for ld in loader_details for x in ld[1]]
+            if not any(fname.endswith(ext) for fname in os.listdir(path) for ext in exts):
+                raise _ImportError(
+                    'only directories containing {ext} files are supported'.format(ext=", ".join(exts)),
+                    path=path)
+            return cls(path, *loader_details)
+
+        return path_hook_for_LarkFinder
+
+    def find_spec(self, fullname, target=None):
+        """
+        Try to find a spec for the specified module.
+        :param fullname: the name of the package we are trying to import
+        :return: the matching spec, or None if not found.
+        """
+
+        # We attempt to load a .lark file as a module
+        tail_module = fullname.rpartition('.')[2]
+        base_path = os.path.join(self.path, tail_module)
+        for suffix, loader_class in self._loaders:
+            full_path = base_path + suffix
+            if os.path.isfile(full_path):  # maybe we need more checks here (importlib filefinder checks its cache...)
+                return self._get_spec(loader_class, fullname, full_path, None, target)
+
+        # Otherwise, we try find python modules (to be able to embed .lark files within python packages)
+        return super(LarkFinder, self).find_spec(fullname=fullname, target=target)
+
+
+

--- a/lark/importer/loader.py
+++ b/lark/importer/loader.py
@@ -1,0 +1,34 @@
+"""
+A module to load lark grammar files
+"""
+
+# We need to be extra careful with python versions
+# Ref : https://docs.python.org/dev/library/importlib.html#importlib.import_module
+
+import filefinder2.machinery
+
+import lark  # just to make sure lark is loaded and our generated python code can be interpreted
+from._utils import _verbose_message
+
+
+class LarkLoader(filefinder2.machinery.SourceFileLoader):
+
+    # CAREFUL : on some python versions, removing get_code breaks the loader.
+    def get_code(self, fullname):
+        source = self.get_source(fullname)
+        _verbose_message('importing code for "{0}"'.format(fullname))
+        try:
+            code = self.source_to_code(source, self.get_filename(fullname))
+            return code
+        except TypeError:
+            raise
+
+    def get_source(self, name):
+        """Implementing actual python code from file content"""
+        path = self.get_filename(name)
+
+        # Returns decoded string from source file
+        larkstr = super(LarkLoader, self).get_source(name)
+        larkstr = "from lark import Lark; parser = Lark(\"\"\"{larkstr}\"\"\", parser='lalr')""".format(**locals())
+
+        return larkstr

--- a/setup.py
+++ b/setup.py
@@ -6,10 +6,10 @@ __version__ ,= re.findall('__version__ = "(.*)"', open('lark/__init__.py').read(
 setup(
     name = "lark-parser",
     version = __version__,
-    packages = ['lark', 'lark.parsers', 'lark.tools', 'lark.grammars'],
+    packages = ['lark', 'lark.parsers', 'lark.tools', 'lark.grammars', 'lark.importer'],
 
     requires = [],
-    install_requires = [],
+    install_requires = ['filefinder2'],
 
     package_data = { '': ['*.md', '*.g'] },
 

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -14,6 +14,8 @@ except ImportError:
 # from .test_selectors import TestSelectors
 # from .test_grammars import TestPythonG, TestConfigG
 
+from .test_importer import TestImporter
+
 from .test_parser import (
         TestLalrStandard,
         TestEarleyStandard,

--- a/tests/test_importer/__init__.py
+++ b/tests/test_importer/__init__.py
@@ -1,0 +1,1 @@
+from .test_importer import TestImporter

--- a/tests/test_importer/calc.lark
+++ b/tests/test_importer/calc.lark
@@ -1,0 +1,25 @@
+//
+// Simple calculator grammar
+//
+
+?start: sum
+      | NAME "=" sum    -> assign_var
+
+?sum: product
+    | sum "+" product   -> add
+    | sum "-" product   -> sub
+
+?product: atom
+    | product "*" atom  -> mul
+    | product "/" atom  -> div
+
+?atom: NUMBER           -> number
+     | "-" atom         -> neg
+     | NAME             -> var
+     | "(" sum ")"
+
+%import common.CNAME -> NAME
+%import common.NUMBER
+%import common.WS_INLINE
+
+%ignore WS_INLINE

--- a/tests/test_importer/test_importer.py
+++ b/tests/test_importer/test_importer.py
@@ -1,0 +1,61 @@
+from lark.importer import LarkImporter
+
+
+import pytest
+import palimport.lark
+
+"""
+Module testing that the calc.lark grammar actually parses string as expected
+"""
+
+with LarkImporter():
+    # This will build a lark instance
+    if __package__ is not None:
+        from . import calc
+    else:  # running standalone
+        import calc
+
+
+def test_calc_add():
+
+    assert calc.parser.parse("3 + 2", ).pretty() == """add
+  number\t3
+  number\t2
+"""
+
+
+def test_calc_sub():
+
+    assert calc.parser.parse("3 - 2", ).pretty() == """sub
+  number\t3
+  number\t2
+"""
+
+
+def test_calc_mul():
+
+    assert calc.parser.parse("3 * 2", ).pretty() == """mul
+  number\t3
+  number\t2
+"""
+
+
+def test_calc_div():
+
+    assert calc.parser.parse("3 / 2", ).pretty() == """div
+  number\t3
+  number\t2
+"""
+
+
+def test_calc_assign():
+
+    assert calc.parser.parse("b = 2", ).pretty() == """assign_var
+  b
+  number\t2
+"""
+
+
+if __name__ == '__main__':
+    pytest.main(['-s'])
+

--- a/tests/test_importer/test_importer.py
+++ b/tests/test_importer/test_importer.py
@@ -1,8 +1,7 @@
 from lark.importer import LarkImporter
 
+import unittest
 
-import pytest
-import palimport.lark
 
 """
 Module testing that the calc.lark grammar actually parses string as expected
@@ -16,46 +15,47 @@ with LarkImporter():
         import calc
 
 
-def test_calc_add():
+class TestImporter(unittest.TestCase):
+    def test_calc_add(self):
 
-    assert calc.parser.parse("3 + 2", ).pretty() == """add
+        assert calc.parser.parse("3 + 2", ).pretty() == """add
   number\t3
   number\t2
 """
 
 
-def test_calc_sub():
+    def test_calc_sub(self):
 
-    assert calc.parser.parse("3 - 2", ).pretty() == """sub
+        assert calc.parser.parse("3 - 2", ).pretty() == """sub
   number\t3
   number\t2
 """
 
 
-def test_calc_mul():
+    def test_calc_mul(self):
 
-    assert calc.parser.parse("3 * 2", ).pretty() == """mul
+        assert calc.parser.parse("3 * 2", ).pretty() == """mul
   number\t3
   number\t2
 """
 
 
-def test_calc_div():
+    def test_calc_div(self):
 
-    assert calc.parser.parse("3 / 2", ).pretty() == """div
+        assert calc.parser.parse("3 / 2", ).pretty() == """div
   number\t3
   number\t2
 """
 
 
-def test_calc_assign():
+    def test_calc_assign(self):
 
-    assert calc.parser.parse("b = 2", ).pretty() == """assign_var
+        assert calc.parser.parse("b = 2", ).pretty() == """assign_var
   b
   number\t2
 """
 
 
 if __name__ == '__main__':
-    pytest.main(['-s'])
+    unittest.main()
 


### PR DESCRIPTION
Not ready for merge. For feedback only.

Tested locally on python 3.5 only (tox PR #144, this PR will need rebasing)

Few notes : 

- the filefinder2 dependency is here to support PEP420 (namespace packages) even in python2, and unify the python import API between python2 and python3. It might be desirable or not here... we could drop it and add one importer for python2 ( no namespace package support) and keep this one for python3 (much better import logic in interpreter). But that might complexify the import logic here.

- the test code might be too simplistic, or misguided... the point here is not to check the grammar, but to check the import system works, no matter the type of file structure and environment one can have. But in practice this can be quite hard to define and include in an automated python test... I ll take any suggestion

- Even if import doesn't provide any syntax for it, we might want to somehow parametrize the parser ? maybe through LarkImporter