### PR TITLE
Proper LALR parser

### DIFF
--- a/lark/grammar.py
+++ b/lark/grammar.py
@@ -3,13 +3,12 @@ from .utils import Serialize
 ###{standalone
 
 class Symbol(Serialize):
-    __slots__ = ('name', '_hash')
+    __slots__ = ('name',)
 
     is_term = NotImplemented
 
     def __init__(self, name):
         self.name = name
-        self._hash = hash(self.name)
 
     def __eq__(self, other):
         assert isinstance(other, Symbol), other
@@ -19,7 +18,7 @@ class Symbol(Serialize):
         return not (self == other)
 
     def __hash__(self):
-        return self._hash
+        return hash(self.name)
 
     def __repr__(self):
         return '%s(%r)' % (type(self).__name__, self.name)
@@ -28,13 +27,12 @@ class Symbol(Serialize):
 
 
 class Terminal(Symbol):
-    __serialize_fields__ = 'name', 'filter_out', '_hash'
+    __serialize_fields__ = 'name', 'filter_out'
 
     is_term = True
 
     def __init__(self, name, filter_out=False):
         self.name = name
-        self._hash = hash(self.name)
         self.filter_out = filter_out
 
     @property
@@ -44,7 +42,7 @@ class Terminal(Symbol):
 
 
 class NonTerminal(Symbol):
-    __serialize_fields__ = 'name', '_hash'
+    __serialize_fields__ = 'name',
 
     is_term = False
 

--- a/lark/grammar.py
+++ b/lark/grammar.py
@@ -3,10 +3,13 @@ from .utils import Serialize
 ###{standalone
 
 class Symbol(Serialize):
+    __slots__ = ('name', '_hash')
+
     is_term = NotImplemented
 
     def __init__(self, name):
         self.name = name
+        self._hash = hash(self.name)
 
     def __eq__(self, other):
         assert isinstance(other, Symbol), other
@@ -16,7 +19,7 @@ class Symbol(Serialize):
         return not (self == other)
 
     def __hash__(self):
-        return hash(self.name)
+        return self._hash
 
     def __repr__(self):
         return '%s(%r)' % (type(self).__name__, self.name)
@@ -31,6 +34,7 @@ class Terminal(Symbol):
 
     def __init__(self, name, filter_out=False):
         self.name = name
+        self._hash = hash(self.name)
         self.filter_out = filter_out
 
     @property
@@ -69,7 +73,7 @@ class Rule(Serialize):
         expansion : a list of symbols
         order : index of this expansion amongst all rules of the same name
     """
-    __slots__ = ('origin', 'expansion', 'alias', 'options', 'order', '_hash')
+    __slots__ = ('origin', 'expansion', 'alias', 'options', 'order', '_hash', '_rp')
 
     __serialize_fields__ = 'origin', 'expansion', 'order', 'alias', 'options'
     __serialize_namespace__ = Terminal, NonTerminal, RuleOptions
@@ -81,6 +85,7 @@ class Rule(Serialize):
         self.order = order
         self.options = options
         self._hash = hash((self.origin, tuple(self.expansion)))
+        self._rp = None
 
     def _deserialize(self):
         self._hash = hash((self.origin, tuple(self.expansion)))

--- a/lark/grammar.py
+++ b/lark/grammar.py
@@ -71,7 +71,7 @@ class Rule(Serialize):
         expansion : a list of symbols
         order : index of this expansion amongst all rules of the same name
     """
-    __slots__ = ('origin', 'expansion', 'alias', 'options', 'order', '_hash', '_rp')
+    __slots__ = ('origin', 'expansion', 'alias', 'options', 'order', '_hash')
 
     __serialize_fields__ = 'origin', 'expansion', 'order', 'alias', 'options'
     __serialize_namespace__ = Terminal, NonTerminal, RuleOptions
@@ -83,7 +83,6 @@ class Rule(Serialize):
         self.order = order
         self.options = options
         self._hash = hash((self.origin, tuple(self.expansion)))
-        self._rp = None
 
     def _deserialize(self):
         self._hash = hash((self.origin, tuple(self.expansion)))

--- a/lark/grammar.py
+++ b/lark/grammar.py
@@ -28,7 +28,7 @@ class Symbol(Serialize):
 
 
 class Terminal(Symbol):
-    __serialize_fields__ = 'name', 'filter_out'
+    __serialize_fields__ = 'name', 'filter_out', '_hash'
 
     is_term = True
 
@@ -44,7 +44,7 @@ class Terminal(Symbol):
 
 
 class NonTerminal(Symbol):
-    __serialize_fields__ = 'name',
+    __serialize_fields__ = 'name', '_hash'
 
     is_term = False
 

--- a/lark/parsers/grammar_analysis.py
+++ b/lark/parsers/grammar_analysis.py
@@ -36,6 +36,23 @@ class RulePtr(object):
     def __hash__(self):
         return hash((self.rule, self.index))
 
+class LR0ItemSet(object):
+    __slots__ = ('kernel', 'closure', 'transitions')
+
+    def __init__(self, kernel, closure):
+        self.kernel = fzset(kernel)
+        self.closure = fzset(closure)
+        self.transitions = {}
+
+    def __eq__(self, other):
+        return self.kernel == other.kernel
+
+    def __hash__(self):
+        return hash(self.kernel)
+
+    def __repr__(self):
+        return '{%s | %s}' % (', '.join([repr(r) for r in self.kernel]), ', '.join([repr(r) for r in self.closure]))
+
 
 def update_set(set1, set2):
     if not set2:
@@ -130,15 +147,29 @@ class GrammarAnalyzer(object):
         self.end_states = {start: fzset({RulePtr(root_rule, len(root_rule.expansion))})
                            for start, root_rule in root_rules.items()}
 
+        lr0_root_rules = {start: Rule(NonTerminal('$root_' + start), [NonTerminal(start)])
+                for start in parser_conf.start}
+
+        lr0_rules = parser_conf.rules + list(lr0_root_rules.values())
+
+        self.lr0_rules_by_origin = classify(lr0_rules, lambda r: r.origin)
+
+        self.lr0_start_states = {start: LR0ItemSet([RulePtr(root_rule, 0)], self.expand_rule(root_rule.origin, self.lr0_rules_by_origin))
+                for start, root_rule in lr0_root_rules.items()}
+
         self.FIRST, self.FOLLOW, self.NULLABLE = calculate_sets(rules)
 
-    def expand_rule(self, rule):
+    def expand_rule(self, rule, rules_by_origin=None):
         "Returns all init_ptrs accessible by rule (recursive)"
