### PR TITLE
Fix missing handles_ambiguity docstring

### DIFF
--- a/docs/forest.rst
+++ b/docs/forest.rst
@@ -62,4 +62,4 @@ TreeForestTransformer
 handles_ambiguity
 -----------------
 
-.. autodecorator:: lark.parsers.earley_forest.handles_ambiguity
+.. autofunction:: lark.parsers.earley_forest.handles_ambiguity


### PR DESCRIPTION
It looks like Read the Docs is not building with the latest version of the autodoc extension.
I think this should fix it.