### PR TITLE
Added .tox to .gitignore (to use tox locally)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 *.pyo
+/.tox
 /lark_parser.egg-info/**
 tags
 .vscode


### PR DESCRIPTION
I usually run tests locally with `tox -e py27`, but these files accumulate on the working tree.