### PR TITLE
Use token type equality as a fallback when matching error examples

### DIFF
--- a/lark/exceptions.py
+++ b/lark/exceptions.py
@@ -32,7 +32,7 @@ class UnexpectedInput(LarkError):
         after = text[pos:end].split('\n', 1)[0]
         return before + after + '\n' + ' ' * len(before) + '^\n'
 
-    def match_examples(self, parse_fn, examples):
+    def match_examples(self, parse_fn, examples, token_type_match_fallback=False):
         """ Given a parser instance and a dictionary mapping some label with
             some malformed syntax examples, it'll return the label for the
             example that bests matches the current error.
@@ -52,8 +52,10 @@ class UnexpectedInput(LarkError):
                             if ut.token == self.token:  # Try exact match first
                                 return label
 
-                            if (ut.token.type == self.token.type) and not candidate[-1]: # Fallback to token types match
-                                candidate = label, True
+                            if token_type_match_fallback:
+                                # Fallback to token types match
+                                if (ut.token.type == self.token.type) and not candidate[-1]:
+                                    candidate = label, True
 
                         except AttributeError:
                             pass

--- a/lark/exceptions.py
+++ b/lark/exceptions.py
@@ -39,7 +39,7 @@ class UnexpectedInput(LarkError):
         """
         assert self.state is not None, "Not supported for this exception"
 
-        candidate = None
+        candidate = (None, False)
         for label, example in examples.items():
             assert not isinstance(example, STRING_TYPE)
 
@@ -51,12 +51,16 @@ class UnexpectedInput(LarkError):
                         try:
                             if ut.token == self.token:  # Try exact match first
                                 return label
+
+                            if (ut.token.type == self.token.type) and not candidate[-1]: # Fallback to token types match
+                                candidate = label, True
+
                         except AttributeError:
                             pass
-                        if not candidate:
-                            candidate = label
+                        if not candidate[0]:
+                            candidate = label, False
 
-        return candidate
+        return candidate[0]
 
 
 class UnexpectedCharacters(LexError, UnexpectedInput):


### PR DESCRIPTION
Enhance UnexpectedInput example matching by using token type equality as a fallback from full token equality (instead of just parser state equality). So with this change best match selection is 3 stage process:
* If parser state match and full token match - select candidate
* If parser state match and token types match - favour this candidate over others matching just parser state
* If parser state match only - select candidate as so far best option
Example of where it is useful is when tokens to match are not fixed strings.