### PR TITLE
ContextualLexer/UnexpectedInput puppet

### DIFF
--- a/lark-stubs/exceptions.pyi
+++ b/lark-stubs/exceptions.pyi
@@ -29,6 +29,7 @@ class UnexpectedInput(LarkError):
     column: int
     pos_in_stream: int
     state: Any
+    puppet: ParserPuppet
 
     def get_context(self, text: str, span: int = ...):
         ...
@@ -46,7 +47,6 @@ class UnexpectedInput(LarkError):
 class UnexpectedToken(ParseError, UnexpectedInput):
     expected: Set[str]
     considered_rules: Set[str]
-    puppet: ParserPuppet
     accepts: Set[str]
 
 class UnexpectedCharacters(LexError, UnexpectedInput):

--- a/lark-stubs/lark.pyi
+++ b/lark-stubs/lark.pyi
@@ -4,6 +4,8 @@ from typing import (
     TypeVar, Type, List, Dict, IO, Iterator, Callable, Union, Optional,
     Literal, Protocol,
 )
+
+from .exceptions import UnexpectedToken
 from .visitors import Transformer
 from .lexer import Token, Lexer, TerminalDef
 from .tree import Tree
@@ -63,7 +65,7 @@ class Lark:
     ):
         ...
 
-    def parse(self, text: str, start: Optional[str] = None) -> Tree:
+    def parse(self, text: str, start: Optional[str] = None, on_error: Callable[[UnexpectedToken], bool] = None) -> Tree:
         ...
 
     @classmethod

--- a/lark/exceptions.py
+++ b/lark/exceptions.py
@@ -25,6 +25,7 @@ class UnexpectedEOF(ParseError):
 
 class UnexpectedInput(LarkError):
     pos_in_stream = None
+    puppet = None
 
     def get_context(self, text, span=40):
         pos = self.pos_in_stream
@@ -85,7 +86,7 @@ class UnexpectedInput(LarkError):
 
 
 class UnexpectedCharacters(LexError, UnexpectedInput):
-    def __init__(self, seq, lex_pos, line, column, allowed=None, considered_tokens=None, state=None, token_history=None):
+    def __init__(self, seq, lex_pos, line, column, allowed=None, considered_tokens=None, state=None, token_history=None, puppet=None):
         self.line = line
         self.column = column
         self.pos_in_stream = lex_pos

--- a/lark/lark.py
+++ b/lark/lark.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import sys, os, pickle, hashlib, logging
 from io import open
 
-
+from .exceptions import UnexpectedInput
 from .utils import STRING_TYPE, Serialize, SerializeMemoizer, FS, isascii
 from .load_grammar import load_grammar
 from .tree import Tree
@@ -403,7 +403,7 @@ class Lark(Serialize):
         """
         try:
             return self.parser.parse(text, start=start)
-        except UnexpectedToken as e:
+        except UnexpectedInput as e:
             if on_error is None:
                 raise
 
@@ -412,7 +412,7 @@ class Lark(Serialize):
                     raise e
                 try:
                     return e.puppet.resume_parse()
-                except UnexpectedToken as e2:
+                except UnexpectedInput as e2:
                     e = e2
 
 

--- a/lark/parsers/lalr_parser.py
+++ b/lark/parsers/lalr_parser.py
@@ -2,7 +2,7 @@
 """
 # Author: Erez Shinan (2017)
 # Email : erezshin@gmail.com
-from ..exceptions import UnexpectedToken
+from ..exceptions import UnexpectedToken, UnexpectedInput
 from ..lexer import Token
 from ..utils import Enumerator, Serialize
 
@@ -104,10 +104,12 @@ class _Parser:
                 for i, s in enumerate(state_stack):
                     print('%d)' % i , s)
                 print("")
-            if isinstance(e, UnexpectedToken):
-                assert e.puppet is None
-                e.state = state_stack[-1]
-                e.puppet = ParserPuppet(self, state_stack, value_stack, start, stream, set_state)
+            if isinstance(e, UnexpectedInput):
+                if e.puppet is None:
+                    try:
+                        e.puppet = ParserPuppet(self, state_stack, value_stack, start, stream, set_state)
+                    except NameError:
+                        pass
             raise
 
         token = Token.new_borrow_pos('$END', '', token) if token else Token('$END', '', 0, 1, 1)

--- a/lark/parsers/lalr_parser.py
+++ b/lark/parsers/lalr_parser.py
@@ -104,7 +104,10 @@ class _Parser:
                 for i, s in enumerate(state_stack):
                     print('%d)' % i , s)
                 print("")
-
+            if isinstance(e, UnexpectedToken):
+                assert e.puppet is None
+                e.state = state_stack[-1]
+                e.puppet = ParserPuppet(self, state_stack, value_stack, start, stream, set_state)
             raise
 
         token = Token.new_borrow_pos('$END', '', token) if token else Token('$END', '', 0, 1, 1)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -25,6 +25,7 @@ class TestStandalone(TestCase):
         standalone.main(StringIO(grammar), 'start')
         sys.stdout = temp
         code = code_buf.getvalue()
+        open("debug_output.py", "w").write(code)
 
         context = {}
         exec(code, context)


### PR DESCRIPTION
This is the start of a solution for the bug report that came up in the gitter.im chat. Note that this does really solve it! It is still impossible (I think) to actually skip over UnexpecedCharacters (or the Tokens the ContextualLexer creates from them).

Also, the tests fail with a for me not understandable error message.