### PR TITLE
Fix Earley determinism

### DIFF
--- a/lark/load_grammar.py
+++ b/lark/load_grammar.py
@@ -511,12 +511,12 @@ class Grammar:
 
         simplify_rule = SimplifyRule_Visitor()
         compiled_rules = []
-        for i, rule_content in enumerate(rules):
+        for rule_content in rules:
             name, tree, options = rule_content
             simplify_rule.visit(tree)
             expansions = rule_tree_to_text.transform(tree)
 
-            for expansion, alias in expansions:
+            for i, (expansion, alias) in enumerate(expansions):
                 if alias and name.startswith('_'):
                     raise GrammarError("Rule %s is marked for expansion (it starts with an underscore) and isn't allowed to have aliases (alias=%s)" % (name, alias))
 

--- a/lark/parser_frontends.py
+++ b/lark/parser_frontends.py
@@ -139,7 +139,8 @@ class Earley(WithLexer):
         self.init_traditional_lexer()
 
         resolve_ambiguity = options.ambiguity == 'resolve'
-        self.parser = earley.Parser(parser_conf, self.match, resolve_ambiguity=resolve_ambiguity)
+        debug = options.debug if options else False
+        self.parser = earley.Parser(parser_conf, self.match, resolve_ambiguity=resolve_ambiguity, debug=debug)
 
     def match(self, term, token):
         return term.name == token.type
@@ -152,10 +153,12 @@ class XEarley(_ParserFrontend):
 
         self._prepare_match(lexer_conf)
         resolve_ambiguity = options.ambiguity == 'resolve'
+        debug = options.debug if options else False
         self.parser = xearley.Parser(parser_conf,
                                     self.match,
                                     ignore=lexer_conf.ignore,
                                     resolve_ambiguity=resolve_ambiguity,
+                                    debug=debug,
                                     **kw
                                     )
 

--- a/lark/parsers/earley.py
+++ b/lark/parsers/earley.py
@@ -20,10 +20,11 @@ from .earley_common import Item, TransitiveItem
 from .earley_forest import ForestToTreeVisitor, ForestSumVisitor, SymbolNode, ForestToAmbiguousTreeVisitor
 
 class Parser:
-    def __init__(self, parser_conf, term_matcher, resolve_ambiguity=True):
+    def __init__(self, parser_conf, term_matcher, resolve_ambiguity=True, debug=False):
         analysis = GrammarAnalyzer(parser_conf)
         self.parser_conf = parser_conf
         self.resolve_ambiguity = resolve_ambiguity
+        self.debug = debug
 
         self.FIRST = analysis.FIRST
         self.NULLABLE = analysis.NULLABLE
@@ -296,6 +297,10 @@ class Parser:
         # symbol should have been completed in the last step of the Earley cycle, and will be in
         # this column. Find the item for the start_symbol, which is the root of the SPPF tree.
         solutions = [n.node for n in columns[-1] if n.is_complete and n.node is not None and n.s == start_symbol and n.start == 0]
+        if self.debug:
+            from .earley_forest import ForestToPyDotVisitor
+            debug_walker = ForestToPyDotVisitor()
+            debug_walker.visit(solutions[0], "sppf.png")
 
         if not solutions:
             expected_tokens = [t.expect for t in to_scan]

--- a/lark/parsers/xearley.py
+++ b/lark/parsers/xearley.py
@@ -24,8 +24,8 @@ from .earley_forest import SymbolNode
 
 
 class Parser(BaseParser):
-    def __init__(self,  parser_conf, term_matcher, resolve_ambiguity=True, ignore = (), complete_lex = False):
-        BaseParser.__init__(self, parser_conf, term_matcher, resolve_ambiguity)
+    def __init__(self,  parser_conf, term_matcher, resolve_ambiguity=True, ignore = (), complete_lex = False, debug=False):
+        BaseParser.__init__(self, parser_conf, term_matcher, resolve_ambiguity, debug)
         self.ignore = [Terminal(t) for t in ignore]
         self.complete_lex = complete_lex
 


### PR DESCRIPTION
The way we were calculating the tie-breaker for Earley was wrong. Rule.order should be the index of the specific rule expansion amount all of the expansions, not the index of the rule within the file. This allows the grammar author to easily control the tie-breaker within a rule:
a: b
  | c

(b will always be preferred over c if neither b nor c have priorities assigned). Priorities trump expansion ordering.
