### PR TITLE
Fix DeprecationWarning in lalr_analysis.py

### DIFF
--- a/lark/parsers/lalr_analysis.py
+++ b/lark/parsers/lalr_analysis.py
@@ -112,9 +112,9 @@ class LALR_Analyzer(GrammarAnalyzer):
             for k, v in lookahead.items():
                 if len(v) > 1:
                     if self.debug:
-                        logging.warn("Shift/reduce conflict for terminal %s:  (resolving as shift)", k.name)
+                        logging.warning("Shift/reduce conflict for terminal %s:  (resolving as shift)", k.name)
                         for act, arg in v:
-                            logging.warn(' * %s: %s', act, arg)
+                            logging.warning(' * %s: %s', act, arg)
                     for x in v:
                         # XXX resolving shift/reduce into shift, like PLY
                         # Give a proper warning


### PR DESCRIPTION
Under python 3.3+, logging.warn is deprecated.
Use logging.warning instead.

Fixes: /Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/lark/parsers/lalr_analysis.py:87: DeprecationWarning: The 'warn' function is deprecated, use 'warning' instead