### PR TITLE
Fix wrong super() call.

### DIFF
--- a/lark/parser_frontends.py
+++ b/lark/parser_frontends.py
@@ -119,7 +119,7 @@ class XEarley:
 
 class XEarley_CompleteLex(XEarley):
     def __init__(self, *args, **kw):
-        super(self).__init__(*args, complete_lex=True, **kw)
+        super(XEarley_CompleteLex, self).__init__(*args, complete_lex=True, **kw)
 
 
 


### PR DESCRIPTION
Fixes:

```
Traceback (most recent call last):
  File "testlark.py", line 19, in <module>
    parser = Lark(GRAMMAR, lexer="dynamic_complete", debug=True)
  File "...\lark\lark.py", line 165, in __init__
    self.parser = self._build_parser()
  File "...\lark\lark.py", line 188, in _build_parser
    return self.parser_class(self.lexer_conf, parser_conf, options=self.options)
  File "...\lark\parser_frontends.py", line 122, in __init__
    super(self).__init__(*args, complete_lex=True, **kw)
TypeError: super() argument 1 must be type, not XEarley_CompleteLex
```