### PR TITLE
Recons terminals unicode

### DIFF
--- a/lark/load_grammar.py
+++ b/lark/load_grammar.py
@@ -5,7 +5,7 @@ import sys
 from copy import copy, deepcopy
 from io import open
 
-from .utils import bfs, eval_escaping, Py36
+from .utils import bfs, eval_escaping, Py36, isalnum, isalpha
 from .lexer import Token, TerminalDef, PatternStr, PatternRE
 
 from .parse_tree_builder import ParseTreeBuilder
@@ -327,9 +327,9 @@ class PrepareAnonTerminals(Transformer_InPlace):
                 try:
                     term_name = _TERMINAL_NAMES[value]
                 except KeyError:
-                    if value.isalnum() and value[0].isalpha() and value.upper() not in self.term_set:
+                    if isalnum(value) and isalpha(value[0]) and value.upper() not in self.term_set:
                         with suppress(UnicodeEncodeError):
-                            value.upper().encode('ascii') # Make sure we don't have unicode in our terminal names
+                            value.upper().encode('utf8')  # Why shouldn't we have unicode in our terminal names?
                             term_name = value.upper()
 
                 if term_name in self.term_set:

--- a/lark/reconstruct.py
+++ b/lark/reconstruct.py
@@ -6,7 +6,7 @@ from .common import ParserConf
 from .lexer import Token, PatternStr
 from .parsers import earley
 from .grammar import Rule, Terminal, NonTerminal
-
+from .utils import isalnum
 
 
 def is_discarded_terminal(t):
@@ -198,7 +198,7 @@ class Reconstructor:
         y = []
         prev_item = ''
         for item in x:
-            if prev_item and item and prev_item[-1].isalnum() and item[0].isalnum():
+            if prev_item and item and isalnum(prev_item[-1]) and isalnum(item[0]):
                 y.append(' ')
             y.append(item)
             prev_item = item

--- a/lark/utils.py
+++ b/lark/utils.py
@@ -1,4 +1,5 @@
 import sys
+import unicodedata
 import os
 from functools import reduce
 from ast import literal_eval
@@ -11,6 +12,17 @@ logger.addHandler(logging.StreamHandler())
 # Set to highest level, since we have some warnings amongst the code
 # By default, we should not output any log messages
 logger.setLevel(logging.CRITICAL)
+
+def isalnum(x):
+    if len(x) != 1:
+        return all(isalnum(y) for y in x)
+    return unicodedata.category(x) in ['Lu', 'Ll', 'Lt', 'Lm', 'Lo', 'Nl', 'Mn', 'Mc', 'Nd', 'Pc']
+
+
+def isalpha(x):
+    if len(x) != 1:
+        return all(isalpha(y) for y in x)
+    return unicodedata.category(x) in ['Lu', 'Ll', 'Lt', 'Lm', 'Lo', 'Mn', 'Mc', 'Pc']
 
 
 def classify(seq, key=None, value=None):


### PR DESCRIPTION
This test checks that a parse tree built with a grammar containing only ascii characters can be reconstructed with a grammar that has unicode rules (or vice versa). The original bug assigned ANON terminals to unicode keywords, which offsets the ANON terminal count in the unicode grammar and causes subsequent identical ANON tokens (e.g., `+=`) to mis-match between the two grammars.

I know that this is an uncommon situation, but it is central to use of Lark as a transpiler (e.g., [லஸ்ஸி](https://லஸ்ஸி.இந்தியா)) and the fix was quite simple, so I thought I'd try to send a pull request. Hope you like it!