### PR TITLE
For Nearley: add argparse, extras install, allow es6 compiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,11 @@ Using Lark? Send me a message and I'll add your project!
 
 Lark comes with a tool to convert grammars from [Nearley](https://github.com/Hardmath123/nearley), a popular Earley library for Javascript. It uses [Js2Py](https://github.com/PiotrDabkowski/Js2Py) to convert and run the Javascript postprocessing code segments.
 
+First, ensure you have Lark installed with the `nearley` component included:
+```bash
+pip install lark-parser[nearley]
+```
+
 Here's an example:
 ```bash
 git clone https://github.com/Hardmath123/nearley
@@ -177,6 +182,12 @@ You can use the output as a regular python module:
 0.38981434460254655
 ```
 
+The Nearley converter also supports an experimental converter for newer JavaScript (ES6+), using the `--es6` flag:
+
+```bash
+git clone https://github.com/Hardmath123/nearley
+python -m lark.tools.nearley nearley/examples/calculator/arithmetic.ne main nearley --es6 > ncalc.py
+```
 
 ## License
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ setup(
     install_requires = [],
 
     extras_require = {
-        "regex": ["regex"]
+        "regex": ["regex"],
+        "nearley": ["js2py"]
     },
 
     package_data = {'': ['*.md', '*.lark'], 'lark-stubs': ['*.pyi']},


### PR DESCRIPTION
Some improvements to the Nearley converter:

* Use argparse instead of manually parsing `argv`. This gives us a `--help` output, and better error detection for free
* Include `js2py` as an "extras" dependency (installed using `pip install lark-parser[nearley]`)
* Add a `--es6` flag to this command, which enables the experimental ES6 support Js2Py
* The changes to the interface are documented in the readme

Todo:
* [ ] Add an explanation of `nearley_lib` in argparse. I don't actually know what this parameter does, so I can't document it without help