### PR TITLE
Copy exc state when converting UnexpectedCharacters to UnexpectedToken exc. Fixes #462

### DIFF
--- a/lark/lexer.py
+++ b/lark/lexer.py
@@ -384,6 +384,6 @@ class ContextualLexer(Lexer):
 
             value, type_ = root_match
             t = Token(type_, value, e.pos_in_stream, e.line, e.column)
-            raise UnexpectedToken(t, e.allowed)
+            raise UnexpectedToken(t, e.allowed, state=e.state)
 
 ###}


### PR DESCRIPTION
I think this change is needed to support `match_examples` for the `UnexpetedToken` exception when using LALR parsers. This bug was probably introduced in v0.7.7