### PR TITLE
Exchange `is not None` with `is None` when possible

### DIFF
--- a/lark/parsers/earley.py
+++ b/lark/parsers/earley.py
@@ -41,7 +41,7 @@ class Item(object):
         self.rule = rule
         self.ptr = ptr
         self.start = start
-        self.tree = tree if tree is not None else Derivation(self.rule)
+        self.tree = Derivation(self.rule) if tree is None else tree
 
     @property
     def expect(self):

--- a/lark/utils.py
+++ b/lark/utils.py
@@ -23,8 +23,8 @@ def classify_bool(seq, pred):
 def classify(seq, key=None, value=None):
     d = {}
     for item in seq:
-        k = key(item) if (key is not None) else item
-        v = value(item) if (value is not None) else item
+        k = item if (key is None) else key(item)
+        v = item if (value is None) else value(item)
         if k in d:
             d[k].append(v)
         else:

--- a/lark/visitors.py
+++ b/lark/visitors.py
@@ -22,7 +22,7 @@ class Transformer:
 
     def _call_userfunc(self, tree, new_children=None):
         # Assumes tree is already transformed
-        children = new_children if new_children is not None else tree.children
+        children = tree.children if new_children is None else new_children
         try:
             f = getattr(self, tree.data)
         except AttributeError:
@@ -33,9 +33,9 @@ class Transformer:
             elif getattr(f, 'inline', False):
                 return f(*children)
             elif getattr(f, 'whole_tree', False):
-                if new_children is not None:
-                    raise NotImplementedError("Doesn't work with the base Transformer class")
-                return f(tree)
+                if new_children is None:
+                    return f(tree)
+                raise NotImplementedError("Doesn't work with the base Transformer class")
             else:
                 return f(children)
 
@@ -76,7 +76,7 @@ class Transformer:
 class InlineTransformer(Transformer):   # XXX Deprecated
     def _call_userfunc(self, tree, new_children=None):
         # Assumes tree is already transformed
-        children = new_children if new_children is not None else tree.children
+        children = tree.children if new_children is None else new_children
         try:
             f = getattr(self, tree.data)
         except AttributeError:


### PR DESCRIPTION
I was working on a custom `Transformer` when I stuck with:
```python
children = new_children if new_children is not None else tree.children
```

I just got a hard time trying to understand the `is not None` thing. At least for me, it is easier to think in terms of `is None` when you got a full `if` with and `else`. Of course, when there is no `else`, it is reasonable a `is not None`, because there is only only thing to think about instead of two:
```python
assert self.state is not None, "Not supported for this exception"
```

But forgetting about my stupidness, 
1. It is less things to write:
	```python
	children = new_children if new_children is not None else tree.children
	# versus
	children = tree.children if new_children is None else new_children
	```
1. In terms of performance, you can get less lines of python assembly using `is None` instead of `is not None`. Checkout the difference:
	<details>
	<p>
	
	```python
	import dis
	
	def func1():
	
	    matchesIterator = None
	
	    if matchesIterator:
	
	        print( "On if." );
	
	def func2():
	
	    matchesIterator = None
	
	    if matchesIterator is not None:
	
	        print( "On if." );
	
	print( "\nFunction 1" );
	dis.dis(func1)
	
	print( "\nFunction 2" );
	dis.dis(func2)
	```
	</p>
	</details><br>
	This is the assembler difference:
	
	![](http://i.imgur.com/0z9CsHK.png)
	
	https://stackoverflow.com/a/40659512/4934640