### PR TITLE
Make `UnexpectedCharacters` print the repr

### DIFF
--- a/lark/exceptions.py
+++ b/lark/exceptions.py
@@ -130,7 +130,7 @@ class UnexpectedCharacters(LexError, UnexpectedInput):
         else:
             _s = seq[lex_pos]
 
-        message = "No terminal defined for '%s' at line %d col %d" % (_s, line, column)
+        message = "No terminal defined for %r at line %d col %d" % (_s, line, column)
         message += '\n\n' + self.get_context(seq)
         if allowed:
             message += '\nExpecting: %s\n' % allowed


### PR DESCRIPTION
This is an additional response to #738.

I also often came across this when unexpectedly having a newline, which would previously result in the message being split up across two lines. This PR makes it easier to identify exactly which special character is causing problems.