+
+        if rules_by_origin is None:
+            rules_by_origin = self.rules_by_origin
+
         init_ptrs = set()
         def _expand_rule(rule):
             assert not rule.is_term, rule
 
-            for r in self.rules_by_origin[rule]:
+            for r in rules_by_origin[rule]:
                 init_ptr = RulePtr(r, 0)
                 init_ptrs.add(init_ptr)
 
@@ -157,4 +188,3 @@ class GrammarAnalyzer(object):
             return {r}
         else:
             return {rp.next for rp in self.expand_rule(r) if rp.next.is_term}
-

--- a/lark/parsers/lalr_analysis.py
+++ b/lark/parsers/lalr_analysis.py
@@ -7,13 +7,16 @@ For now, shift/reduce conflicts are automatically resolved as shifts.
 # Email : erezshin@gmail.com
 
 import logging
-from collections import defaultdict
+from collections import defaultdict, deque
 
 from ..utils import classify, classify_bool, bfs, fzset, Serialize, Enumerator
 from ..exceptions import GrammarError
 
 from .grammar_analysis import GrammarAnalyzer, Terminal, RulePtr, LR0ItemSet
 from ..grammar import Rule
+from . import grammar_analysis
+
+import time
 
 ###{standalone
 
@@ -27,6 +30,16 @@ class Action:
 
 Shift = Action('Shift')
 Reduce = Action('Reduce')
+
+t_set_0 = 0
+t_set_1 = 0
+t_expand = 0
+t_rules = 0
+t_append = 0
+t_z = 0
+t_begin = 0
+t_count = 0
+t_call = 0
 
 class ParseTable:
     def __init__(self, states, start_states, end_states):
@@ -86,20 +99,24 @@ class LALR_Analyzer(GrammarAnalyzer):
 
     def generate_lr0_states(self):
         self.states = set()
+        # map of kernels to LR0ItemSets
+        cache = {}
 
         def step(state):
             _, unsat = classify_bool(state.closure, lambda rp: rp.is_satisfied)
 
             d = classify(unsat, lambda rp: rp.next)
             for sym, rps in d.items():
-                kernel = {rp.advance(sym) for rp in rps}
-                closure = set(kernel)
+                kernel = fzset({rp.advance(sym) for rp in rps})
+                new_state = cache.get(kernel, None)
+                if new_state is None:
+                    closure = set(kernel)
+                    for rp in kernel:
+                        if not rp.is_satisfied and not rp.next.is_term:
+                            closure |= self.expand_rule(rp.next, self.lr0_rules_by_origin)
+                    new_state = LR0ItemSet(kernel, closure)
+                    cache[kernel] = new_state
 
-                for rp in kernel:
-                    if not rp.is_satisfied and not rp.next.is_term:
-                        closure |= self.expand_rule(rp.next, self.lr0_rules_by_origin)
-
-                new_state = LR0ItemSet(kernel, closure)
                 state.transitions[sym] = new_state
                 yield new_state
 
@@ -109,35 +126,58 @@ class LALR_Analyzer(GrammarAnalyzer):
             pass
 
     def discover_lookaheads(self):
+        # lookaheads is now a member of LR0ItemSet, so don't need to look up a dictionary here
         # state -> rule -> set of lookaheads
-        self.lookaheads = defaultdict(lambda: defaultdict(set))
+        #self.lookaheads = defaultdict(lambda: defaultdict(set))
         # state -> rule -> list of (set of lookaheads) to propagate to
-        self.propagates = defaultdict(lambda: defaultdict(list))
+        #self.propagates = defaultdict(lambda: defaultdict(list))
+        self.propagates = {}
 
+        t0 = time.time()
+
+        t = Terminal('$END')
         for s in self.lr0_start_states.values():
             for rp in s.kernel:
-                self.lookaheads[s][rp].add(Terminal('$END'))
+                #self.lookaheads[s][rp].add(Terminal('$END'))
+                s.lookaheads[rp].add(t)
+
+        t_closure = 0
 
         # There is a 1 to 1 correspondance between LR0 and LALR1 states.
         # We calculate the lookaheads for LALR1 kernel items from the LR0 kernel items.
         # use a terminal that does not exist in the grammar
         t = Terminal('$#')
         for s in self.states:
+            p = {}
+            self.propagates[s] = p
             for rp in s.kernel:
-                for rp2, la in self.generate_lr1_closure([(rp, t)]):
+                q = []
+                p[rp] = q
+                t2 = time.time()
+                z = self.generate_lr1_closure([rp.lookahead(t)], time.time())
+                t3 = time.time()
+                t_closure += t3 - t2
+                #for rp2, la in self.generate_lr1_closure([(rp, t)], time.time()):
+                for rp2_la in z:
+                    rp2 = rp2_la.rp
+                    la = rp2_la.la
                     if rp2.is_satisfied:
                         continue
                     next_symbol = rp2.next
                     next_state = s.transitions[next_symbol]
                     rp3 = rp2.advance(next_symbol)
                     assert(rp3 in next_state.kernel)
-                    x = self.lookaheads[next_state][rp3]
+                    #x = self.lookaheads[next_state][rp3]
+                    x = next_state.lookaheads[rp3]
                     if la == t:
                         # we must propagate rp's lookaheads to rp3's lookahead set
-                        self.propagates[s][rp].append(x)
+                        q.append(x)
                     else:
                         # this lookahead is "generated spontaneously" for rp3
                         x.add(la)
+
+        t1 = time.time()
+        print('Discovering took {:.3f} (generating closure), {:.3f} (total)'.format(t_closure, t1 - t0))
 
     def propagate_lookaheads(self):
         changed = True
@@ -146,7 +186,8 @@ class LALR_Analyzer(GrammarAnalyzer):
             for s in self.states:
                 for rp in s.kernel:
                     # from (from is a keyword)
-                    f = self.lookaheads[s][rp]
+                    #f = self.lookaheads[s][rp]
+                    f = s.lookaheads[rp]
                     # to
                     t = self.propagates[s][rp]
                     for x in t:
@@ -155,20 +196,33 @@ class LALR_Analyzer(GrammarAnalyzer):
                         changed = changed or (len(x) != old)
 
     def generate_lalr1_states(self):
+        t0 = time.time()
         # 1 to 1 correspondance between LR0 and LALR1 states
         # We must fetch the lookaheads we calculated,
         # to create the LALR1 kernels from the LR0 kernels.
         # Then, we generate the LALR1 states by taking the LR1 closure of the new kernel items.
         # map of LR0 states to LALR1 states
         m = {}
