### PR TITLE
Scoped ignore

### DIFF
--- a/lark/grammar.py
+++ b/lark/grammar.py
@@ -49,21 +49,23 @@ class NonTerminal(Symbol):
 
 
 class RuleOptions(Serialize):
-    __serialize_fields__ = 'keep_all_tokens', 'expand1', 'priority', 'template_source', 'empty_indices'
+    __serialize_fields__ = 'keep_all_tokens', 'expand1', 'priority', 'template_source', 'empty_indices', 'ignore'
 
-    def __init__(self, keep_all_tokens=False, expand1=False, priority=None, template_source=None, empty_indices=()):
+    def __init__(self, keep_all_tokens=False, expand1=False, priority=None, template_source=None, empty_indices=(), ignore=()):
         self.keep_all_tokens = keep_all_tokens
         self.expand1 = expand1
         self.priority = priority
         self.template_source = template_source
         self.empty_indices = empty_indices
+        self.ignore = ignore
 
     def __repr__(self):
-        return 'RuleOptions(%r, %r, %r, %r)' % (
+        return 'RuleOptions(%r, %r, %r, %r, %r)' % (
             self.keep_all_tokens,
             self.expand1,
             self.priority,
-            self.template_source
+            self.template_source,
+            self.ignore
         )
 
 

--- a/lark/load_grammar.py
+++ b/lark/load_grammar.py
@@ -778,7 +778,7 @@ class GrammarLoader:
     def __init__(self, re_module):
         terminals = [TerminalDef(name, PatternRE(value)) for name, value in TERMINALS.items()]
 
-        rules = [options_from_rule(name, None, (), x) for name, x in  RULES.items()]
+        rules = [options_from_rule(name, None, ['WS', 'COMMENT'], x) for name, x in  RULES.items()]
         rules = [Rule(NonTerminal(r), symbols_from_strcase(x.split()), i, None, o) for r, _p, xs, o in rules for i, x in enumerate(xs)]
         callback = ParseTreeBuilder(rules, ST).create_callback()
         lexer_conf = LexerConf(terminals, re_module, ['WS', 'COMMENT'])

--- a/lark/load_grammar.py
+++ b/lark/load_grammar.py
@@ -915,53 +915,55 @@ class GrammarLoader:
 
         # Execute statements
         ignore, imports = [], {}
-        for (stmt,) in statements:
-            if stmt.data == 'ignore':
-                t ,= stmt.children
-                ignore.append(t)
-            elif stmt.data == 'import':
-                if len(stmt.children) > 1:
-                    path_node, arg1 = stmt.children
-                else:
-                    path_node, = stmt.children
-                    arg1 = None
+        statements = classify(statements, lambda c: c[0].data, lambda c: c[0])
 
-                if isinstance(arg1, Tree):  # Multi import
-                    dotted_path = tuple(path_node.children)
-                    names = arg1.children
-                    aliases = dict(zip(names, names))  # Can't have aliased multi import, so all aliases will be the same as names
-                else:  # Single import
-                    dotted_path = tuple(path_node.children[:-1])
-                    name = path_node.children[-1]  # Get name from dotted path
-                    aliases = {name: arg1 or name}  # Aliases if exist
+        for stmt in statements.pop('ignore', []):
+            t ,= stmt.children
+            ignore.append(t)
 
-                if path_node.data == 'import_lib':  # Import from library
-                    base_paths = []
-                else:  # Relative import
-                    if grammar_name == '<string>':  # Import relative to script file path if grammar is coded in script
-                        try:
-                            base_file = os.path.abspath(sys.modules['__main__'].__file__)
-                        except AttributeError:
-                            base_file = None
-                    else:
-                        base_file = grammar_name  # Import relative to grammar file path if external grammar file
-                    if base_file:
-                        base_paths = [os.path.split(base_file)[0]]
-                    else:
-                        base_paths = [os.path.abspath(os.path.curdir)]
-
-                try:
-                    import_base_paths, import_aliases = imports[dotted_path]
-                    assert base_paths == import_base_paths, 'Inconsistent base_paths for %s.' % '.'.join(dotted_path)
-                    import_aliases.update(aliases)
-                except KeyError:
-                    imports[dotted_path] = base_paths, aliases
-
-            elif stmt.data == 'declare':
-                for t in stmt.children:
-                    term_defs.append([t.value, (None, None)])
+        for stmt in statements.pop('import', []):
+            if len(stmt.children) > 1:
+                path_node, arg1 = stmt.children
             else:
-                assert False, stmt
+                path_node, = stmt.children
+                arg1 = None
+
+            if isinstance(arg1, Tree):  # Multi import
+                dotted_path = tuple(path_node.children)
+                names = arg1.children
+                aliases = dict(zip(names, names))  # Can't have aliased multi import, so all aliases will be the same as names
+            else:  # Single import
+                dotted_path = tuple(path_node.children[:-1])
+                name = path_node.children[-1]  # Get name from dotted path
+                aliases = {name: arg1 or name}  # Aliases if exist
+
+            if path_node.data == 'import_lib':  # Import from library
+                base_paths = []
+            else:  # Relative import
+                if grammar_name == '<string>':  # Import relative to script file path if grammar is coded in script
+                    try:
+                        base_file = os.path.abspath(sys.modules['__main__'].__file__)
+                    except AttributeError:
+                        base_file = None
+                else:
+                    base_file = grammar_name  # Import relative to grammar file path if external grammar file
+                if base_file:
+                    base_paths = [os.path.split(base_file)[0]]
+                else:
+                    base_paths = [os.path.abspath(os.path.curdir)]
+
+            try:
+                import_base_paths, import_aliases = imports[dotted_path]
+                assert base_paths == import_base_paths, 'Inconsistent base_paths for %s.' % '.'.join(dotted_path)
+                import_aliases.update(aliases)
+            except KeyError:
+                imports[dotted_path] = base_paths, aliases
+
+        for stmt in statements.pop('declare', []):
+            for t in stmt.children:
+                term_defs.append([t.value, (None, None)])
+
+        assert not statements
 
         return rule_defs, term_defs, imports, ignore
 

--- a/lark/load_grammar.py
+++ b/lark/load_grammar.py
@@ -219,7 +219,7 @@ class EBNF_to_BNF(Transformer_InPlace):
         assert False, op
 
     def maybe(self, rule):
-        keep_all_tokens = self.rule_options and self.rule_options.keep_all_tokens
+        keep_all_tokens = self.rule_options.keep_all_tokens
 
         def will_not_get_removed(sym):
             if isinstance(sym, NonTerminal):
@@ -561,7 +561,9 @@ class Grammar:
             i += 1
             if len(params) != 0: # Dont transform templates
                 continue
-            ebnf_to_bnf.rule_options = RuleOptions(keep_all_tokens=True) if options.keep_all_tokens else None
+            ebnf_to_bnf.rule_options = RuleOptions()
+            ebnf_to_bnf.rule_options.keep_all_tokens = options.keep_all_tokens
+            ebnf_to_bnf.rule_options.ignore = options.ignore
             ebnf_to_bnf.prefix = name
             tree = transformer.transform(rule_tree)
             res = ebnf_to_bnf.transform(tree)

--- a/lark/load_grammar.py
+++ b/lark/load_grammar.py
@@ -91,8 +91,10 @@ TERMINALS = {
     'COMMENT': r'\s*//[^\n]*',
     '_TO': '->',
     '_IGNORE': r'%ignore',
+    '_UNIGNORE': r'%unignore',
     '_DECLARE': r'%declare',
     '_IMPORT': r'%import',
+    '_SCOPED': r'%scoped',
     'NUMBER': r'[+-]?\d+',
 }
 
@@ -146,12 +148,15 @@ RULES = {
 
     'term': ['TERMINAL _COLON expansions _NL',
              'TERMINAL _DOT NUMBER _COLON expansions _NL'],
-    'statement': ['ignore', 'import', 'declare'],
+    'statement': ['ignore', 'unignore', 'import', 'declare', 'scoped'],
     'ignore': ['_IGNORE expansions _NL'],
+    'unignore': ['_UNIGNORE expansions _NL'],
     'declare': ['_DECLARE _declare_args _NL'],
     'import': ['_IMPORT _import_path _NL',
                '_IMPORT _import_path _LPAR name_list _RPAR _NL',
                '_IMPORT _import_path _TO name _NL'],
+    'scoped': ['_SCOPED _LBRACE _list _RBRACE _NL',
+               '_SCOPED _NL _LBRACE _list _RBRACE _NL'],
 
     '_import_path': ['import_lib', 'import_rel'],
     'import_lib': ['_import_args'],

--- a/tests/test_scoped_ignore.py
+++ b/tests/test_scoped_ignore.py
@@ -1,0 +1,65 @@
+import json
+import unittest
+from lark import Lark
+from lark.exceptions import GrammarError, ParseError, UnexpectedToken, UnexpectedInput, UnexpectedCharacters
+
+class TestScopedIgnore(unittest.TestCase):
+    def test_parse1(self):
+        # Just a simple example of the grammar, to see that it parses
+        Lark("""
+            B: /b/
+            %ignore /aaa/
+            %scoped {
+                %ignore B
+                %unignore /aaa/
+                start: "a" B "a"
+            }
+        """)
+
+    def test_parse2(self):
+        # Just a simple example of the grammar, to see that it parses
+        Lark("""
+            B: /b/
+            %ignore B
+            %scoped {
+                %unignore B
+                start: "a" "a"
+            }
+        """)
+
+    def test_parse_fail_remove(self):
+        # Can't unignore something that isn't in the ignore set
+        g = """
+            %unignore /c/
+            start: "a"
+        """
+        self.assertRaises(GrammarError, Lark, g)
+
+    def test_parse_unignore(self):
+        # Unignoring works
+        Lark("""
+            B: /b/
+            %ignore B
+            rule1: "a" "a"
+            %scoped {
+                %unignore B
+                start: rule1 "c" rule1
+            }
+        """)
+        # Should match abbbbacaba, aacaa, but not aabcaa
+
+    def test_parse_fail_remove_alias(self):
+        # Aliases don't count as the same
+        g = """
+            B: /b/
+            %ignore /b/
+            %scoped
+            {
+                %unignore B
+                start: "foo"
+            }
+        """
+        self.assertRaises(GrammarError, Lark, g)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Allows different `%ignore` rules across different parts of the grammar, as per #629.