### PR TITLE
Custom import sources

### DIFF
--- a/lark-stubs/lark.pyi
+++ b/lark-stubs/lark.pyi
@@ -33,6 +33,13 @@ class LarkOptions:
     g_regex_flags: int
     use_bytes: bool
     import_sources: List[Union[str, Callable[[str, str], str]]]
+    source: Optional[str]
+
+
+class FromPackageLoader:
+    def __init__(self, pkg_name: str, search_paths: Tuple[str, ...] = ...): ...
+    
+    def __call__(self, base_paths: List[str], grammar_path: str) -> Tuple[str, str]: ...
 
 
 class Lark:
@@ -62,6 +69,7 @@ class Lark:
         g_regex_flags: int = ...,
         use_bytes: bool = False,
         import_sources: List[Union[str, Callable[[List[str], str], Tuple[str, str]]]] = ...,
+        source: Optional[str],
     ):
         ...
 
@@ -70,6 +78,10 @@ class Lark:
 
     @classmethod
     def open(cls: Type[_T], grammar_filename: str, rel_to: Optional[str] = None, **options) -> _T:
+        ...
+    
+    @classmethod
+    def open_from_package(cls: Type[_T], package: str, grammar_path: str, search_paths: Tuple[str, ...] = ..., **options) -> _T:
         ...
 
     def lex(self, text: str) -> Iterator[Token]:

--- a/lark-stubs/lark.pyi
+++ b/lark-stubs/lark.pyi
@@ -50,7 +50,7 @@ class FromPackageLoader:
 
 class Lark:
     source_path: str
-    source_code: str
+    source_grammar: str
     options: LarkOptions
     lexer: Lexer
     terminals: List[TerminalDef]
@@ -75,7 +75,7 @@ class Lark:
         g_regex_flags: int = ...,
         use_bytes: bool = False,
         import_paths: List[Union[str, Callable[[Union[None, str, PackageResource], str], Tuple[str, str]]]] = ...,
-        source_path: Optional[str],
+        source_path: Optional[str]=None,
     ):
         ...
 

--- a/lark-stubs/lark.pyi
+++ b/lark-stubs/lark.pyi
@@ -2,7 +2,7 @@
 
 from typing import (
     TypeVar, Type, List, Dict, IO, Iterator, Callable, Union, Optional,
-    Literal, Protocol,
+    Literal, Protocol, Tuple,
 )
 from .visitors import Transformer
 from .lexer import Token, Lexer, TerminalDef
@@ -32,6 +32,7 @@ class LarkOptions:
     cache: Union[bool, str]
     g_regex_flags: int
     use_bytes: bool
+    import_sources: List[Union[str, Callable[[str, str], str]]]
 
 
 class Lark:
@@ -60,6 +61,7 @@ class Lark:
         cache: Union[bool, str] = False,
         g_regex_flags: int = ...,
         use_bytes: bool = False,
+        import_sources: List[Union[str, Callable[[List[str], str], Tuple[str, str]]]] = ...,
     ):
         ...
 

--- a/lark-stubs/lark.pyi
+++ b/lark-stubs/lark.pyi
@@ -32,19 +32,19 @@ class LarkOptions:
     cache: Union[bool, str]
     g_regex_flags: int
     use_bytes: bool
-    import_sources: List[Union[str, Callable[[str, str], str]]]
-    source: Optional[str]
+    import_paths: List[Union[str, Callable[[Optional[str], str], Tuple[str, str]]]]
+    source_path: Optional[str]
 
 
 class FromPackageLoader:
     def __init__(self, pkg_name: str, search_paths: Tuple[str, ...] = ...): ...
     
-    def __call__(self, base_paths: List[str], grammar_path: str) -> Tuple[str, str]: ...
+    def __call__(self, base_paths: str, grammar_path: str) -> Tuple[str, str]: ...
 
 
 class Lark:
-    source: str
-    grammar_source: str
+    source_path: str
+    source_code: str
     options: LarkOptions
     lexer: Lexer
     terminals: List[TerminalDef]