+        t_closure = 0
+        z = 0
         for s in self.states:
+            z = max(z, len(s.closure))
             kernel = []
             for rp in s.kernel:
-                las = self.lookaheads[s][rp]
+                #las = self.lookaheads[s][rp]
+                las = s.lookaheads[rp]
                 assert(len(las) > 0)
                 for la in las:
-                    kernel.append((rp, la))
-            m[s] = self.generate_lr1_closure(kernel)
+                    kernel.append(rp.lookahead(la))
+            t0_0 = time.time()
+            m[s] = self.generate_lr1_closure(kernel, time.time())
+            t0_1 = time.time()
+            t_closure += t0_1 - t0_0
+
+        print('Generating lalr1 closure for lalr kernels took {:.3f}'.format(t_closure))
+        print('Max lr0 state size was {}'.format(z))
+
+        t1 = time.time()
 
         self.states = {}
         for s, v in m.items():
@@ -176,8 +230,8 @@ class LALR_Analyzer(GrammarAnalyzer):
             for la, next_state in s.transitions.items():
                 actions[la] = (Shift, next_state.closure)
 
-            sat, _ = classify_bool(v, lambda x: x[0].is_satisfied)
-            reductions = classify(sat, lambda x: x[1], lambda x: x[0])
+            sat, _ = classify_bool(v, lambda x: x.rp.is_satisfied)
+            reductions = classify(sat, lambda x: x.la, lambda x: x.rp)
             for la, rps in reductions.items():
                 if len(rps) > 1:
                     raise GrammarError("Collision in %s: %s" % (la, ', '.join([ str(r.rule) for r in rps ])))
@@ -190,6 +244,8 @@ class LALR_Analyzer(GrammarAnalyzer):
 
             self.states[s.closure] = {k.name: v for k, v in actions.items()}
 
+        t2 = time.time()
+
         end_states = {}
         for s in self.states:
             for rp in s:
@@ -198,44 +254,168 @@ class LALR_Analyzer(GrammarAnalyzer):
                         assert(not start in end_states)
                         end_states[start] = s
 
+        t3 = time.time()
+
         self._parse_table = ParseTable(self.states, {start: state.closure for start, state in self.lr0_start_states.items()}, end_states)
+
+        t4 = time.time()
 
         if self.debug:
             self.parse_table = self._parse_table
         else:
             self.parse_table = IntParseTable.from_ParseTable(self._parse_table)
 
-    def generate_lr1_closure(self, kernel):
+        t5 = time.time()
+
+        print(('Generating lalr1 states took ' + ', '.join([ '{:.3f}' ] * 5)).format(t1 - t0, t2 - t1, t3 - t2, t4 - t3, t5 - t4))
+        print('Generating firsts took {:.3f} (time actually calculating), {:.3f} (end to end), {:.3f} (just function call)'.format(grammar_analysis.t_firsts, grammar_analysis.t_xy, grammar_analysis.t_call))
+
+    def generate_lr1_closure(self, kernel, t_caller):
+        global t_call
+        global t_set_0
+        global t_set_1
+        global t_expand
+        global t_rules
+        global t_append
+        global t_z
+        global t_begin
+        global t_count
+
+        t_start = time.time()
+        t_call += t_start - t_caller
+
+        # cache the results of this function
+        # not many hits, no noticeable performance improvement
+        '''
+        k = fzset(kernel)
+        cached = self.lr1_cache.get(k, None)
+        if not cached is None:
+            return cached
+        '''
+
         closure = set()
+        closure_hash = {}
+
+        y = 0
 
         q = list(kernel)
         while len(q) > 0:
-            rp, la = q.pop()
-            if (rp, la) in closure:
+            t_a = time.time()
+            rp_la = q.pop()
+            #rp_la_hash = hash(rp_la)
+            t0 = time.time()
+            t_begin += t0 - t_a
+            # try to manually maintain hashtable,
+            # as a set of just hashes (ints) was notably faster
+            '''
+            if rp_la_hash in closure_hash:
+                if rp_la in closure_hash[rp_la_hash]:
+                    t0_0 = time.time()
+                    t_set_0 += t0_0 - t0
+                    continue
+                t0_0 = time.time()
+                t_set_0 += t0_0 - t0
+            else:
+                closure_hash[rp_la_hash] = []
+            '''
+            if rp_la in closure:
+                t0_0 = time.time()
+                t_set_0 += t0_0 - t0
                 continue
-            closure.add((rp, la))
+            t0_0 = time.time()
+            closure.add(rp_la)
+            #closure_hash[rp_la_hash].append(rp_la)
+            t1 = time.time()
+            t_set_0 += t0_0 - t0
+            t_set_1 += t1 - t0_0
+            rp = rp_la.rp
+            la = rp_la.la
 
             if rp.is_satisfied:
                 continue
             if rp.next.is_term:
                 continue
 
+            t2 = time.time()
+
+            # cache these calculations inside each RulePtr
+            # see grammar_analysis.py:79
             l = []
+            '''
             i = rp.index + 1
             n = len(rp.rule.expansion)
-            while i < n:
-                s = rp.rule.expansion[i]
-                l.extend(self.FIRST.get(s, []))
-                if not s in self.NULLABLE:
-                    break
-                i += 1
+            l2_i = self.lr1_cache2.get((rp.rule, i), None)
+            l2 = []
+            if l2_i is None:
+                while i < n:
+                    s = rp.rule.expansion[i]
+                    l2.extend(self.FIRST.get(s, []))
+                    if not s in self.NULLABLE:
+                        break
+                    i += 1
+                self.lr1_cache2[(rp.rule, i)] = (l2, i)
+            else:
+                l2 = l2_i[0]
+                i = l2_i[1]
 
+            l.extend(l2)
+            '''
+            # this function call seems really slow (see grammar_analysis.t_call above)
+            # tried making it not a method call so don't need to look up vtable
+            # still equally slow
+            l2, nullable = rp.first(rp.index + 1, self.FIRST, self.NULLABLE, time.time())
+            #l2, nullable = grammar_analysis.first(rp, rp.index + 1, self.FIRST, self.NULLABLE, time.time())
+            #l.extend(l2)
+            l = l2
+            t3 = time.time()
+
+            t_expand += t3 - t2
+
+            # if we don't modify l2 and add an extra check in the loop below,
+            # we don't have to copy it
             # if all of rp.rule.expansion[rp.index + 1:] were nullable:
-            if i == n:
-                l.append(la)
+            #if nullable:
+            #    l.append(la)
 
