### PR TITLE
Documentation and examples for earley_forest

### DIFF
--- a/docs/classes.rst
+++ b/docs/classes.rst
@@ -51,6 +51,11 @@ Transformer, Visitor & Interpreter
 
 See :doc:`visitors`.
 
+ForestVisitor, ForestTransformer, & TreeForestTransformer
+-----------------------------------------------------------
+
+See :doc:`forest`.
+
 UnexpectedInput
 ---------------
 

--- a/docs/forest.rst
+++ b/docs/forest.rst
@@ -1,0 +1,65 @@
+Working with the SPPF
+=====================
+
+When parsing with Earley, Lark provides the ``ambiguity='forest'`` option
+to obtain the shared packed parse forest (SPPF) produced by the parser as
+an alternative to it being automatically converted to a tree.
+
+Lark provides a few tools to facilitate working with the SPPF. Here are some
+things to consider when deciding whether or not to use the SPPF.
+
+**Pros**
+
+- Efficient storage of highly ambiguous parses
+- Precise handling of ambiguities
+- Custom rule prioritizers
+- Ability to handle infinite ambiguities
+- Directly transform forest -> object instead of forest -> tree -> object
+
+**Cons**
+
+- More complex than working with a tree
+- SPPF may contain nodes corresponding to rules generated internally
+- Loss of Lark grammar features:
+
+  - Rules starting with '_' are not inlined in the SPPF
+  - Rules starting with '?' are never inlined in the SPPF
+  - All tokens will appear in the SPPF
+
+SymbolNode
+----------
+
+.. autoclass:: lark.parsers.earley_forest.SymbolNode
+   :members: is_ambiguous, children
+
+PackedNode
+----------
+
+.. autoclass:: lark.parsers.earley_forest.PackedNode
+   :members: children
+
+ForestVisitor
+-------------
+
+.. autoclass:: lark.parsers.earley_forest.ForestVisitor
+   :members: visit, visit_symbol_node_in, visit_symbol_node_out,
+             visit_packed_node_in, visit_packed_node_out,
+             visit_token_node, on_cycle, get_cycle_in_path
+
+ForestTransformer
+-----------------
+
+.. autoclass:: lark.parsers.earley_forest.ForestTransformer
+   :members: transform, transform_symbol_node, transform_intermediate_node,
+             transform_packed_node, transform_token_node
+
+TreeForestTransformer
+---------------------
+
+.. autoclass:: lark.parsers.earley_forest.TreeForestTransformer
+   :members: __default__, __default_token__, __default_ambig__
+
+handles_ambiguity
+-----------------
+
+.. autodecorator:: lark.parsers.earley_forest.handles_ambiguity

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,6 +36,7 @@ Welcome to Lark's documentation!
    tree_construction
    classes
    visitors
+   forest
    nearley
 
 
@@ -96,6 +97,7 @@ Resources
    -  :doc:`grammar`
    -  :doc:`tree_construction`
    -  :doc:`visitors`
+   -  :doc:`forest`
    -  :doc:`classes`
    -  :doc:`nearley`
    -  `Cheatsheet (PDF)`_

--- a/docs/parsers.md
+++ b/docs/parsers.md
@@ -23,8 +23,7 @@ Lark provides the following options to combat ambiguity:
 
 2) Users may choose to receive the set of all possible parse-trees (using ambiguity='explicit'), and choose the best derivation themselves. While simple and flexible, it comes at the cost of space and performance, and so it isn't recommended for highly ambiguous grammars, or very long inputs.
 
-3) As an advanced feature, users may use specialized visitors to iterate the SPPF themselves. Future versions of Lark intend to improve and simplify this interface.
-
+3) As an advanced feature, users may use specialized visitors to iterate the SPPF themselves.
 
 **dynamic_complete**
 

