### PR TITLE
Fixed broken link in docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -65,7 +65,7 @@ Syntax Highlighting
 -  `Visual Studio Code`_ (Or install through the vscode plugin system)
 -  `Intellij & PyCharm`_
 -  `Vim`_
--  `Atom`
+-  `Atom`_
 
 .. _Sublime Text & TextMate: https://github.com/lark-parser/lark_syntax
 .. _Visual Studio Code: https://github.com/lark-parser/vscode-lark

--- a/docs/json_tutorial.md
+++ b/docs/json_tutorial.md
@@ -78,7 +78,7 @@ By the way, if you're curious what these terminals signify, they are roughly equ
 
 Lark will accept this, if you really want to complicate your life :)
 
-You can find the original definitions in [common.lark](/lark/grammars/common.lark).
+You can find the original definitions in [common.lark](https://github.com/lark-parser/lark/blob/master/lark/grammars/common.lark).
 They're don't strictly adhere to [json.org](https://json.org/) - but our purpose here is to accept json, not validate it.
 
 Notice that terminals are written in UPPER-CASE, while rules are written in lower-case.


### PR DESCRIPTION
The link for the Atom editor syntax highlighting in the docs was broken. This pull request fixes it