-            for r in self.lr0_rules_by_origin[rp.next]:
+            t4 = time.time()
+            x = rp.next_rules_by_origin(self.lr0_rules_by_origin)
+            t5 = time.time()
+
+            # usually between 20-60? seen as high as ~175
+            y = max(y, len(x) * len(l))
+            #print('adding {} * {} rules to closure max {}'.format(len(x), len(l), y))
+            for r in x:
                 for s in l:
-                    q.append((RulePtr(r, 0), s))
+                    # cache RulePtr(r, 0) in r (no duplicate RulePtr objects)
+                    # cache r._rp in _rp (1 less object property lookup?)
+                    _rp = r._rp
+                    if _rp is None:
+                        _rp = RulePtr(r, 0)
+                        r._rp = _rp
+                    q.append(_rp.lookahead(s))
+                    #q.append((r._rp, s))
+                if nullable:
+                    _rp = r._rp
+                    if _rp is None:
+                        _rp = RulePtr(r, 0)
+                        r._rp = _rp
+                    q.append(_rp.lookahead(la))
+                    #q.append((r._rp, la))
+
+            t6 = time.time()
+            t_rules += t5 - t4
+            t_append += t6 - t5
+
+        #self.lr1_cache[k] = closure
+
+        t_end = time.time()
+        t_z += t_end - t_start
+
+        t_count += 1
+
+        if t_count % 1000 == 0:
+            print('\tGenerating lr1 closure took begin {:.3f}, set contains {:.3f}, set add {:.3f}, get first {:.3f}'.format(t_begin, t_set_0, t_set_1, t_expand))
+            print('\tget next rules {:.3f}, append rules {:.3f}, total {:.3f}, call time {:.3f}, count {}'.format(t_rules, t_append, t_z, t_call, t_count))
+            print('\tmax number of appends {}'.format(y))
 
         return closure

--- a/lark/parsers/lalr_analysis.py
+++ b/lark/parsers/lalr_analysis.py
@@ -12,9 +12,8 @@ from collections import defaultdict, deque
 from ..utils import classify, classify_bool, bfs, fzset, Serialize, Enumerator
 from ..exceptions import GrammarError
 
-from .grammar_analysis import GrammarAnalyzer, Terminal, RulePtr, LR0ItemSet
+from .grammar_analysis import GrammarAnalyzer, Terminal, LR0ItemSet
 from ..grammar import Rule
-from . import grammar_analysis
 
 import time
 
@@ -31,15 +30,6 @@ class Action:
 Shift = Action('Shift')
 Reduce = Action('Reduce')
 
-t_set_0 = 0
-t_set_1 = 0
-t_expand = 0
-t_rules = 0
-t_append = 0
-t_z = 0
-t_begin = 0
-t_count = 0
-t_call = 0
 
 class ParseTable:
     def __init__(self, states, start_states, end_states):
@@ -95,9 +85,60 @@ class IntParseTable(ParseTable):
 
 ###}
 
+
+# digraph and traverse, see The Theory and Practice of Compiler Writing
+
+# computes F(x) = G(x) union (union { G(y) | x R y })
+# X: nodes
+# R: relation (function mapping node -> list of nodes that satisfy the relation)
+# G: set valued function
+def digraph(X, R, G):
+    F = {}
+    S = []
+    N = {}
+    for x in X:
+        N[x] = 0
+    for x in X:
+        # this is always true for the first iteration, but N[x] may be updated in traverse below
+        if N[x] == 0:
+            traverse(x, S, N, X, R, G, F)
+    return F
+
+# x: single node
+# S: stack
+# N: weights
+# X: nodes
+# R: relation (see above)
+# G: set valued function
+# F: set valued function we are computing (map of input -> output)
+def traverse(x, S, N, X, R, G, F):
+    S.append(x)
+    d = len(S)
+    N[x] = d
+    F[x] = G(x)
+    for y in R(x):
+        if N[y] == 0:
+            traverse(y, S, N, X, R, G, F)
+        n_x = N[x]
+        assert(n_x > 0)
+        n_y = N[y]
+        assert(n_y != 0)
+        if (n_y > 0) and (n_y < n_x):
+            N[x] = n_y
+        F[x].update(F[y])
+    if N[x] == d:
+        f_x = F[x]
+        while True:
+            z = S.pop()
+            N[z] = -1
+            F[z] = f_x
+            if z == x:
+                break
+
+
 class LALR_Analyzer(GrammarAnalyzer):
 
-    def generate_lr0_states(self):
+    def compute_lr0_states(self):
         self.states = set()
         # map of kernels to LR0ItemSets
         cache = {}
@@ -125,297 +166,118 @@ class LALR_Analyzer(GrammarAnalyzer):
         for _ in bfs(self.lr0_start_states.values(), step):
             pass
 
-    def discover_lookaheads(self):
-        # lookaheads is now a member of LR0ItemSet, so don't need to look up a dictionary here
-        # state -> rule -> set of lookaheads
-        #self.lookaheads = defaultdict(lambda: defaultdict(set))
-        # state -> rule -> list of (set of lookaheads) to propagate to
-        #self.propagates = defaultdict(lambda: defaultdict(list))
-        self.propagates = {}
+    def compute_reads_relations(self):
+        # handle start state
+        for root in self.lr0_start_states.values():
+            assert(len(root.kernel) == 1)
+            for rp in root.kernel:
+                assert(rp.index == 0)
+                self.directly_reads[(root, rp.next)] = set([ Terminal('$END') ])
 
-        t0 = time.time()
-
-        t = Terminal('$END')
-        for s in self.lr0_start_states.values():
-            for rp in s.kernel:
-                #self.lookaheads[s][rp].add(Terminal('$END'))
-                s.lookaheads[rp].add(t)
-
-        t_closure = 0
-
-        # There is a 1 to 1 correspondance between LR0 and LALR1 states.
-        # We calculate the lookaheads for LALR1 kernel items from the LR0 kernel items.
-        # use a terminal that does not exist in the grammar
-        t = Terminal('$#')
-        for s in self.states:
-            p = {}
-            self.propagates[s] = p
-            for rp in s.kernel:
-                q = []
-                p[rp] = q
-                t2 = time.time()
-                z = self.generate_lr1_closure([rp.lookahead(t)], time.time())
-                t3 = time.time()
-                t_closure += t3 - t2
-                #for rp2, la in self.generate_lr1_closure([(rp, t)], time.time()):
-                for rp2_la in z:
-                    rp2 = rp2_la.rp
-                    la = rp2_la.la
+        for state in self.states:
+            seen = set()
+            for rp in state.closure:
+                if rp.is_satisfied:
+                    continue
+                s = rp.next
+                # if s is a not a nonterminal
+                if not s in self.lr0_rules_by_origin:
+                    continue
+                if s in seen:
+                    continue
+                seen.add(s)
+                nt = (state, s)
+                self.nonterminal_transitions.append(nt)
+                dr = self.directly_reads[nt]
+                r = self.reads[nt]
+                next_state = state.transitions[s]
+                for rp2 in next_state.closure:
                     if rp2.is_satisfied:
                         continue
