### PR TITLE
Support hex escape (\xhh) in string literal

### DIFF
--- a/lark/load_grammar.py
+++ b/lark/load_grammar.py
@@ -346,7 +346,7 @@ def _fix_escaping(s):
             n2 = next(i)
             if n2 == '\\':
                 w += '\\\\'
-            elif n2 not in 'unftr':
+            elif n2 not in 'uxnftr':
                 w += '\\'
             w += n2
     w = w.replace('\\"', '"').replace("'", "\\'")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -448,6 +448,12 @@ def _make_parser_test(LEXER, PARSER):
                         """)
             g.parse(u'\xa3\u0101\u00a3\u0203\n')
 
+        def test_hex_escape(self):
+            g = _Lark(r"""start: A B
+                          A: "\x01"
+                          B: /\x02/
+                          """)
+            g.parse('\x01\x02')
 
         @unittest.skipIf(PARSER == 'cyk', "Takes forever")
         def test_stack_for_ebnf(self):
@@ -1363,4 +1369,3 @@ for _LEXER in ('dynamic', 'dynamic_complete'):
 
 if __name__ == '__main__':
     unittest.main()
-


### PR DESCRIPTION
I'm trying to parse some binary opcodes with Lark and quite satisfied with what it offers so far. A minor gripe I had was limited support for string literal escape in Lark grammar.

Let's say I want to capture `\x01` in a string with a rule with embedded literal, while not keeping its terminal node. Introducing non-capturing regex literal (i.e. `_A: /x01/`) was not an option since otherwise grammar would get too complicated.

Then only left with some partial solutions:

```
A: /\x01/ ... // string literal always captured
B: "\u0001" ... // not captured, but verbose and maybe confusing to represent a byte
C: /\u0001/ ... // captured, confusing?
```

Here I want to directly use hex escape in my string literal like this:

```
D: "\x01" // string literal not captured, clearly representing a byte
```

It can be possible with a very little change in `_fix_escaping()` although I have no idea if there was any other reasons it didn't have one on the first place.

Maybe we could also add other [escape sequences](https://docs.python.org/3/reference/lexical_analysis.html) (i.e. `\ooo` for octal) if interested.