### PR TITLE
Added fix for v_args

### DIFF
--- a/lark/visitors.py
+++ b/lark/visitors.py
@@ -24,11 +24,11 @@ class _Decoratable:
             # Make sure the function isn't inherited (unless it's overwritten)
             if name.startswith('_') or (name in libmembers and name not in cls.__dict__):
                 continue
-            if not callable(cls.__dict__[name]):
+            if not callable(value):
                 continue
 
             # Skip if v_args already applied (at the function level)
-            if hasattr(cls.__dict__[name], 'vargs_applied'):
+            if hasattr(cls.__dict__[name], 'vargs_applied') or hasattr(value, 'vargs_applied'):
                 continue
 
             static = isinstance(cls.__dict__[name], (staticmethod, classmethod))

--- a/tests/test_trees.py
+++ b/tests/test_trees.py
@@ -166,6 +166,15 @@ class TestTrees(TestCase):
         x = MyTransformer().transform( Tree('hello', [2]))
         self.assertEqual(x, 'hello')
 
+    def test_inline_static(self):
+        @v_args(inline=True)
+        class T(Transformer):
+            @staticmethod
+            def test(a, b):
+                return a + b
+        x = T().transform(Tree('test', ['a', 'b']))
+        self.assertEqual(x, 'ab')
+
     def test_vargs_override(self):
         t = Tree('add', [Tree('sub', [Tree('i', ['3']), Tree('f', ['1.1'])]), Tree('i', ['1'])])
 


### PR DESCRIPTION
Mentioned in recent [Gitter chat](https://gitter.im/lark-parser/Lobby?at=5e911e4ae7ca460b06518aa9), if `v_args(inline=True)`, and a function in the class is decorated with `@staticmethod`, the effect will not be applied to the static method.

This is because when a function is decorated with staticmethod, `cls.__dict__[name]` is not callable, skipping out of the loop early.