-                    next_symbol = rp2.next
-                    next_state = s.transitions[next_symbol]
-                    rp3 = rp2.advance(next_symbol)
-                    assert(rp3 in next_state.kernel)
-                    #x = self.lookaheads[next_state][rp3]
-                    x = next_state.lookaheads[rp3]
-                    if la == t:
-                        # we must propagate rp's lookaheads to rp3's lookahead set
-                        q.append(x)
+                    s2 = rp2.next
+                    # if s2 is a terminal
+                    if not s2 in self.lr0_rules_by_origin:
+                        dr.add(s2)
+                    if s2 in self.NULLABLE:
+                        r.add((next_state, s2))
+
+    def compute_read_sets(self):
+        R = lambda nt: self.reads[nt]
+        G = lambda nt: self.directly_reads[nt]
+        self.read_sets = digraph(self.nonterminal_transitions, R, G)
+
+    def compute_includes_lookback(self):
+        for nt in self.nonterminal_transitions:
+            state, nonterminal = nt
+            includes = []
+            lookback = self.lookback[nt]
+            for rp in state.closure:
+                if rp.rule.origin != nonterminal:
+                    continue
+                # traverse the states for rp(.rule)
+                state2 = state
+                for i in range(rp.index, len(rp.rule.expansion)):
+                    s = rp.rule.expansion[i]
+                    nt2 = (state2, s)
+                    state2 = state2.transitions[s]
+                    if not nt2 in self.reads:
+                        continue
+                    j = i + 1
+                    for j in range(i + 1, len(rp.rule.expansion)):
+                        if not rp.rule.expansion[j] in self.NULLABLE:
+                            break
                     else:
-                        # this lookahead is "generated spontaneously" for rp3
-                        x.add(la)
+                        includes.append(nt2)
+                # state2 is at the final state for rp.rule
+                if rp.index == 0:
+                    for rp2 in state2.closure:
+                        if (rp2.rule == rp.rule) and rp2.is_satisfied:
+                            lookback.add((state2, rp2.rule))
+            for nt2 in includes:
+                self.includes[nt2].add(nt)
 
-        t1 = time.time()
-        print('Discovering took {:.3f} (generating closure), {:.3f} (total)'.format(t_closure, t1 - t0))
+    def compute_follow_sets(self):
+        R = lambda nt: self.includes[nt]
+        G = lambda nt: self.read_sets[nt]
+        self.follow_sets = digraph(self.nonterminal_transitions, R, G)
 
-    def propagate_lookaheads(self):
-        changed = True
-        while changed:
-            changed = False
-            for s in self.states:
-                for rp in s.kernel:
-                    # from (from is a keyword)
-                    #f = self.lookaheads[s][rp]
-                    f = s.lookaheads[rp]
-                    # to
-                    t = self.propagates[s][rp]
-                    for x in t:
-                        old = len(x)
-                        x |= f
-                        changed = changed or (len(x) != old)
+    def compute_lookaheads(self):
+        for nt, lookbacks in self.lookback.items():
+            for state, rule in lookbacks:
+                for s in self.follow_sets[nt]:
+                    state.lookaheads[s].add(rule)
 
-    def generate_lalr1_states(self):
-        t0 = time.time()
-        # 1 to 1 correspondance between LR0 and LALR1 states
-        # We must fetch the lookaheads we calculated,
-        # to create the LALR1 kernels from the LR0 kernels.
-        # Then, we generate the LALR1 states by taking the LR1 closure of the new kernel items.
-        # map of LR0 states to LALR1 states
+    def compute_lalr1_states(self):
         m = {}
-        t_closure = 0
-        z = 0
-        for s in self.states:
-            z = max(z, len(s.closure))
-            kernel = []
-            for rp in s.kernel:
-                #las = self.lookaheads[s][rp]
-                las = s.lookaheads[rp]
-                assert(len(las) > 0)
-                for la in las:
-                    kernel.append(rp.lookahead(la))
-            t0_0 = time.time()
-            m[s] = self.generate_lr1_closure(kernel, time.time())
-            t0_1 = time.time()
-            t_closure += t0_1 - t0_0
-
-        print('Generating lalr1 closure for lalr kernels took {:.3f}'.format(t_closure))
-        print('Max lr0 state size was {}'.format(z))
-
-        t1 = time.time()
-
-        self.states = {}
-        for s, v in m.items():
+        for state in self.states:
             actions = {}
-            for la, next_state in s.transitions.items():
+            for la, next_state in state.transitions.items():
                 actions[la] = (Shift, next_state.closure)
-
-            sat, _ = classify_bool(v, lambda x: x.rp.is_satisfied)
-            reductions = classify(sat, lambda x: x.la, lambda x: x.rp)
-            for la, rps in reductions.items():
-                if len(rps) > 1:
-                    raise GrammarError("Collision in %s: %s" % (la, ', '.join([ str(r.rule) for r in rps ])))
+            for la, rules in state.lookaheads.items():
+                if len(rules) > 1:
+                    raise GrammarError('Collision in %s: %s' % (la, ', '.join([ str(r) for r in rules ])))
                 if la in actions:
                     if self.debug:
-                        logging.warning("Shift/reduce conflict for terminal %s:  (resolving as shift)", la.name)
-                        logging.warning(' * %s', str(rps[0]))
+                        logging.warning('Shift/reduce conflict for terminal %s: (resolving as shift)', la.name)
+                        logging.warning(' * %s', list(rules)[0])
                 else:
-                    actions[la] = (Reduce, rps[0].rule)
+                    actions[la] = (Reduce, list(rules)[0])
+            m[state] = { k.name: v for k, v in actions.items() }
 
-            self.states[s.closure] = {k.name: v for k, v in actions.items()}
+        self.states = { k.closure: v for k, v in m.items() }
 
-        t2 = time.time()
-
+        # compute end states
         end_states = {}
-        for s in self.states:
-            for rp in s:
+        for state in self.states:
+            for rp in state:
                 for start in self.lr0_start_states:
                     if rp.rule.origin.name == ('$root_' + start) and rp.is_satisfied:
                         assert(not start in end_states)
