### PR TITLE
import_grammar now include base_path in recursive call to load_grammar

### DIFF
--- a/lark/load_grammar.py
+++ b/lark/load_grammar.py
@@ -562,9 +562,10 @@ def import_grammar(grammar_path, base_paths=[]):
         import_paths = base_paths + IMPORT_PATHS
         for import_path in import_paths:
             with suppress(IOError):
-                with open(os.path.join(import_path, grammar_path)) as f:
+                joined_path = os.path.join(import_path, grammar_path)
+                with open(joined_path) as f:
                     text = f.read()
-                grammar = load_grammar(text, grammar_path)
+                grammar = load_grammar(text, joined_path)
                 _imported_grammars[grammar_path] = grammar
                 break
         else:

--- a/tests/grammars/test_relative_import_of_nested_grammar.lark
+++ b/tests/grammars/test_relative_import_of_nested_grammar.lark
@@ -1,0 +1,4 @@
+
+start: rule_to_import
+
+%import .test_relative_import_of_nested_grammar__grammar_to_import.rule_to_import

--- a/tests/grammars/test_relative_import_of_nested_grammar__grammar_to_import.lark
+++ b/tests/grammars/test_relative_import_of_nested_grammar__grammar_to_import.lark
@@ -1,0 +1,4 @@
+
+rule_to_import: NESTED_TERMINAL
+
+%import .test_relative_import_of_nested_grammar__nested_grammar.NESTED_TERMINAL

--- a/tests/grammars/test_relative_import_of_nested_grammar__nested_grammar.lark
+++ b/tests/grammars/test_relative_import_of_nested_grammar__nested_grammar.lark
@@ -1,0 +1,1 @@
+NESTED_TERMINAL: "N"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1104,6 +1104,11 @@ def _make_parser_test(LEXER, PARSER):
             x = l.parse('Ax')
             self.assertEqual(next(x.find_data('c')).children, ['A'])
 
+        def test_relative_import_of_nested_grammar(self):
+            l = _Lark_open("grammars/test_relative_import_of_nested_grammar.lark", rel_to=__file__)
+            x = l.parse('N')
+            self.assertEqual(next(x.find_data('rule_to_import')).children, ['N'])
+
         def test_import_errors(self):
             grammar = """
             start: NUMBER WORD


### PR DESCRIPTION
fixes https://github.com/lark-parser/lark/issues/347