### PR TITLE
Reconstruction keep terminals

### DIFF
--- a/lark/load_grammar.py
+++ b/lark/load_grammar.py
@@ -307,6 +307,7 @@ class PrepareAnonTerminals(Transformer_InPlace):
         self.term_set = {td.name for td in self.terminals}
         self.term_reverse = {td.pattern: td for td in terminals}
         self.i = 0
+        self.rule_options = None
 
 
     @inline_args
@@ -351,7 +352,10 @@ class PrepareAnonTerminals(Transformer_InPlace):
             self.term_reverse[p] = termdef
             self.terminals.append(termdef)
 
-        return Terminal(term_name, filter_out=isinstance(p, PatternStr))
+        filter_out = False if self.rule_options and self.rule_options.keep_all_tokens else isinstance(p, PatternStr)
+
+        return Terminal(term_name, filter_out=filter_out)
+
 
 class _ReplaceSymbols(Transformer_InPlace):
     " Helper for ApplyTemplates "
@@ -527,7 +531,8 @@ class Grammar:
         # =================
 
         # 1. Pre-process terminals
-        transformer = PrepareLiterals() * PrepareSymbols() * PrepareAnonTerminals(terminals)  # Adds to terminals
+        anon_tokens_transf = PrepareAnonTerminals(terminals)
+        transformer = PrepareLiterals() * PrepareSymbols() * anon_tokens_transf  # Adds to terminals
 
         # 2. Inline Templates
 
@@ -542,8 +547,10 @@ class Grammar:
             i += 1
             if len(params) != 0: # Dont transform templates
                 continue
-            ebnf_to_bnf.rule_options = RuleOptions(keep_all_tokens=True) if options.keep_all_tokens else None
+            rule_options = RuleOptions(keep_all_tokens=True) if options and options.keep_all_tokens else None
+            ebnf_to_bnf.rule_options = rule_options
             ebnf_to_bnf.prefix = name
+            anon_tokens_transf.rule_options = rule_options
             tree = transformer.transform(rule_tree)
             res = ebnf_to_bnf.transform(tree)
             rules.append((name, res, options))

--- a/lark/reconstruct.py
+++ b/lark/reconstruct.py
@@ -148,7 +148,6 @@ class Reconstructor:
                     yield rule
                 else:
                     self.rules_for_root[sym.name].append(rule)
-            # yield rule  # Rule(sym, recons_exp, alias=MakeMatchTree(sym.name, r.expansion))
 
         for origin, rule_aliases in aliases.items():
             for alias in rule_aliases:

--- a/lark/reconstruct.py
+++ b/lark/reconstruct.py
@@ -1,3 +1,4 @@
+import unicodedata
 from collections import defaultdict
 
 from .tree import Tree
@@ -166,7 +167,12 @@ class Reconstructor:
         try:
             parser = self._parser_cache[tree.data]
         except KeyError:
-            rules = self.rules + self.rules_for_root[tree.data]
+            rules = self.rules + best_from_group(
+                self.rules_for_root[tree.data], lambda r: r, lambda r: -len(r.expansion)
+            )
+
+            rules.sort(key=lambda r: len(r.expansion))
+
             callbacks = {rule: rule.alias for rule in rules}  # TODO pass callbacks through dict, instead of alias?
             parser = earley.Parser(ParserConf(rules, callbacks, [tree.data]), self._match, resolve_ambiguity=True)
             self._parser_cache[tree.data] = parser

--- a/tests/test_reconstructor.py
+++ b/tests/test_reconstructor.py
@@ -84,7 +84,6 @@ class TestReconstructor(TestCase):
 
         self.assert_reconstruct(g, code)
 
-    @unittest.skip('Not working yet')
     def test_expand_rule(self):
         g = """
         ?start: (NL | mult_stmt)*

--- a/tests/test_reconstructor.py
+++ b/tests/test_reconstructor.py
@@ -69,6 +69,36 @@ class TestReconstructor(TestCase):
 
         self.assert_reconstruct(g, code)
 
+    def test_keep_tokens(self):
+        g = """
+        start: (NL | stmt)*
+        stmt: var op var
+        !op: ("+" | "-" | "*" | "/")
+        var: WORD
+        NL: /(\\r?\\n)+\s*/
+        """ + common
+
+        code = """
+        a+b
+        """
+
+        self.assert_reconstruct(g, code)
+
+    @unittest.skip('Not working yet')
+    def test_expand_rule(self):
+        g = """
+        ?start: (NL | mult_stmt)*
+        ?mult_stmt: sum_stmt ["*" sum_stmt]
+        ?sum_stmt: var ["+" var]
+        var: WORD
+        NL: /(\\r?\\n)+\s*/
+        """ + common
+
+        code = ['a', 'a*b', 'a+b', 'a*b+c', 'a+b*c', 'a+b*c+d']
+
+        for c in code:
+            self.assert_reconstruct(g, c)
+
     def test_json_example(self):
         test_json = '''
             {


### PR DESCRIPTION
This pull request ports over some commits made on the `recons_work2` branch some time ago, which has since fallen behind `master`. This part fixes problems with tokens that should be kept in the parse tree for reconstruction.