-                        end_states[start] = s
+                        end_states[start] = state
 
-        t3 = time.time()
-
-        self._parse_table = ParseTable(self.states, {start: state.closure for start, state in self.lr0_start_states.items()}, end_states)
-
-        t4 = time.time()
+        self._parse_table = ParseTable(self.states, { start: state.closure for start, state in self.lr0_start_states.items() }, end_states)
 
         if self.debug:
             self.parse_table = self._parse_table
         else:
             self.parse_table = IntParseTable.from_ParseTable(self._parse_table)
-
-        t5 = time.time()
-
-        print(('Generating lalr1 states took ' + ', '.join([ '{:.3f}' ] * 5)).format(t1 - t0, t2 - t1, t3 - t2, t4 - t3, t5 - t4))
-        print('Generating firsts took {:.3f} (time actually calculating), {:.3f} (end to end), {:.3f} (just function call)'.format(grammar_analysis.t_firsts, grammar_analysis.t_xy, grammar_analysis.t_call))
-
-    def generate_lr1_closure(self, kernel, t_caller):
-        global t_call
-        global t_set_0
-        global t_set_1
-        global t_expand
-        global t_rules
-        global t_append
-        global t_z
-        global t_begin
-        global t_count
-
-        t_start = time.time()
-        t_call += t_start - t_caller
-
-        # cache the results of this function
-        # not many hits, no noticeable performance improvement
-        '''
-        k = fzset(kernel)
-        cached = self.lr1_cache.get(k, None)
-        if not cached is None:
-            return cached
-        '''
-
-        closure = set()
-        closure_hash = {}
-
-        y = 0
-
-        q = list(kernel)
-        while len(q) > 0:
-            t_a = time.time()
-            rp_la = q.pop()
-            #rp_la_hash = hash(rp_la)
-            t0 = time.time()
-            t_begin += t0 - t_a
-            # try to manually maintain hashtable,
-            # as a set of just hashes (ints) was notably faster
-            '''
-            if rp_la_hash in closure_hash:
-                if rp_la in closure_hash[rp_la_hash]:
-                    t0_0 = time.time()
-                    t_set_0 += t0_0 - t0
-                    continue
-                t0_0 = time.time()
-                t_set_0 += t0_0 - t0
-            else:
-                closure_hash[rp_la_hash] = []
-            '''
-            if rp_la in closure:
-                t0_0 = time.time()
-                t_set_0 += t0_0 - t0
-                continue
-            t0_0 = time.time()
-            closure.add(rp_la)
-            #closure_hash[rp_la_hash].append(rp_la)
-            t1 = time.time()
-            t_set_0 += t0_0 - t0
-            t_set_1 += t1 - t0_0
-            rp = rp_la.rp
-            la = rp_la.la
-
-            if rp.is_satisfied:
-                continue
-            if rp.next.is_term:
-                continue
-
-            t2 = time.time()
-
-            # cache these calculations inside each RulePtr
-            # see grammar_analysis.py:79
-            l = []
-            '''
-            i = rp.index + 1
-            n = len(rp.rule.expansion)
-            l2_i = self.lr1_cache2.get((rp.rule, i), None)
-            l2 = []
-            if l2_i is None:
-                while i < n:
-                    s = rp.rule.expansion[i]
-                    l2.extend(self.FIRST.get(s, []))
-                    if not s in self.NULLABLE:
-                        break
-                    i += 1
-                self.lr1_cache2[(rp.rule, i)] = (l2, i)
-            else:
-                l2 = l2_i[0]
-                i = l2_i[1]
-
-            l.extend(l2)
-            '''
-            # this function call seems really slow (see grammar_analysis.t_call above)
-            # tried making it not a method call so don't need to look up vtable
-            # still equally slow
-            l2, nullable = rp.first(rp.index + 1, self.FIRST, self.NULLABLE, time.time())
-            #l2, nullable = grammar_analysis.first(rp, rp.index + 1, self.FIRST, self.NULLABLE, time.time())
-            #l.extend(l2)
-            l = l2
-            t3 = time.time()
-
-            t_expand += t3 - t2
-
-            # if we don't modify l2 and add an extra check in the loop below,
-            # we don't have to copy it
-            # if all of rp.rule.expansion[rp.index + 1:] were nullable:
-            #if nullable:
-            #    l.append(la)
-
-            t4 = time.time()
-            x = rp.next_rules_by_origin(self.lr0_rules_by_origin)
-            t5 = time.time()
-
-            # usually between 20-60? seen as high as ~175
-            y = max(y, len(x) * len(l))
-            #print('adding {} * {} rules to closure max {}'.format(len(x), len(l), y))
-            for r in x:
-                for s in l:
-                    # cache RulePtr(r, 0) in r (no duplicate RulePtr objects)
-                    # cache r._rp in _rp (1 less object property lookup?)
-                    _rp = r._rp
-                    if _rp is None:
-                        _rp = RulePtr(r, 0)
-                        r._rp = _rp
-                    q.append(_rp.lookahead(s))
-                    #q.append((r._rp, s))
-                if nullable:
-                    _rp = r._rp
-                    if _rp is None:
-                        _rp = RulePtr(r, 0)
-                        r._rp = _rp
-                    q.append(_rp.lookahead(la))
-                    #q.append((r._rp, la))
-
-            t6 = time.time()
-            t_rules += t5 - t4
-            t_append += t6 - t5
-
-        #self.lr1_cache[k] = closure
-
-        t_end = time.time()
-        t_z += t_end - t_start
-
-        t_count += 1
-
-        if t_count % 1000 == 0:
-            print('\tGenerating lr1 closure took begin {:.3f}, set contains {:.3f}, set add {:.3f}, get first {:.3f}'.format(t_begin, t_set_0, t_set_1, t_expand))
-            print('\tget next rules {:.3f}, append rules {:.3f}, total {:.3f}, call time {:.3f}, count {}'.format(t_rules, t_append, t_z, t_call, t_count))
-            print('\tmax number of appends {}'.format(y))
-
-        return closure

--- a/lark/parsers/lalr_analysis.py
+++ b/lark/parsers/lalr_analysis.py
@@ -12,7 +12,7 @@ from collections import defaultdict
 from ..utils import classify, classify_bool, bfs, fzset, Serialize, Enumerator
 from ..exceptions import GrammarError
 
-from .grammar_analysis import GrammarAnalyzer, Terminal
+from .grammar_analysis import GrammarAnalyzer, Terminal, RulePtr, LR0ItemSet
 from ..grammar import Rule
 
 ###{standalone
