### PR TITLE
Slots fix

### DIFF
--- a/lark/common.py
+++ b/lark/common.py
@@ -11,14 +11,14 @@ Py36 = (sys.version_info[:2] >= (3, 6))
 
 
 
-class LexerConf:
+class LexerConf(object):
     def __init__(self, tokens, ignore=(), postlex=None, callbacks=None):
         self.tokens = tokens
         self.ignore = ignore
         self.postlex = postlex
         self.callbacks = callbacks or {}
 
-class ParserConf:
+class ParserConf(object):
     def __init__(self, rules, callback, start):
         self.rules = rules
         self.callback = callback

--- a/lark/grammar.py
+++ b/lark/grammar.py
@@ -46,7 +46,7 @@ class Rule(object):
         return 'Rule(%r, %r, %r, %r)' % (self.origin, self.expansion, self.alias, self.options)
 
 
-class RuleOptions:
+class RuleOptions(object):
     def __init__(self, keep_all_tokens=False, expand1=False, priority=None):
         self.keep_all_tokens = keep_all_tokens
         self.expand1 = expand1

--- a/lark/lexer.py
+++ b/lark/lexer.py
@@ -43,7 +43,7 @@ class Token(Str):
     __hash__ = Str.__hash__
 
 
-class LineCounter:
+class LineCounter(object):
     def __init__(self):
         self.newline_char = '\n'
         self.char_pos = 0
@@ -65,7 +65,7 @@ class LineCounter:
         self.char_pos += len(token)
         self.column = self.char_pos - self.line_start_pos + 1
 
-class _Lex:
+class _Lex(object):
     "Built to serve both Lexer and ContextualLexer"
     def __init__(self, lexer, state=None):
         self.lexer = lexer
@@ -105,7 +105,7 @@ class _Lex:
                     raise UnexpectedCharacters(stream, line_ctr.char_pos, line_ctr.line, line_ctr.column, state=self.state)
                 break
 
-class UnlessCallback:
+class UnlessCallback(object):
     def __init__(self, mres):
         self.mres = mres
 
@@ -166,7 +166,7 @@ def build_mres(tokens, match_whole=False):
 def _regexp_has_newline(r):
     return '\n' in r or '\\n' in r or ('(?s' in r and '.' in r)
 
