### PR TITLE
Resumable - working towards completely resumable parser+lexer (from puppet)

### DIFF
--- a/lark/lark.py
+++ b/lark/lark.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from lark.exceptions import UnexpectedCharacters, UnexpectedInput, UnexpectedToken
 
 import sys, os, pickle, hashlib
 from io import open
@@ -9,7 +10,7 @@ from .load_grammar import load_grammar
 from .tree import Tree
 from .common import LexerConf, ParserConf
 
-from .lexer import Lexer, TraditionalLexer, TerminalDef, UnexpectedToken
+from .lexer import Lexer, TraditionalLexer, TerminalDef
 from .parse_tree_builder import ParseTreeBuilder
 from .parser_frontends import get_frontend, _get_lexer_callbacks
 from .grammar import Rule
@@ -436,7 +437,7 @@ class Lark(Serialize):
 
         try:
             return self.parser.parse(text, start=start)
-        except UnexpectedToken as e:
+        except UnexpectedInput as e:
             if on_error is None:
                 raise
 
@@ -446,9 +447,11 @@ class Lark(Serialize):
                 try:
                     return e.puppet.resume_parse()
                 except UnexpectedToken as e2:
-                    if e.token.type == e2.token.type == '$END' and e.puppet == e2.puppet:
+                    if isinstance(e, UnexpectedToken) and e.token.type == e2.token.type == '$END' and e.puppet == e2.puppet:
                         # Prevent infinite loop
                         raise e2
+                    e = e2
+                except UnexpectedCharacters as e2:
                     e = e2
 
 

--- a/lark/lexer.py
+++ b/lark/lexer.py
@@ -271,7 +271,7 @@ class Lexer(object):
     lex = NotImplemented
 
     def make_lexer_state(self, text):
-        line_ctr = LineCounter('\n')
+        line_ctr = LineCounter(b'\n' if isinstance(text, bytes) else '\n')
         return LexerState(text, line_ctr)
 
 
@@ -346,7 +346,8 @@ class TraditionalLexer(Lexer):
                 allowed = {v for m, tfi in self.mres for v in tfi.values()} - self.ignore_types
                 if not allowed:
                     allowed = {"<END-OF-FILE>"}
-                raise UnexpectedCharacters(lex_state.text, line_ctr.char_pos, line_ctr.line, line_ctr.column, allowed=allowed, token_history=lex_state.last_token and [lex_state.last_token])
+                raise UnexpectedCharacters(lex_state.text, line_ctr.char_pos, line_ctr.line, line_ctr.column,
+                                           allowed=allowed, token_history=lex_state.last_token and [lex_state.last_token])
 
             value, type_ = res
 

--- a/lark/lexer.py
+++ b/lark/lexer.py
@@ -424,16 +424,10 @@ class ContextualLexer(Lexer):
         except EOFError:
             pass
         except UnexpectedCharacters as e:
-            # In the contextual lexer, UnexpectedCharacters can mean that the terminal is defined,
-            # but not in the current context.
+            # In the contextual lexer, UnexpectedCharacters can mean that the terminal is defined, but not in the current context.
             # This tests the input against the global context, to provide a nicer error.
-            root_match = self.root_lexer.match(lexer_state.text, e.pos_in_stream)
-            if not root_match:
-                raise
-
-            value, type_ = root_match
-            t = Token(type_, value, e.pos_in_stream, e.line, e.column)
-            raise UnexpectedToken(t, e.allowed, state=parser_state.position)
+            token = self.root_lexer.next_token(lexer_state)
+            raise UnexpectedToken(token, e.allowed, state=parser_state.position)
 
 class LexerThread:
     "A thread that ties a lexer instance and a lexer state, to be used by the parser"

--- a/lark/parser_frontends.py
+++ b/lark/parser_frontends.py
@@ -154,15 +154,6 @@ class LALR_CustomLexer(LALR_WithLexer):
         WithLexer.__init__(self, lexer_conf, parser_conf, options)
 
 
-def tokenize_text(text):
-    line = 1
-    col_start_pos = 0
-    for i, ch in enumerate(text):
-        if '\n' in ch:
-            line += ch.count('\n')
-            col_start_pos = i + ch.rindex('\n')
-        yield Token('CHAR', ch, line=line, column=i - col_start_pos)
-
 class Earley(WithLexer):
     def __init__(self, lexer_conf, parser_conf, options=None):
         WithLexer.__init__(self, lexer_conf, parser_conf, options)