@@ -68,8 +68,8 @@ class Lark:
         cache: Union[bool, str] = False,
         g_regex_flags: int = ...,
         use_bytes: bool = False,
-        import_sources: List[Union[str, Callable[[List[str], str], Tuple[str, str]]]] = ...,
-        source: Optional[str],
+        import_paths: List[Union[str, Callable[[Optional[str], str], Tuple[str, str]]]] = ...,
+        source_path: Optional[str],
     ):
         ...
 

--- a/lark-stubs/lark.pyi
+++ b/lark-stubs/lark.pyi
@@ -32,14 +32,20 @@ class LarkOptions:
     cache: Union[bool, str]
     g_regex_flags: int
     use_bytes: bool
-    import_paths: List[Union[str, Callable[[Optional[str], str], Tuple[str, str]]]]
+    import_paths: List[Union[str, Callable[[Union[None, str, PackageResource], str], Tuple[str, str]]]]
     source_path: Optional[str]
 
+
+class PackageResource(object):
+    pkg_name: str
+    path: str
+    
+    def __init__(self, pkg_name: str, path: str):
 
 class FromPackageLoader:
     def __init__(self, pkg_name: str, search_paths: Tuple[str, ...] = ...): ...
     
-    def __call__(self, base_paths: str, grammar_path: str) -> Tuple[str, str]: ...
+    def __call__(self, base_path: Union[None, str, PackageResource], grammar_path: str) -> Tuple[PackageResource, str]: ...
 
 
 class Lark:
@@ -68,7 +74,7 @@ class Lark:
         cache: Union[bool, str] = False,
         g_regex_flags: int = ...,
         use_bytes: bool = False,
-        import_paths: List[Union[str, Callable[[Optional[str], str], Tuple[str, str]]]] = ...,
+        import_paths: List[Union[str, Callable[[Union[None, str, PackageResource], str], Tuple[str, str]]]] = ...,
         source_path: Optional[str],
     ):
         ...

--- a/lark/lark.py
+++ b/lark/lark.py
@@ -90,6 +90,8 @@ class LarkOptions(Serialize):
             Accept an input of type ``bytes`` instead of ``str`` (Python 3 only).
     edit_terminals
             A callback for editing the terminals before parse.
+    import_sources
+            A List of either paths or loader functions to specify from where grammars are imported 
 
     **=== End Options ===**
     """
@@ -115,6 +117,7 @@ class LarkOptions(Serialize):
         'edit_terminals': None,
         'g_regex_flags': 0,
         'use_bytes': False,
+        'import_sources': [],
     }
 
     def __init__(self, options_dict):
@@ -267,7 +270,7 @@ class Lark(Serialize):
         assert self.options.ambiguity in ('resolve', 'explicit', 'forest', 'auto', )
 
         # Parse the grammar file and compose the grammars (TODO)
-        self.grammar = load_grammar(grammar, self.source, re_module)
+        self.grammar = load_grammar(grammar, self.source, re_module, self.options.import_sources)
 
         # Compile the EBNF grammar into BNF
         self.terminals, self.rules, self.ignore_tokens = self.grammar.compile(self.options.start)

--- a/lark/lark.py
+++ b/lark/lark.py
@@ -213,7 +213,7 @@ class Lark(Serialize):
             grammar = read()
 
         assert isinstance(grammar, STRING_TYPE)
-        self.source_code = grammar
+        self.source_grammar = grammar
         if self.options.use_bytes:
             if not isascii(grammar):
                 raise ValueError("Grammar must be ascii only, when use_bytes=True")

--- a/lark/lark.py
+++ b/lark/lark.py
@@ -489,5 +489,14 @@ class Lark(Serialize):
     def source(self, value):
         self.source_path = value
 
+    @property
+    def grammar_source(self):
+        warn("Lark.grammar_source attribute has been renamed to Lark.source_grammar", DeprecationWarning)
+        return self.source_grammar
+    
+    @grammar_source.setter
+    def grammar_source(self, value):
+        self.source_grammar = value
+
 
 ###}

--- a/lark/load_grammar.py
+++ b/lark/load_grammar.py
@@ -663,17 +663,17 @@ def import_grammar(grammar_path, re_, base_paths=(), import_sources=()):
     if grammar_path not in _imported_grammars:
         import_paths = import_sources + base_paths + [stdlib_loader]
         for source in import_paths:
-            if isinstance(source, str):
+            if callable(source):
                 with suppress(IOError):
-                    joined_path = os.path.join(source, grammar_path)
-                    with open(joined_path, encoding='utf8') as f:
-                        text = f.read()
+                    joined_path, text = source(base_paths, grammar_path)
                     grammar = load_grammar(text, joined_path, re_, import_sources)
                     _imported_grammars[grammar_path] = grammar
                     break
             else:
                 with suppress(IOError):
-                    joined_path, text = source(base_paths, grammar_path)
+                    joined_path = os.path.join(source, grammar_path)
+                    with open(joined_path, encoding='utf8') as f:
+                        text = f.read()
                     grammar = load_grammar(text, joined_path, re_, import_sources)
                     _imported_grammars[grammar_path] = grammar
                     break

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1792,7 +1792,7 @@ def _make_parser_test(LEXER, PARSER):
             %import ab.startab
             """
 