-class Lexer:
+class Lexer(object):
     """Lexer interface
 
     Method Signatures:

--- a/lark/load_grammar.py
+++ b/lark/load_grammar.py
@@ -442,7 +442,7 @@ class PrepareSymbols(Transformer_InPlace):
 def _choice_of_rules(rules):
     return ST('expansions', [ST('expansion', [Token('RULE', name)]) for name in rules])
 
-class Grammar:
+class Grammar(object):
     def __init__(self, rule_defs, token_defs, ignore):
         self.token_defs = token_defs
         self.rule_defs = rule_defs
@@ -578,7 +578,7 @@ class PrepareGrammar(Transformer_InPlace):
         return name
 
 
-class GrammarLoader:
+class GrammarLoader(object):
     def __init__(self):
         tokens = [TokenDef(name, PatternRE(value)) for name, value in TERMINALS.items()]
 

--- a/lark/parse_tree_builder.py
+++ b/lark/parse_tree_builder.py
@@ -9,7 +9,7 @@ from .visitors import InlineTransformer # XXX Deprecated
 from functools import partial, wraps
 
 
-class ExpandSingleChild:
+class ExpandSingleChild(object):
     def __init__(self, node_builder):
         self.node_builder = node_builder
 
@@ -20,7 +20,7 @@ class ExpandSingleChild:
             return self.node_builder(children)
 
 
-class PropagatePositions:
+class PropagatePositions(object):
     def __init__(self, node_builder):
         self.node_builder = node_builder
 
@@ -51,7 +51,7 @@ class PropagatePositions:
         return res
 
 
-class ChildFilter:
+class ChildFilter(object):
     def __init__(self, to_include, node_builder):
         self.node_builder = node_builder
         self.to_include = to_include
@@ -105,7 +105,7 @@ def inline_args(func):
 
 
 
-class ParseTreeBuilder:
+class ParseTreeBuilder(object):
     def __init__(self, rules, tree_class, propagate_positions=False, keep_all_tokens=False, ambiguous=False):
         self.tree_class = tree_class
         self.propagate_positions = propagate_positions

--- a/lark/reconstruct.py
+++ b/lark/reconstruct.py
@@ -54,7 +54,7 @@ class WriteTokensTransformer(Transformer_InPlace):
 class MatchTree(Tree):
     pass
 
-class MakeMatchTree:
+class MakeMatchTree(object):
     def __init__(self, name, expansion):
         self.name = name
         self.expansion = expansion
@@ -65,7 +65,7 @@ class MakeMatchTree:
         t.meta.orig_expansion = self.expansion
         return t
 
-class Reconstructor:
+class Reconstructor(object):
     def __init__(self, parser):
         # XXX TODO calling compile twice returns different results!
         tokens, rules, _grammar_extra = parser.grammar.compile()
@@ -100,9 +100,9 @@ class Reconstructor:
         for origin, rule_aliases in aliases.items():
             for alias in rule_aliases:
                 yield Rule(origin, [Terminal(alias)], MakeMatchTree(origin.name, [NonTerminal(alias)]))
-            
+
             yield Rule(origin, [Terminal(origin.name)], MakeMatchTree(origin.name, [origin]))
-        
+
 
 
     def _match(self, term, token):

--- a/lark/tree.py
+++ b/lark/tree.py
@@ -5,11 +5,13 @@ except ImportError:
 
 from copy import deepcopy
 
-class Meta:
+class Meta(object):
     pass
 
 ###{standalone
-class Tree(object):
+class SlottedTree(object):
+    __slots__ = 'data', 'children', 'rule', '_meta'
+
     def __init__(self, data, children, meta=None):
         self.data = data
         self.children = children
@@ -22,18 +24,18 @@ class Tree(object):
         return self._meta
 
     def __repr__(self):
-        return 'Tree(%s, %s)' % (self.data, self.children)
+        return '{self.__class__.__name__}({self.data}, {self.children})'.format(self=self)
 
     def _pretty_label(self):
         return self.data
 
     def _pretty(self, level, indent_str):
-        if len(self.children) == 1 and not isinstance(self.children[0], Tree):
+        if len(self.children) == 1 and not isinstance(self.children[0], SlottedTree):
             return [ indent_str*level, self._pretty_label(), '\t', '%s' % (self.children[0],), '\n']
 
         l = [ indent_str*level, self._pretty_label(), '\n' ]
         for n in self.children:
-            if isinstance(n, Tree):
+            if isinstance(n, SlottedTree):
                 l += n._pretty(level+1, indent_str)
             else:
                 l += [ indent_str*(level+1), '%s' % (n,), '\n' ]
@@ -72,7 +74,7 @@ class Tree(object):
 
     def scan_values(self, pred):
         for c in self.children:
-            if isinstance(c, Tree):
+            if isinstance(c, SlottedTree):
                 for t in c.scan_values(pred):
                     yield t
             else:
@@ -92,7 +94,7 @@ class Tree(object):
             if id(subtree) in visited:
                 continue    # already been here from another branch
             visited.add(id(subtree))
-            q += [c for c in subtree.children if isinstance(c, Tree)]
+            q += [c for c in subtree.children if isinstance(c, SlottedTree)]
 
         seen = set()
         for x in reversed(l):
@@ -125,8 +127,8 @@ class Tree(object):
         return self.meta.end_column
 
 
-class SlottedTree(Tree):
-    __slots__ = 'data', 'children', 'rule', '_meta'
+class Tree(SlottedTree):
+    pass
 
 
 def pydot__tree_to_png(tree, filename):


### PR DESCRIPTION
Once a class is `__dict__` based, slots can no longer be added on subclasses (that is, they have no effect). The current SlottedTree does not therefore really have slots. ~~This reverses the inheritance of `Tree` and `SlottedTree`, so that `SlottedTree` really will be slots based instead of `__dict__` based.~~

Edit: This now drops SlottedTree entirely, simply making Tree slotted. This should provide the benefits of slotted trees, and since it's hard to get access to the original Tree, should be pretty safe for user code. Let me know if the original dual method is needed. If a user wants a Dict based tree, it's just two lines:

```python
class UserTree(Tree):
    pass
````


I've also added `(object)` in more places, since forgetting it will create an old-style class in Python 2.

I would highly recommend adding `__slots__` in more places; on classes that have many instances you should see a nice memory reduction/speed up I think (especially on older Pythons, I think 3.6 or so improved dictionaries a bit for instances).

## Example illustrating slots inheritance

```python
In [4]: class NoSlots: # Skipping (object) is okay on Python 3
   ...:     pass
   ...:
   ...: class ReallySlots:
   ...:     __slots__ = ('x',)
   ...:
   ...: class NotReallySlots(NoSlots):
   ...:    __slots__ = ('x',)
   ...:

In [5]: NoSlots().x = 1

In [6]: a = ReallySlots()

In [7]: a.x = 1

In [8]: a.y = 3
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-8-af5b34806ad0> in <module>()
----> 1 a.y = 3

AttributeError: 'ReallySlots' object has no attribute 'y'

In [9]: b = NotReallySlots()

In [10]: b.x = 1

In [11]: b.y = 3

In [12]: hasattr(a, '__dict__')
Out[12]: False

In [13]: hasattr(b, '__dict__')
Out[13]: True
```