@@ -84,53 +84,158 @@ class IntParseTable(ParseTable):
 
 class LALR_Analyzer(GrammarAnalyzer):
 
-    def compute_lookahead(self):
+    def generate_lr0_states(self):
+        self.states = set()
 
-        self.states = {}
         def step(state):
-            lookahead = defaultdict(list)
-            sat, unsat = classify_bool(state, lambda rp: rp.is_satisfied)
-            for rp in sat:
-                for term in self.FOLLOW.get(rp.rule.origin, ()):
-                    lookahead[term].append((Reduce, rp.rule))
+            _, unsat = classify_bool(state.closure, lambda rp: rp.is_satisfied)
 
             d = classify(unsat, lambda rp: rp.next)
             for sym, rps in d.items():
-                rps = {rp.advance(sym) for rp in rps}
+                kernel = {rp.advance(sym) for rp in rps}
+                closure = set(kernel)
 
-                for rp in set(rps):
+                for rp in kernel:
                     if not rp.is_satisfied and not rp.next.is_term:
-                        rps |= self.expand_rule(rp.next)
+                        closure |= self.expand_rule(rp.next, self.lr0_rules_by_origin)
 
-                new_state = fzset(rps)
-                lookahead[sym].append((Shift, new_state))
+                new_state = LR0ItemSet(kernel, closure)
+                state.transitions[sym] = new_state
                 yield new_state
 
-            for k, v in lookahead.items():
-                if len(v) > 1:
-                    if self.debug:
-                        logging.warning("Shift/reduce conflict for terminal %s:  (resolving as shift)", k.name)
-                        for act, arg in v:
-                            logging.warning(' * %s: %s', act, arg)
-                    for x in v:
-                        # XXX resolving shift/reduce into shift, like PLY
-                        # Give a proper warning
-                        if x[0] is Shift:
-                            lookahead[k] = [x]
+            self.states.add(state)
 
-            for k, v in lookahead.items():
-                if not len(v) == 1:
-                    raise GrammarError("Collision in %s: %s" %(k, ', '.join(['\n  * %s: %s' % x for x in v])))
-
-            self.states[state] = {k.name:v[0] for k, v in lookahead.items()}
-
-        for _ in bfs(self.start_states.values(), step):
+        for _ in bfs(self.lr0_start_states.values(), step):
             pass
 
-        self._parse_table = ParseTable(self.states, self.start_states, self.end_states)
+    def discover_lookaheads(self):
+        # state -> rule -> set of lookaheads
+        self.lookaheads = defaultdict(lambda: defaultdict(set))
+        # state -> rule -> list of (set of lookaheads) to propagate to
+        self.propagates = defaultdict(lambda: defaultdict(list))
+
+        for s in self.lr0_start_states.values():
+            for rp in s.kernel:
+                self.lookaheads[s][rp].add(Terminal('$END'))
+
+        # There is a 1 to 1 correspondance between LR0 and LALR1 states.
+        # We calculate the lookaheads for LALR1 kernel items from the LR0 kernel items.
+        # use a terminal that does not exist in the grammar
+        t = Terminal('$#')
+        for s in self.states:
+            for rp in s.kernel:
+                for rp2, la in self.generate_lr1_closure([(rp, t)]):
+                    if rp2.is_satisfied:
+                        continue
+                    next_symbol = rp2.next
+                    next_state = s.transitions[next_symbol]
+                    rp3 = rp2.advance(next_symbol)
+                    assert(rp3 in next_state.kernel)
+                    x = self.lookaheads[next_state][rp3]
+                    if la == t:
+                        # we must propagate rp's lookaheads to rp3's lookahead set
+                        self.propagates[s][rp].append(x)
+                    else:
+                        # this lookahead is "generated spontaneously" for rp3
+                        x.add(la)
+
+    def propagate_lookaheads(self):
+        changed = True
+        while changed:
+            changed = False
+            for s in self.states:
+                for rp in s.kernel:
+                    # from (from is a keyword)
+                    f = self.lookaheads[s][rp]
+                    # to
+                    t = self.propagates[s][rp]
+                    for x in t:
+                        old = len(x)
+                        x |= f
+                        changed = changed or (len(x) != old)
+
+    def generate_lalr1_states(self):
+        # 1 to 1 correspondance between LR0 and LALR1 states
+        # We must fetch the lookaheads we calculated,
+        # to create the LALR1 kernels from the LR0 kernels.
+        # Then, we generate the LALR1 states by taking the LR1 closure of the new kernel items.
+        # map of LR0 states to LALR1 states
+        m = {}
+        for s in self.states:
+            kernel = []
+            for rp in s.kernel:
+                las = self.lookaheads[s][rp]
+                assert(len(las) > 0)
+                for la in las:
+                    kernel.append((rp, la))
+            m[s] = self.generate_lr1_closure(kernel)
+
+        self.states = {}
+        for s, v in m.items():
+            actions = {}
+            for la, next_state in s.transitions.items():
+                actions[la] = (Shift, next_state.closure)
+
+            sat, _ = classify_bool(v, lambda x: x[0].is_satisfied)
+            reductions = classify(sat, lambda x: x[1], lambda x: x[0])
+            for la, rps in reductions.items():
+                if len(rps) > 1:
+                    raise GrammarError("Collision in %s: %s" % (la, ', '.join([ str(r.rule) for r in rps ])))
+                if la in actions:
+                    if self.debug:
+                        logging.warning("Shift/reduce conflict for terminal %s:  (resolving as shift)", la.name)
+                        logging.warning(' * %s', str(rps[0]))
+                else:
+                    actions[la] = (Reduce, rps[0].rule)
+
+            self.states[s.closure] = {k.name: v for k, v in actions.items()}
+
+        end_states = {}
+        for s in self.states:
+            for rp in s:
+                for start in self.lr0_start_states:
+                    if rp.rule.origin.name == ('$root_' + start) and rp.is_satisfied:
+                        assert(not start in end_states)
+                        end_states[start] = s
+
+        self._parse_table = ParseTable(self.states, {start: state.closure for start, state in self.lr0_start_states.items()}, end_states)
 
         if self.debug:
             self.parse_table = self._parse_table
         else:
             self.parse_table = IntParseTable.from_ParseTable(self._parse_table)
 
