### PR TITLE
Add vaild_parse method for Lark class.

### DIFF
--- a/docs/classes.md
+++ b/docs/classes.md
@@ -44,6 +44,12 @@ Return a complete parse tree for the text (of type Tree)
 
 If a transformer is supplied to `__init__`, returns whatever is the result of the transformation.
 
+#### valid_parse(self, text)
+
+Return the result same as `parse` method, but return `None` instead to raise a `ParseError`.
+
+Suitable for use in conditional expressions.
+
 ----
 
 ## Tree

--- a/lark/lark.py
+++ b/lark/lark.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 from io import open
 
 from .utils import STRING_TYPE, Serialize, SerializeMemoizer
+from .exceptions import ParseError
 from .load_grammar import load_grammar
 from .tree import Tree
 from .common import LexerConf, ParserConf
@@ -290,5 +291,12 @@ class Lark(Serialize):
     def parse(self, text):
         "Parse the given text, according to the options provided. Returns a tree, unless specified otherwise."
         return self.parser.parse(text)
+
+    def valid_parse(self, text):
+        "Parse the given text, return `None` if it's invalid."
+        try:
+            return self.parser.parse(text)
+        except ParseError:
+            return None
 
 ###}


### PR DESCRIPTION
For more simpler statement with `Lark.vaild_parse` to discard tracking exceptions:

```python
tree = g.vaild_parse(expr)
if tree is None:
    return
vaild_operation(tree)
```

Python 3.8 style:

```python
if (tree := g.vaild_parse(expr)) is not None:
    vaild_operation(tree)
```