-            p = _Lark(grammar, import_sources=[custom_loader])
+            p = _Lark(grammar, import_paths=[custom_loader])
             self.assertEqual(p.parse('ab'),
                              Tree('start', [Tree('startab', [Tree('ab__expr', [Token('ab__A', 'a'), Token('ab__B', 'b')])])]))
 
@@ -1801,7 +1801,7 @@ def _make_parser_test(LEXER, PARSER):
 
             %import test_relative_import_of_nested_grammar__grammar_to_import.rule_to_import
             """
-            p = _Lark(grammar, import_sources=[custom_loader])
+            p = _Lark(grammar, import_paths=[custom_loader])
             x = p.parse('N')
             self.assertEqual(next(x.find_data('rule_to_import')).children, ['N'])
             
@@ -1810,7 +1810,7 @@ def _make_parser_test(LEXER, PARSER):
             %import .test_relative_import (start, WS)
             %ignore WS
             """
-            p = _Lark(grammar, import_sources=[custom_loader2])
+            p = _Lark(grammar, import_paths=[custom_loader2])
             x = p.parse('12 capybaras')
             self.assertEqual(x.children, ['12', 'capybaras'])
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1782,6 +1782,24 @@ def _make_parser_test(LEXER, PARSER):
             """
             self.assertRaises(IOError, _Lark, grammar)
 
+        def test_import_custom_sources(self):
+            def custom_loader(base_paths, grammar_path):
+                import pkgutil
+                text = pkgutil.get_data('tests', 'grammars/' + grammar_path)
+                if text is None:
+                    raise FileNotFoundError()
+                return '<tests.grammars:' + grammar_path + '>', text.decode()
+
+            grammar = """
+            start: startab
+
+            %import ab.startab
+            """
+
+            p = _Lark(grammar, import_sources=[custom_loader])
+            self.assertEqual(p.parse('ab'),
+                             Tree('start', [Tree('startab', [Tree('ab__expr', [Token('ab__A', 'a'), Token('ab__B', 'b')])])]))
+
         @unittest.skipIf(PARSER != 'earley', "Currently only Earley supports priority in rules")
         def test_earley_prioritization(self):
             "Tests effect of priority on result"


### PR DESCRIPTION
Added a new option to `Lark`, `import_sources`.
This is a list of either:

- A string, representing a folder which will be directly searched for any grammars
- A callable of the form `(base_paths, grammar_path) -> (grammar_name, grammar_source)`
  - `base_paths`: A list of paths lark identified as source folders. Probably not useful in custom loaders
  - `grammar_path`: The joined relative path of the grammar file, including the extension
  - `grammar_name`: The name that will be used for the grammar. Should be the path, but doesn't have to.
  - `grammar_source`: The raw grammar source, not a file object.

(This branch also includes a change to use `pkgutil` for `common.lark`, closing #703)

This should also close #603.

Note: while not a draft, I would like for someone to check whether this works for zipapp before merging.