### PR TITLE
Guard Lark.__doc__ assignment for tools.standalone

### DIFF
--- a/lark/lark.py
+++ b/lark/lark.py
@@ -310,7 +310,8 @@ class Lark(Serialize):
             with FS.open(cache_fn, 'wb') as f:
                 self.save(f)
 
-    __doc__ += "\n\n" + LarkOptions.OPTIONS_DOC
+    if __doc__:
+        __doc__ += "\n\n" + LarkOptions.OPTIONS_DOC
 
     __serialize_fields__ = 'parser', 'rules', 'options'
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -25,7 +25,7 @@ class TestStandalone(TestCase):
         standalone.main(StringIO(grammar), 'start', print=pr)
         code = code_buf.getvalue()
 
-        context = {}
+        context = {'__doc__': None}
         exec(code, context)
         return context
 


### PR DESCRIPTION
This change is necessary for standalones to work, otherwise you get errors like:


    kson/grammar/kson.py:2285: in Lark
        __doc__ += "\n\n" + LarkOptions.OPTIONS_DOC
    E   TypeError: unsupported operand type(s) for +=: 'NoneType' and 'str'
