### PR TITLE
docs: clarify end_column value

### DIFF
--- a/docs/classes.md
+++ b/docs/classes.md
@@ -189,7 +189,7 @@ When using a lexer, the resulting tokens in the trees will be of the Token class
 * `line` - The line of the token in the text (starting with 1)
 * `column` - The column of the token in the text (starting with 1)
 * `end_line` - The line where the token ends
-* `end_column` - The column where the token ends
+* `end_column` - The next column after the end of the token. For example, if the token is a single character with a `column` value of 4, `end_column` will be 5.
 
 
 ## UnexpectedInput


### PR DESCRIPTION
I interpreted "the column where the token ends" to mean "a pointer
to the last character in the token", which would be the same as
the start column for a single-character token.

However, that's not what lark actually reports. Reword to clarify
this.

https://github.com/lark-parser/lark/issues/240