### PR TITLE
`maybe_placeholders` made True by default

### DIFF
--- a/lark/lark.py
+++ b/lark/lark.py
@@ -94,7 +94,7 @@ class LarkOptions(Serialize):
         'ambiguity': 'auto',
         'propagate_positions': False,
         'lexer_callbacks': {},
-        'maybe_placeholders': False,
+        'maybe_placeholders': True,
         'edit_terminals': None,
         'g_regex_flags': 0,
     }


### PR DESCRIPTION
Docs:
> `maybe_placeholders` - - When True, the `[]` operator returns None when not matched. - When False, `[]` behaves like the ? operator, and returns no value at all. - (default=False. Recommended to set to True)

It also says in the grammar docs that:
> `[item item ..]` - Maybe. Same as (item item ..)?, but generates None if there is no match
which by default is wrong

Why not set the default to True? It would make the most sense that by default `(...)?` and `[...]` behave differently.