### PR TITLE
Prevent invalid tree with ambiguity="explicit"

### DIFF
--- a/lark/parsers/earley.py
+++ b/lark/parsers/earley.py
@@ -314,7 +314,7 @@ class Parser:
 
         # Perform our SPPF -> AST conversion using the right ForestVisitor.
         forest_tree_visitor_cls = ForestToTreeVisitor if self.resolve_ambiguity else ForestToAmbiguousTreeVisitor
-        forest_tree_visitor = forest_tree_visitor_cls(self.callbacks, self.forest_sum_visitor and self.forest_sum_visitor())
+        forest_tree_visitor = forest_tree_visitor_cls(self.callbacks, self.forest_sum_visitor and self.forest_sum_visitor(), self.debug)
 
         return forest_tree_visitor.visit(solutions[0])
 

--- a/lark/parsers/earley_forest.py
+++ b/lark/parsers/earley_forest.py
@@ -7,6 +7,7 @@ Full reference and more details is here:
 http://www.bramvandersanden.com/post/2014/06/shared-packed-parse-forest/
 """
 
+import logging
 from random import randint
 from math import isinf
 from collections import deque
@@ -330,7 +331,10 @@ class ForestToAmbiguousTreeVisitor(ForestToTreeVisitor):
     def visit_symbol_node_in(self, node):
         if self.forest_sum_visitor and node.is_ambiguous and isinf(node.priority):
             self.forest_sum_visitor.visit(node)
-        if not node.is_intermediate and node.is_ambiguous:
+        if node.is_ambiguous:
+            if node.is_intermediate:
+                logging.warning("Ambiguous intermediate node in the SPPF: %s. Lark does not currently process these ambiguities: (resolving with the first derivation)", node)
+                return next(iter(node.children))
             self.output_stack.append(Tree('_ambig', []))
         return iter(node.children)
 


### PR DESCRIPTION
This mitigates #455 by making sure that Lark.parse() with ambiguity="explicit" returns a valid tree even if it cannot process all ambiguities in the SPPF. A warning of this occurrence has been added when debug=True.

Example:

```python
from lark import Lark

grammar = """
start: ab bc d?
!ab: "A" "B"?
!bc: "B"? "C"
!d: "D"
"""

p = Lark(grammar, ambiguity="explicit", debug=True)

tree = p.parse("ABCD")
print(tree.pretty())
```

One possible current output (invalid tree):
```
start
  ab
    A
    B
  bc    C
  ab    A
  bc
    B
    C
  d     D
```

One possible new output (valid tree):
```
WARNING:root:Ambiguous intermediate node in the SPPF: (start ::= ab bc* d, 0, 3, 2). Lark does not currently process these ambiguities: (resolving with the first derivation)
start
  ab    A
  bc
    B
    C
  d     D
```