### PR TITLE
Allow comments in rule definitions

### DIFF
--- a/examples/lark.lark
+++ b/examples/lark.lark
@@ -44,7 +44,7 @@ _NL: /(\r?\n)+\s*/
 %import common.INT -> NUMBER
 %import common.WS_INLINE
 
-COMMENT: "//" /[^\n]/*
+COMMENT: /\s*/ "//" /[^\n]/*
 
 %ignore WS_INLINE
 %ignore COMMENT

--- a/lark/load_grammar.py
+++ b/lark/load_grammar.py
@@ -85,7 +85,7 @@ TERMINALS = {
     'REGEXP': r'/(?!/)(\\/|\\\\|[^/\n])*?/[%s]*' % _RE_FLAGS,
     '_NL': r'(\r?\n)+\s*',
     'WS': r'[ \t]+',
-    'COMMENT': r'//[^\n]*',
+    'COMMENT': r'\s*//[^\n]*',
     '_TO': '->',
     '_IGNORE': r'%ignore',
     '_DECLARE': r'%declare',

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -94,6 +94,16 @@ class TestParsers(unittest.TestCase):
         r = g.parse('xx')
         self.assertEqual( r.children[0].data, "c" )
 
+    def test_comment_in_rule_definition(self):
+        g = Lark("""start: a
+               a: "a"
+               // A comment
+               // Another
+                | "b"
+            """)
+        r = g.parse('b')
+        self.assertEqual( r.children[0].data, "a" )
+
     def test_visit_tokens(self):
         class T(Transformer):
             def a(self, children):


### PR DESCRIPTION
Fixes a bug whereby adding comments in the middle of multi line rule definitions causes a parsing error.

Example:
```
from lark import Lark

grammar = """
start: example+

example: "a"
  // Comment
  | "b"
"""

l = Lark(grammar)
```

Gives:
```
lark.exceptions.UnexpectedToken: Unexpected token Token(_OR, '|') at line 6, column 3.
```