### PR TITLE
Error handling

### DIFF
--- a/lark-stubs/exceptions.pyi
+++ b/lark-stubs/exceptions.pyi
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from typing import Dict, Iterable, Callable, Union, TypeVar, Tuple
+from typing import Dict, Iterable, Callable, Union, TypeVar, Tuple, Any, List, Set
 from .tree import Tree
 from .lexer import Token
 
@@ -25,7 +25,10 @@ T = TypeVar('T')
 
 
 class UnexpectedInput(LarkError):
+    line: int
+    column: int
     pos_in_stream: int
+    state: Any
 
     def get_context(self, text: str, span: int = ...):
         ...
@@ -41,12 +44,14 @@ class UnexpectedInput(LarkError):
 
 
 class UnexpectedToken(ParseError, UnexpectedInput):
-    pass
-
+    expected: List[str]
+    considered_rules: Set[str]
+    puppet: Any
+    accepts: List[str]
 
 class UnexpectedCharacters(LexError, UnexpectedInput):
-    line: int
-    column: int
+    allowed: Set[str]
+    considered_tokens: Set[Any]
 
 
 class VisitError(LarkError):

--- a/lark-stubs/exceptions.pyi
+++ b/lark-stubs/exceptions.pyi
@@ -3,7 +3,7 @@
 from typing import Dict, Iterable, Callable, Union, TypeVar, Tuple, Any, List, Set
 from .tree import Tree
 from .lexer import Token
-
+from .parsers.lalr_puppet import ParserPuppet
 
 class LarkError(Exception):
     pass
@@ -38,16 +38,16 @@ class UnexpectedInput(LarkError):
             parse_fn: Callable[[str], Tree],
             examples: Union[Dict[T, Iterable[str]], Iterable[Tuple[T, Iterable[str]]]],
             token_type_match_fallback: bool = False,
-            print_debug_info: bool = True
+            use_accepts: bool = False,
     ) -> T:
         ...
 
 
 class UnexpectedToken(ParseError, UnexpectedInput):
-    expected: List[str]
+    expected: Set[str]
     considered_rules: Set[str]
-    puppet: Any
-    accepts: List[str]
+    puppet: ParserPuppet
+    accepts: Set[str]
 
 class UnexpectedCharacters(LexError, UnexpectedInput):
     allowed: Set[str]

--- a/lark-stubs/exceptions.pyi
+++ b/lark-stubs/exceptions.pyi
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from typing import Dict, Iterable, Callable, Union
+from typing import Dict, Iterable, Callable, Union, TypeVar, Tuple
 from .tree import Tree
 from .lexer import Token
 
@@ -21,6 +21,9 @@ class LexError(LarkError):
     pass
 
 
+T = TypeVar('T')
+
+
 class UnexpectedInput(LarkError):
     pos_in_stream: int
 
@@ -28,10 +31,12 @@ class UnexpectedInput(LarkError):
         ...
 
     def match_examples(
-        self,
-        parse_fn: Callable[[str], Tree],
-        examples: Dict[str, Iterable[str]]
-    ):
+            self,
+            parse_fn: Callable[[str], Tree],
+            examples: Union[Dict[T, Iterable[str]], Iterable[Tuple[T, Iterable[str]]]],
+            token_type_match_fallback: bool = False,
+            print_debug_info: bool = True
+    ) -> T:
         ...
 
 

--- a/lark-stubs/parsers/lalr_puppet.pyi
+++ b/lark-stubs/parsers/lalr_puppet.pyi
@@ -1,0 +1,21 @@
+from typing import Set, Dict, Any
+
+from lark import Token, Tree
+
+
+class ParserPuppet(object):
+    """
+    Represents a LalrParser that can be step through.
+    Shouldn't instantiated by hand, but is accessible as `UnexpectedToken.puppet`
+    """
+    def feed_token(self, token: Token): ...
+
+    def copy(self) -> ParserPuppet: ...
+
+    def pretty(self) -> str: ...
+
+    def choices(self) -> Dict[str, Any]: ...
+
+    def accepts(self) -> Set[str]: ...
+
+    def resume_parse(self) -> Tree: ...

--- a/lark/exceptions.py
+++ b/lark/exceptions.py
@@ -55,7 +55,7 @@ class UnexpectedInput(LarkError):
                 try:
                     parse_fn(malformed)
                 except UnexpectedInput as ut:
-                    if ut.state == self.state:
+                    if ut.state == self.state and ut.accepts == self.accepts:
                         try:
                             if ut.token == self.token:  # Try exact match first
                                 if print_debug_info:

