### PR TITLE
Implement embedded in-place transformers. See #378.

### DIFF
--- a/lark/parse_tree_builder.py
+++ b/lark/parse_tree_builder.py
@@ -2,6 +2,7 @@ from .exceptions import GrammarError
 from .lexer import Token
 from .tree import Tree
 from .visitors import InlineTransformer # XXX Deprecated
+from .visitors import Transformer_InPlace
 
 ###{standalone
 from functools import partial, wraps
@@ -193,6 +194,15 @@ def ptb_inline_args(func):
         return func(*children)
     return f
 
+def inplace_transformer(func):
+    @wraps(func)
+    def f(children):
+        # function name in a Transformer is a rule name.
+        tree = Tree(func.__name__, children)
+        func(tree)
+        return tree
+    return f
+
 class ParseTreeBuilder:
     def __init__(self, rules, tree_class, propagate_positions=False, keep_all_tokens=False, ambiguous=False, maybe_placeholders=False):
         self.tree_class = tree_class
@@ -231,6 +241,8 @@ class ParseTreeBuilder:
                 # XXX InlineTransformer is deprecated!
                 if getattr(f, 'inline', False) or isinstance(transformer, InlineTransformer):
                     f = ptb_inline_args(f)
+                elif hasattr(f, 'whole_tree') or isinstance(transformer, Transformer_InPlace):
+                    f = inplace_transformer(f)
             except AttributeError:
                 f = partial(self.tree_class, user_callback_name)
 


### PR DESCRIPTION
As discussed in issue #378, when an embedded transformer (that is, one
passed to the Lark class using the transformer argument), is an
inplace transformer (either a subclass of Transformer_InPlace, or with
the @v_args(tree=True) decorator), the in-place transformer was not
working correctly and in-fact Lark used it like a normal non-in-place
transformer, expecting it to return the transformed value.