### PR TITLE
number add BIN_NUMBER

### DIFF
--- a/examples/python3.lark
+++ b/examples/python3.lark
@@ -161,7 +161,7 @@ yield_expr: "yield" [yield_arg]
 yield_arg: "from" test | testlist
 
 
-number: DEC_NUMBER | HEX_NUMBER | OCT_NUMBER | FLOAT_NUMBER | IMAG_NUMBER
+number: DEC_NUMBER | HEX_NUMBER | BIN_NUMBER | OCT_NUMBER | FLOAT_NUMBER | IMAG_NUMBER
 string: STRING | LONG_STRING
 // Tokens
 


### PR DESCRIPTION
Without BIN_NUMBER, the following error occurs:
lark.exceptions.UnexpectedCharacters: No terminal defined for 'b' at line 1 col 2

0b10
 ^