### PR TITLE
Makes cyk.py deterministic

### DIFF
--- a/lark/parsers/cyk.py
+++ b/lark/parsers/cyk.py
@@ -83,7 +83,7 @@ class Grammar(object):
     """Context-free grammar."""
 
     def __init__(self, rules):
-        self.rules = frozenset(rules)
+        self.rules = tuple(sorted(rules, key=lambda x: str(x)))
 
     def __eq__(self, other):
         return self.rules == other.rules


### PR DESCRIPTION
Makes cyk.py deterministic by replacing frozenset(...) with tuple(sorted(...))

Non deterministic behavior in cyk.py gives inconsistent results in our parses.