--- a/lark/parsers/lalr_parser.py
+++ b/lark/parsers/lalr_parser.py
@@ -36,84 +36,96 @@ class LALR_Parser(object):
         return self.parser.parse(*args)
 
 
+class ParserState:
+    __slots__ = 'parse_table', 'lexer', 'callbacks', 'start', 'state_stack', 'value_stack', 'start_state', 'end_state', 'states'
+
+    def __init__(self, parse_table, lexer, callbacks, start, state_stack=None, value_stack=None):
+        self.parse_table = parse_table
+
+        self.start_state = self.parse_table.start_states[start]
+        self.end_state = self.parse_table.end_states[start]
+        self.states = self.parse_table.states
+
+        self.lexer = lexer
+        self.callbacks = callbacks
+        self.start = start
+        self.state_stack = state_stack or [self.start_state]
+        self.value_stack = value_stack or []
+
+    @property
+    def position(self):
+        return self.state_stack[-1]
+
+    def feed_token(self, token, is_end=False):
+        state_stack = self.state_stack
+        value_stack = self.value_stack
+        states = self.states
+
+        while True:
+            state = state_stack[-1]
+            try:
+                action, arg = states[state][token.type]
+            except KeyError:
+                expected = {s for s in states[state].keys() if s.isupper()}
+                raise UnexpectedToken(token, expected, state=state, puppet=None)
+
+            assert arg != self.end_state
+
+            if action is Shift:
+                # shift once and return
+                assert not is_end
+                state_stack.append(arg)
+                value_stack.append(token)
+                return arg
+            else:
+                # reduce+shift as many times as necessary
+                rule = arg
+                size = len(rule.expansion)
+                if size:
+                    s = value_stack[-size:]
+                    del state_stack[-size:]
+                    del value_stack[-size:]
+                else:
+                    s = []
+
+                value = self.callbacks[rule](s)
+
+                _action, new_state = states[state_stack[-1]][rule.origin.name]
+                assert _action is Shift
+                state_stack.append(new_state)
+                value_stack.append(value)
+
+                if is_end and state_stack[-1] == self.end_state:
+                    return value_stack[-1]
+
 class _Parser:
     def __init__(self, parse_table, callbacks, debug=False):
         self.parse_table = parse_table
         self.callbacks = callbacks
         self.debug = debug
 
-    def parse(self, seq, start, set_state=None, value_stack=None, state_stack=None):
-        token = None
-        stream = iter(seq)
-        states = self.parse_table.states
-        start_state = self.parse_table.start_states[start]
-        end_state = self.parse_table.end_states[start]
+    def parse(self, lexer, start, value_stack=None, state_stack=None):
+        parser_state = ParserState(self.parse_table, lexer, self.callbacks, start, state_stack, value_stack)
+        return self.parse_from_state(parser_state)
 
-        state_stack = state_stack or [start_state]
-        value_stack = value_stack or []
-
-        if set_state: set_state(start_state)
-
-        def get_action(token):
-            state = state_stack[-1]
-            try:
-                return states[state][token.type]
-            except KeyError:
-                expected = {s for s in states[state].keys() if s.isupper()}
-                try:
-                    puppet = ParserPuppet(self, state_stack, value_stack, start, stream, set_state)
-                except NameError:   # For standalone parser
-                    puppet = None
-                raise UnexpectedToken(token, expected, state=state, puppet=puppet)
-
-        def reduce(rule):
-            size = len(rule.expansion)
-            if size:
-                s = value_stack[-size:]
-                del state_stack[-size:]
-                del value_stack[-size:]
-            else:
-                s = []
-
-            value = self.callbacks[rule](s)
-
-            _action, new_state = states[state_stack[-1]][rule.origin.name]
-            assert _action is Shift
-            state_stack.append(new_state)
-            value_stack.append(value)
-
+    def parse_from_state(self, state):
         # Main LALR-parser loop
         try:
-            for token in stream:
-                while True:
-                    action, arg = get_action(token)
-                    assert arg != end_state
+            token = None
+            for token in state.lexer.lex(state):
+                state.feed_token(token)
 
