### PR TITLE
Make VisitError inherit from LarkError

### DIFF
--- a/lark/exceptions.py
+++ b/lark/exceptions.py
@@ -86,7 +86,7 @@ class UnexpectedToken(ParseError, UnexpectedInput):
 
         super(UnexpectedToken, self).__init__(message)
 
-class VisitError(Exception):
+class VisitError(LarkError):
     def __init__(self, tree, orig_exc):
         self.tree = tree
         self.orig_exc = orig_exc


### PR DESCRIPTION
The recently added VisitError (https://github.com/lark-parser/lark/commit/8e7c05a8f6e58c3e7c1ce34956dccc15f68880bc) is the only lark exception not inheriting from LarkError, which makes it painful to catch for client application.
This simple change allows a common catch-all of LarkError.