--- a/examples/advanced/prioritizer.py
+++ b/examples/advanced/prioritizer.py
@@ -1,0 +1,72 @@
+"""
+Custom SPPF Prioritizer
+=======================
+
+This example demonstrates how to subclass ``ForestVisitor`` to make a custom
+SPPF node prioritizer to be used in conjunction with ``TreeForestTransformer``.
+
+Our prioritizer will count the number of descendants of a node that are tokens.
+By negating this count, our prioritizer will prefer nodes with fewer token
+descendants. Thus, we choose the more specific parse.
+"""
+
+from lark import Lark
+from lark.parsers.earley_forest import ForestVisitor, TreeForestTransformer
+
+class TokenPrioritizer(ForestVisitor):
+
+    def visit_symbol_node_in(self, node):
+        # visit the entire forest by returning node.children
+        return node.children
+
+    def visit_packed_node_in(self, node):
+        return node.children
+
+    def visit_symbol_node_out(self, node):
+        priority = 0
+        for child in node.children:
+            # Tokens do not have a priority attribute
+            # count them as -1
+            priority += getattr(child, 'priority', -1)
+        node.priority = priority
+
+    def visit_packed_node_out(self, node):
+        priority = 0
+        for child in node.children:
+            priority += getattr(child, 'priority', -1)
+        node.priority = priority
+
+    def on_cycle(self, node, path):
+        raise Exception("Oops, we encountered a cycle.")
+
+grammar = """
+start: hello " " world | hello_world
+hello: "Hello"
+world: "World"
+hello_world: "Hello World"
+"""
+
+parser = Lark(grammar, parser='earley', ambiguity='forest')
+forest = parser.parse("Hello World")
+
+print("Default prioritizer:")
+tree = TreeForestTransformer(resolve_ambiguity=True).transform(forest)
+print(tree.pretty())
+
+forest = parser.parse("Hello World")
+
+print("Custom prioritizer:")
+tree = TreeForestTransformer(resolve_ambiguity=True, prioritizer=TokenPrioritizer()).transform(forest)
+print(tree.pretty())
+
+# Output:
+#
+# Default prioritizer:
+# start
+#   hello Hello
+#
+#   world World
+#
+# Custom prioritizer:
+# start
+#   hello_world   Hello World

--- a/examples/advanced/tree_forest_transformer.py
+++ b/examples/advanced/tree_forest_transformer.py
@@ -1,0 +1,58 @@
+"""
+Transform a Forest
+==================
+
+This example demonstrates how to subclass ``TreeForestTransformer`` to
+directly transform a SPPF.
+"""
+
+from lark import Lark
+from lark.parsers.earley_forest import TreeForestTransformer, handles_ambiguity, Discard
+
+class CustomTransformer(TreeForestTransformer):
+
+    @handles_ambiguity
+    def sentence(self, trees):
+        return next(tree for tree in trees if tree.data == 'simple')
+
+    def simple(self, children):
+        children.append('.')
+        return self.tree_class('simple', children)
+
+    def adj(self, children):
+        raise Discard()
+
+    def __default_token__(self, token):
+        return token.capitalize()
+
+grammar = """
+    sentence: noun verb noun        -> simple
+            | noun verb "like" noun -> comparative
+
+    noun: adj? NOUN
+    verb: VERB
+    adj: ADJ
+
+    NOUN: "flies" | "bananas" | "fruit"
+    VERB: "like" | "flies"
+    ADJ: "fruit"
+
+    %import common.WS
+    %ignore WS
+"""
+
+parser = Lark(grammar, start='sentence', ambiguity='forest')
+sentence = 'fruit flies like bananas'
+forest = parser.parse(sentence)
+
+tree = CustomTransformer(resolve_ambiguity=False).transform(forest)
+print(tree.pretty())
+
+# Output:
+#
+# simple
+#   noun  Flies
+#   verb  Like
+#   noun  Bananas
+#   .
+#

--- a/lark/lark.py
+++ b/lark/lark.py
@@ -73,8 +73,8 @@ class LarkOptions(Serialize):
     ambiguity
             Decides how to handle ambiguity in the parse. Only relevant if parser="earley"
 
-            - "resolve" - The parser will automatically choose the simplest derivation
-                        (it chooses consistently: greedy for tokens, non-greedy for rules)
+            - "resolve": The parser will automatically choose the simplest derivation
+              (it chooses consistently: greedy for tokens, non-greedy for rules)
             - "explicit": The parser will return all derivations wrapped in "_ambig" tree nodes (i.e. a forest).
             - "forest": The parser will return the root of the shared packed parse forest.
 


### PR DESCRIPTION
Here is API reference for members of `earley_forest.py`.
Advanced examples have also been added to demonstrate the usage of `ForestVisitor` and `TreeForestTransformer`.