### PR TITLE
start with empty callbacks, then assign UnlessCallback

### DIFF
--- a/lark/lexer.py
+++ b/lark/lexer.py
@@ -270,12 +270,13 @@ class TraditionalLexer(Lexer):
 
         terminals.sort(key=lambda x:(-x.priority, -x.pattern.max_width, -len(x.pattern.value), x.name))
 
-        terminals, self.callback = _create_unless(terminals)
-        assert all(self.callback.values())
-
+        self.callback = dict()
         for type_, f in user_callbacks.items():
             assert type_ not in self.callback
             self.callback[type_] = f
+
+        terminals, self.callback = _create_unless(terminals)
+        assert all(self.callback.values())
 
         self.terminals = terminals
 

--- a/lark/lexer.py
+++ b/lark/lexer.py
@@ -270,13 +270,12 @@ class TraditionalLexer(Lexer):
 
         terminals.sort(key=lambda x:(-x.priority, -x.pattern.max_width, -len(x.pattern.value), x.name))
 
-        self.callback = dict()
-        for type_, f in user_callbacks.items():
-            assert type_ not in self.callback
-            self.callback[type_] = f
-
         terminals, self.callback = _create_unless(terminals)
         assert all(self.callback.values())
+
+        for type_, f in user_callbacks.items():
+            assert type_ not in self.callback or isinstance(self.callback[type_], UnlessCallback)
+            self.callback[type_] = f
 
         self.terminals = terminals
 


### PR DESCRIPTION
If I'm to supply lexer_callbacks={???} then they can't all be predefined as UnlessCallback and then also check assert type_ not in self.callbacks

https://lark-parser.readthedocs.io/en/latest/recipes/#recipes