-                    if action is Shift:
-                        state_stack.append(arg)
-                        value_stack.append(token)
-                        if set_state: set_state(arg)
-                        break # next token
-                    else:
-                        reduce(arg)
+            token = Token.new_borrow_pos('$END', '', token) if token else Token('$END', '', 0, 1, 1)
+            return state.feed_token(token, True)
         except Exception as e:
             if self.debug:
                 print("")
                 print("STATE STACK DUMP")
                 print("----------------")
-                for i, s in enumerate(state_stack):
+                for i, s in enumerate(state.state_stack):
                     print('%d)' % i , s)
                 print("")
 
             raise
-
-        token = Token.new_borrow_pos('$END', '', token) if token else Token('$END', '', 0, 1, 1)
-        while True:
-            _action, arg = get_action(token)
-            assert(_action is Reduce)
-            reduce(arg)
-            if state_stack[-1] == end_state:
-                return value_stack[-1]
-
 ###}
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -43,8 +43,8 @@ class CustomLexer(Lexer):
     def __init__(self, lexer_conf):
         pass
 
-    def lex(self, data):
-        for obj in data:
+    def lex(self, lexer_state, parser_state):
+        for obj in lexer_state.text:
             yield Token('A', obj)
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2178,6 +2178,11 @@ def _make_parser_test(LEXER, PARSER):
         @unittest.skipIf(PARSER!='lalr', "Puppet error handling only works with LALR for now")
         def test_error_with_puppet(self):
             def ignore_errors(e):
+                if isinstance(e, UnexpectedCharacters):
+                    # Skip bad character
+                    return True
+
+                # Must be UnexpectedToken
                 if e.token.type == 'COMMA':
                     # Skip comma
                     return True
@@ -2200,6 +2205,9 @@ def _make_parser_test(LEXER, PARSER):
             tree = g.parse(s, on_error=ignore_errors)
             res = [int(x) for x in tree.children]
             assert res == list(range(7))
+
+            s = "[0 1, 2,@, 3,,, 4, 5 6 ]$"
+            tree = g.parse(s, on_error=ignore_errors)
 
 
     _NAME = "Test" + PARSER.capitalize() + LEXER.capitalize()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2174,6 +2174,34 @@ def _make_parser_test(LEXER, PARSER):
                         """, regex=True)
             self.assertEqual(g.parse('வணக்கம்'), 'வணக்கம்')
 
+
+        @unittest.skipIf(PARSER!='lalr', "Puppet error handling only works with LALR for now")
+        def test_error_with_puppet(self):
+            def ignore_errors(e):
+                if e.token.type == 'COMMA':
+                    # Skip comma
+                    return True
+                elif e.token.type == 'SIGNED_NUMBER':
+                    # Try to feed a comma and retry the number
+                    e.puppet.feed_token(Token('COMMA', ','))
+                    e.puppet.feed_token(e.token)
+                    return True
+
+                # Unhandled error. Will stop parse and raise exception
+                return False
+
+            g = _Lark(r'''
+                start: "[" num ("," num)* "]"
+                ?num: SIGNED_NUMBER
+                %import common.SIGNED_NUMBER
+                %ignore " "
+            ''')
+            s = "[0 1, 2,, 3,,, 4, 5 6 ]"
+            tree = g.parse(s, on_error=ignore_errors)
+            res = [int(x) for x in tree.children]
+            assert res == list(range(7))
+
+
     _NAME = "Test" + PARSER.capitalize() + LEXER.capitalize()
     _TestParser.__name__ = _NAME
     _TestParser.__qualname__ = "tests.test_parser." + _NAME


### PR DESCRIPTION
This is the first refactoring in order to allow a resumable lexer in addition to the parser.

To support it, I had to completely change and refactor the interface between them (or it would end up pretty ugly). That's because the parser must have access to the lexer, so it can request its state, and later recreate a new `LexerThread` with the saved state.

I think I also improved a few things on the way, but it's not perfect yet.

But I want some input before I continue. Did I miss anything important? Maybe I should use different architecture or better names?

Notes:

The puppet mechanism is currently broken. Later on I will fix it, and it will be much shorter, because it will be able to reuse most of the code from `lalr_parser.py`.

It breaks the custom lexer interface, so maybe it will have to go into v1.0

I managed to keep the postlexer interface the same with a hack, but maybe it's better to change it too.

Despite the changes, it seems that performance hasn't suffered noticeably.