### PR TITLE
Correct parameters to UnexpectedToken

### DIFF
--- a/lark/parsers/earley.py
+++ b/lark/parsers/earley.py
@@ -197,7 +197,7 @@ class Parser:
 
             if not next_set:
                 expect = {i.expect for i in column.to_scan}
-                raise UnexpectedToken(token, expect, stream, set(column.to_scan))
+                raise UnexpectedToken(token, expect, stream, i, set(column.to_scan))
 
             return next_set
 


### PR DESCRIPTION
Without this, UnexpectedToken will always display <no context> even if it could show context.