### PR TITLE
Allow any graph attribute in `pydot__tree_to_png`.

### DIFF
--- a/lark/tree.py
+++ b/lark/tree.py
@@ -141,17 +141,19 @@ class SlottedTree(Tree):
     __slots__ = 'data', 'children', 'rule', '_meta'
 
 
-def pydot__tree_to_png(tree, filename, rankdir="LR"):
+def pydot__tree_to_png(tree, filename, rankdir="LR", **kwargs):
     """Creates a colorful image that represents the tree (data+children, without meta)
 
     Possible values for `rankdir` are "TB", "LR", "BT", "RL", corresponding to
     directed graphs drawn from top to bottom, from left to right, from bottom to
-    top, and from right to left, respectively. See:
-    https://www.graphviz.org/doc/info/attrs.html#k:rankdir
+    top, and from right to left, respectively.
+
+    `kwargs` can be any graph attribute (e. g. `dpi=200`). For a list of
+    possible attributes, see https://www.graphviz.org/doc/info/attrs.html.
     """
 
     import pydot
-    graph = pydot.Dot(graph_type='digraph', rankdir=rankdir)
+    graph = pydot.Dot(graph_type='digraph', rankdir=rankdir, **kwargs)
 
     i = [0]
 


### PR DESCRIPTION
I needed to increase the dpi of the pydot graph, so I added `**kwargs` to `pydot__tree_to_png` in `tree.py`, as adding a single additional attribute seemed silly to me. To keep compatibility, `rankdir="LR"` is still an explicit default value in the function signature. The docstring has been updated accordingly.