--- a/lark/exceptions.py
+++ b/lark/exceptions.py
@@ -105,7 +105,7 @@ class UnexpectedCharacters(LexError, UnexpectedInput):
 
 
 class UnexpectedToken(ParseError, UnexpectedInput):
-    def __init__(self, token, expected, considered_rules=None, state=None, puppet=None):
+    def __init__(self, token, expected, considered_rules=None, state=None, puppet=None, accepts=None):
         self.token = token
         self.expected = expected     # XXX str shouldn't necessary
         self.line = getattr(token, 'line', '?')
@@ -114,10 +114,11 @@ class UnexpectedToken(ParseError, UnexpectedInput):
         self.state = state
         self.pos_in_stream = getattr(token, 'pos_in_stream', None)
         self.puppet = puppet
+        self.accepts = accepts
 
         message = ("Unexpected token %r at line %s, column %s.\n"
                    "Expected one of: \n\t* %s\n"
-                   % (token, self.line, self.column, '\n\t* '.join(self.expected)))
+                   % (token, self.line, self.column, '\n\t* '.join(self.accepts or self.expected)))
 
         super(UnexpectedToken, self).__init__(message)
 

--- a/lark/parsers/lalr_parser.py
+++ b/lark/parsers/lalr_parser.py
@@ -62,9 +62,18 @@ class _Parser:
                 expected = [s for s in states[state].keys() if s.isupper()]
                 try:
                     puppet = ParserPuppet(self, state_stack, value_stack, start, stream, set_state)
+                    accepts = []
+                    for t in expected:
+                        new_puppet = puppet.copy()
+                        try:
+                            new_puppet.feed_token(Token(t, ''))
+                        except KeyError:
+                            pass
+                        else:
+                            accepts.append(t)
                 except NameError:
-                    puppet = None
-                raise UnexpectedToken(token, expected, state=state, puppet=puppet)
+                    puppet = accepts = None
+                raise UnexpectedToken(token, expected, state=state, puppet=puppet, accepts=accepts)
 
         def reduce(rule):
             size = len(rule.expansion)

--- a/lark/parsers/lalr_parser.py
+++ b/lark/parsers/lalr_parser.py
@@ -59,18 +59,10 @@ class _Parser:
             try:
                 return states[state][token.type]
             except KeyError:
-                expected = [s for s in states[state].keys() if s.isupper()]
+                expected = {s for s in states[state].keys() if s.isupper()}
                 try:
                     puppet = ParserPuppet(self, state_stack, value_stack, start, stream, set_state)
-                    accepts = []
-                    for t in expected:
-                        new_puppet = puppet.copy()
-                        try:
-                            new_puppet.feed_token(Token(t, ''))
-                        except KeyError:
-                            pass
-                        else:
-                            accepts.append(t)
+                    accepts = puppet.accepts()
                 except NameError:
                     puppet = accepts = None
                 raise UnexpectedToken(token, expected, state=state, puppet=puppet, accepts=accepts)

--- a/lark/parsers/lalr_puppet.py
+++ b/lark/parsers/lalr_puppet.py
@@ -16,7 +16,7 @@ class ParserPuppet:
         self.result = None
 
     def feed_token(self, token):
-        """Advance the parser state, as if it just recieved `token` from the lexer
+        """Advance the parser state, as if it just received `token` from the lexer
 
         """
         end_state = self.parser.parse_table.end_states[self._start]
@@ -66,9 +66,9 @@ class ParserPuppet:
             self._set_state,
         )
 
-    def pretty():
+    def pretty(self):
         print("Puppet choices:")
-        for k, v in self.choices.items():
+        for k, v in self.choices().items():
             print('\t-', k, '->', v)
         print('stack size:', len(self._state_stack))
 

--- a/lark/parsers/lalr_puppet.py
+++ b/lark/parsers/lalr_puppet.py
@@ -4,7 +4,7 @@ from copy import deepcopy
 
 from .lalr_analysis import Shift, Reduce
 
-class ParserPuppet:
+class ParserPuppet(object):
     def __init__(self, parser, state_stack, value_stack, start, stream, set_state):
         self.parser = parser
         self._state_stack = state_stack


### PR DESCRIPTION
Closes #646 and closes #644. 

Has two big changes:

- Allows both dictionaries and any iterable of tuple as example for `match_example`
- Adds an `accepts` list to `UnexpectedToken` and uses it in `match_example` to restrict the context more precisely. (Might be a 'breaking' change if we consider the behavior clearly defined.)