+    def generate_lr1_closure(self, kernel):
+        closure = set()
+
+        q = list(kernel)
+        while len(q) > 0:
+            rp, la = q.pop()
+            if (rp, la) in closure:
+                continue
+            closure.add((rp, la))
+
+            if rp.is_satisfied:
+                continue
+            if rp.next.is_term:
+                continue
+
+            l = []
+            i = rp.index + 1
+            n = len(rp.rule.expansion)
+            while i < n:
+                s = rp.rule.expansion[i]
+                l.extend(self.FIRST.get(s, []))
+                if not s in self.NULLABLE:
+                    break
+                i += 1
+
+            # if all of rp.rule.expansion[rp.index + 1:] were nullable:
+            if i == n:
+                l.append(la)
+
+            for r in self.lr0_rules_by_origin[rp.next]:
+                for s in l:
+                    q.append((RulePtr(r, 0), s))
+
+        return closure

--- a/lark/parsers/lalr_parser.py
+++ b/lark/parsers/lalr_parser.py
@@ -8,8 +8,6 @@ from ..utils import Enumerator, Serialize
 
 from .lalr_analysis import LALR_Analyzer, Shift, Reduce, IntParseTable
 
-import time
-
 
 ###{standalone
 class LALR_Parser(object):
@@ -17,13 +15,7 @@ class LALR_Parser(object):
         assert all(r.options is None or r.options.priority is None
                    for r in parser_conf.rules), "LALR doesn't yet support prioritization"
         analysis = LALR_Analyzer(parser_conf, debug=debug)
-        analysis.compute_lr0_states()
-        analysis.compute_reads_relations()
-        analysis.compute_read_sets()
-        analysis.compute_includes_lookback()
-        analysis.compute_follow_sets()
-        analysis.compute_lookaheads()
-        analysis.compute_lalr1_states()
+        analysis.compute_lalr()
         callbacks = parser_conf.callbacks
 
         self._parse_table = analysis.parse_table
@@ -88,11 +80,6 @@ class _Parser:
             state_stack.append(new_state)
             value_stack.append(value)
 
-            if state_stack[-1] == end_state:
-                return True
-
-            return False
-
         # Main LALR-parser loop
         for token in stream:
             while True:
@@ -111,7 +98,8 @@ class _Parser:
         while True:
             _action, arg = get_action(token)
             assert(_action is Reduce)
-            if reduce(arg):
+            reduce(arg)
+            if state_stack[-1] == end_state:
                 return value_stack[-1]
 
 ###}

--- a/lark/parsers/lalr_parser.py
+++ b/lark/parsers/lalr_parser.py
@@ -8,6 +8,8 @@ from ..utils import Enumerator, Serialize
 
 from .lalr_analysis import LALR_Analyzer, Shift, Reduce, IntParseTable
 
+import time
+
 
 ###{standalone
 class LALR_Parser(object):
@@ -15,10 +17,20 @@ class LALR_Parser(object):
         assert all(r.options is None or r.options.priority is None
                    for r in parser_conf.rules), "LALR doesn't yet support prioritization"
         analysis = LALR_Analyzer(parser_conf, debug=debug)
+        t0 = time.time()
         analysis.generate_lr0_states()
+        t1 = time.time()
         analysis.discover_lookaheads()
+        t2 = time.time()
         analysis.propagate_lookaheads()
+        t3 = time.time()
         analysis.generate_lalr1_states()
+        t4 = time.time()
+        print('Generating lr0 states took {:.3f}'.format(t1 - t0))
+        print('Discovering lookaheads took {:.3f}'.format(t2 - t1))
+        print('Propagating lookaheads took took {:.3f}'.format(t3 - t2))
+        print('Generating lalr states (closure) took {:.3f}'.format(t4 - t3))
+        print('-' * 32)
         callbacks = parser_conf.callbacks
 
         self._parse_table = analysis.parse_table


### PR DESCRIPTION
The existing parser calculates lookaheads for reductions by looking at the FOLLOW set of the grammar, making it actually an SLR(1) parser. LALR(1) parsers have the same number of states as SLR(1) parsers, but parse a strict superset of SLR(1) grammars, so they are generally preferred.

~~These commits implement the algorithm described in Compilers: Principles, Techniques, and Tools (2nd edition) to (supposedly) efficiently calculate LALR(1) lookaheads.~~ This now implements [DeRemer and Pennello's LALR lookahead algorithm][1], based on PLY and The Theory and Practice of Compiler Writing. It does _not_ generate LR(1) states (which may be orders of magnitudes larger) to merge into LALR(1) states. **Update**: it is now much much faster than the old (dragon book) algorithm.

At a high level, the algorithm:

1. Generates LR(0) itemsets/states (similar to the existing parser, see below for minor change)~~
1. ~~Calculates lookaheads~~
1. ~~Attaches lookaheads to the LR(0) kernels to form LALR(1) kernels~~
1. ~~Generates the LR(1) closure of the LALR(1) kernels to obtain the LALR(1) states (same number as LR(0) states)~~
1. Does some stuff I can't really explain 😅

I tried my best to maintain Lark's coding style and I believe the code is ~~well documented~~ documented wherever I thought possible. My main concern is the naming scheme, particularly the `lr0_*` member variables introduced to `GrammarAnalyzer`. The LALR(1) algorithm I implemented does not use an `$END` token for the root rules. However, I did not want to overwrite the existing member variables as it would affect the Earley parser. **Update**: I can't really explain _why_ the algorithm works, so I couldn't add many insightful comments unfortunately.

The LALR(1) parser can be tested with the following grammar/program:

```
from lark import Lark

grammar = r'''
EQUALS:  "="
STAR: "*"
ID: "id"

s: l EQUALS r | r
l: STAR r | ID
r: l
'''

parser = Lark(grammar, parser='lalr', lexer='standard', start='s')
text = '*id=id'
print(parser.parse(text).pretty())
```

The older parser (with debug enabled) logs a shift/reduce conflict. While shifting produces the right behaviour in this example (which is the default conflict resolution mechanism), LALR(1) parsers are known to be more powerful than SLR(1) parsers. As it is, users may see shift/reduce or reduce/reduce conflicts with proper LALR(1) grammars, if the grammars are not SLR(1).

I have run the tests and only 3 tests in `tests.test_nearley.test_nearley.TestNearley` fail, which were failing for me before my changes (they have a `FileNotFoundError`, so I assume I'm just missing some test files). However, I have not profiled these changes. Theoretically, parsing speed should be the same because the parsing table format and algorithm were only minimally changed (removed the artificial `$END` token appended to root rules. Now, a successful parse ends in a reduce action). Generating the parser may be slower as the lookahead calculation is more complex compared to SLR(1).

[1]: https://dl.acm.org/citation.cfm?id=357187