### PR TITLE
Fix v_args when used on classes with non-callable members

### DIFF
--- a/lark/visitors.py
+++ b/lark/visitors.py
@@ -74,6 +74,8 @@ class Transformer:
         for name, value in getmembers(cls):
             if name.startswith('_') or name in libmembers:
                 continue
+            if not callable(cls.__dict__[name]):
+                continue
 
             # Skip if v_args already applied (at the function level)
             if hasattr(cls.__dict__[name], 'vargs_applied'):

--- a/tests/test_trees.py
+++ b/tests/test_trees.py
@@ -137,6 +137,8 @@ class TestTrees(TestCase):
             f = float
             sub = lambda self, a, b: a-b
 
+            not_a_method = {'other': 'stuff'}
+
             @v_args(inline=False)
             def add(self, values):
                 return sum(values)


### PR DESCRIPTION
When `v_args` was used on an entire class but the class had static members that were not callable (such as a constant with some dictionary), it would crash on:
```
...
  File "./lark/utils.py", line 80, in smart_decorator
    return create_decorator(f.__func__.__call__, True)
AttributeError: 'dict' object has no attribute '__func__'
```

https://github.com/lark-parser/lark/issues/340