### PR TITLE
Lark now loads faster

### DIFF
--- a/examples/python_parser.py
+++ b/examples/python_parser.py
@@ -26,6 +26,13 @@ python_parser2 = Lark.open('python2.lark', parser='lalr', **kwargs)
 python_parser3 = Lark.open('python3.lark',parser='lalr', **kwargs)
 python_parser2_earley = Lark.open('python2.lark', parser='earley', lexer='standard', **kwargs)
 
+try:
+    xrange
+except NameError:
+    chosen_parser = python_parser3
+else:
+    chosen_parser = python_parser2
+
 
 def _read(fn, *args):
     kwargs = {'encoding': 'iso-8859-1'}
@@ -42,24 +49,13 @@ def _get_lib_path():
         return [x for x in sys.path if x.endswith('%s.%s' % sys.version_info[:2])][0]
 
 def test_python_lib():
-
     path = _get_lib_path()
 
     start = time.time()
     files = glob.glob(path+'/*.py')
     for f in files:
         print( f )
-        try:
-            # print list(python_parser.lex(_read(os.path.join(path, f)) + '\n'))
-            try:
-                xrange
-            except NameError:
-                python_parser3.parse(_read(os.path.join(path, f)) + '\n')
-            else:
-                python_parser2.parse(_read(os.path.join(path, f)) + '\n')
-        except:
-            print ('At %s' % f)
-            raise
+        chosen_parser.parse(_read(os.path.join(path, f)) + '\n')
 
     end = time.time()
     print( "test_python_lib (%d files), time: %s secs"%(len(files), end-start) )

--- a/lark/common.py
+++ b/lark/common.py
@@ -7,12 +7,14 @@ class LexerConf(Serialize):
     __serialize_fields__ = 'tokens', 'ignore', 'g_regex_flags'
     __serialize_namespace__ = TerminalDef,
 
-    def __init__(self, tokens, ignore=(), postlex=None, callbacks=None, g_regex_flags=0):
-        self.tokens = tokens
+    def __init__(self, tokens, re_module, ignore=(), postlex=None, callbacks=None, g_regex_flags=0, skip_validation=False):
+        self.tokens = tokens    # TODO should be terminals
         self.ignore = ignore
         self.postlex = postlex
         self.callbacks = callbacks or {}
         self.g_regex_flags = g_regex_flags
+        self.re_module = re_module
+        self.skip_validation = skip_validation
 
     def _deserialize(self):
         self.callbacks = {} # TODO

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -6,7 +6,7 @@ import unittest
 import logging
 import os
 import sys
-from copy import deepcopy
+from copy import copy, deepcopy
 try:
     from cStringIO import StringIO as cStringIO
 except ImportError:
@@ -553,8 +553,8 @@ class CustomLexer(Lexer):
     Purpose of this custom lexer is to test the integration,
     so it uses the traditionalparser as implementation without custom lexing behaviour.
     """
-    def __init__(self, lexer_conf, re_):
-        self.lexer = TraditionalLexer(lexer_conf.tokens, re_, ignore=lexer_conf.ignore, user_callbacks=lexer_conf.callbacks, g_regex_flags=lexer_conf.g_regex_flags)
+    def __init__(self, lexer_conf):
+        self.lexer = TraditionalLexer(copy(lexer_conf))
     def lex(self, *args, **kwargs):
         return self.lexer.lex(*args, **kwargs)
 


### PR DESCRIPTION
- Refactored lexer interface into LexerConf
- Lexer now compiles regexps only when used (especially useful for ContextualLexer)
- Lexer now doesn't validate on deserialize (noticable speedup)