### PR TITLE
Fix for staticmethods in Transformers + examples, docs

### DIFF
--- a/docs/classes.md
+++ b/docs/classes.md
@@ -142,10 +142,22 @@ class EvalExpressions(Transformer):
     def expr(self, args):
             return eval(args[0])
 
-t = Tree('a', [Tree('expr', ['1+2'])])
+    # lambdas provide for neat one liners
+
+    # by default lambda will bind, taking self as the first argument
+    mul = lambda self, args: args[0] * args[1]
+
+    # if you don't need self, wrap it in a staticmethod
+    add = staticmethod(lambda args: args[0] + args[1])
+
+t = Tree('a', [
+        Tree('expr', ['1+2']),
+        Tree('mul', [3, 4]),
+        Tree('add', [3, 4])
+    ])
 print(EvalExpressions().transform( t ))
 
-# Prints: Tree(a, [3])
+# Prints: Tree(a, [3, 12, 7])
 ```
 
 
@@ -177,6 +189,20 @@ class SolveArith(Transformer):
     def add(self, left, right):
         return left + right
 
+    # neat one liner for dealing with hex that works with v_args inline
+    hexnumber = functools.partial(int, base=16)
+
+    mul = staticmethod(lambda left, right: left * right)
+
+t = Tree('a', [
+        Tree('add', [5, 6]),
+        Tree('mul', [
+            Tree('hexnumber', ['0x3']),
+            4
+        ])
+    ])
+print(SolveArith().transform( t ))
+# Prints: Tree(a, [11, 12])
 
 class ReverseNotation(Transformer_InPlace):
     @v_args(tree=True):

--- a/lark/visitors.py
+++ b/lark/visitors.py
@@ -76,7 +76,9 @@ class Transformer:
             # Make sure the function isn't inherited (unless it's overwritten)
             if name.startswith('_') or (name in libmembers and name not in cls.__dict__):
                 continue
-            if not callable(cls.__dict__[name]):
+            # Check the actual value here, as staticmethod is a descriptor and
+            # as such returns False for callable.
+            if not callable(value):
                 continue
 
             # Skip if v_args already applied (at the function level)


### PR DESCRIPTION
If you use the pattern x = staticmethod(lambda: True) or similar
with v_args annotations at a class level; the staticmethod may not
be correctly wrapped; due to:
https://stackoverflow.com/questions/45375944/python-static-method-is-not-always-callable