### PR TITLE
Allow to pass to lark/tree.py pydot__tree_to_png

### DIFF
--- a/lark/tree.py
+++ b/lark/tree.py
@@ -138,7 +138,7 @@ def pydot__tree_to_png(tree, filename, rankdir="LR"):
     """
 
     import pydot
-    graph = pydot.Dot(graph_type='digraph', rankdir)
+    graph = pydot.Dot(graph_type='digraph', rankdir=rankdir)
 
     i = [0]
 

--- a/lark/tree.py
+++ b/lark/tree.py
@@ -128,11 +128,17 @@ class SlottedTree(Tree):
     __slots__ = 'data', 'children', 'rule', '_meta'
 
 
-def pydot__tree_to_png(tree, filename):
-    "Creates a colorful image that represents the tree (data+children, without meta)"
+def pydot__tree_to_png(tree, filename, rankdir="LR"):
+    """Creates a colorful image that represents the tree (data+children, without meta)
+
+    Possible values for `rankdir` are "TB", "LR", "BT", "RL", corresponding to
+    directed graphs drawn from top to bottom, from left to right, from bottom to
+    top, and from right to left, respectively. See:
+    https://www.graphviz.org/doc/info/attrs.html#k:rankdir
+    """
 
     import pydot
-    graph = pydot.Dot(graph_type='digraph', rankdir="LR")
+    graph = pydot.Dot(graph_type='digraph', rankdir)
 
     i = [0]
 


### PR DESCRIPTION
For the pydot tree shaping. For example, passing "TB" instead of "LR" makes the tree
to be draw vertically instead of horizontally.

![duplicated_contexts](https://user-images.githubusercontent.com/5332158/46305140-f0244b00-c586-11e8-90b2-1a46404ea834.png)

![duplicated_contexts](https://user-images.githubusercontent.com/5332158/46305187-16e28180-c587-11e8-9b32-ff46bcd877b5.png)

https://stackoverflow.com/questions/29003465/pydot-graphviz-how-to-order-horizontally-nodes-in-a-cluster-while-the-rest-of-t