### PR TITLE
Allows building TraditionalLexer with current configuration convention

### DIFF
--- a/lark/lark.py
+++ b/lark/lark.py
@@ -294,7 +294,7 @@ class Lark(Serialize):
     __serialize_fields__ = 'parser', 'rules', 'options'
 
     def _build_lexer(self):
-        return TraditionalLexer(self.lexer_conf.tokens, ignore=self.lexer_conf.ignore, user_callbacks=self.lexer_conf.callbacks, g_regex_flags=self.lexer_conf.g_regex_flags)
+        return TraditionalLexer(self.lexer_conf)
 
     def _prepare_callbacks(self):
         self.parser_class = get_frontend(self.options.parser, self.options.lexer)


### PR DESCRIPTION
This test case will currently cause an exception:

```
from lark import Lark

l = Lark('''start: WORD "," WORD "!"

            %import common.WORD   // imports from terminal library
            %ignore " "           // Disregard spaces in text
         ''', lexer="standard")

lexed = l.lex("Hello, World!")
```

Along the lines of:
```
  File "/usr/local/lib/python3.8/site-packages/lark_parser-0.9.0-py3.8.egg/lark/lark.py", line 297, in _build_lexer
    return TraditionalLexer(self.lexer_conf.tokens, ignore=self.lexer_conf.ignore, user_callbacks=self.lexer_conf.callbacks, g_regex_flags=self.lexer_conf.g_regex_flags)
TypeError: __init__() got an unexpected keyword argument 'ignore'
```

The proposed change fixes this error and correctly passes the lexer_conf object to the lexer (as far I can see).
