### PR TITLE
Fix literal range escape assertion

### DIFF
--- a/lark/load_grammar.py
+++ b/lark/load_grammar.py
@@ -389,7 +389,7 @@ class PrepareLiterals(Transformer_InPlace):
         assert start.type == end.type == 'STRING'
         start = start.value[1:-1]
         end = end.value[1:-1]
-        assert len(start) == len(end) == 1, (start, end, len(start), len(end))
+        assert len(_fix_escaping(start)) == len(_fix_escaping(end)) == 1, (start, end, len(_fix_escaping(start)), len(_fix_escaping(end)))
         regexp = '[%s-%s]' % (start, end)
         return ST('pattern', [PatternRE(regexp)])
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -456,6 +456,18 @@ def _make_parser_test(LEXER, PARSER):
                           """)
             g.parse('\x01\x02\xABCD')
 
+        def test_unicode_literal_range_escape(self):
+            g = _Lark(r"""start: A+
+                          A: "\u0061".."\u0063"
+                          """)
+            g.parse('abc')
+
+        def test_hex_literal_range_escape(self):
+            g = _Lark(r"""start: A+
+                          A: "\x01".."\x03"
+                          """)
+            g.parse('\x01\x02\x03')
+
         @unittest.skipIf(PARSER == 'cyk', "Takes forever")
         def test_stack_for_ebnf(self):
             """Verify that stack depth isn't an issue for EBNF grammars"""


### PR DESCRIPTION
Currently string literal range syntax doesn't work for unicode/hex escaped string because it assumes the length of literal always one which is not true for those escaped strings. It can be simply fixed by  using `_fix_escaping()` on `len()` although assert now looks a bit busy.