### PR TITLE
Adding missing Testcase to `__main__`

### DIFF
--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -9,6 +9,7 @@ from .test_tools import TestStandalone
 from .test_cache import TestCache
 from .test_grammar import TestGrammar
 from .test_reconstructor import TestReconstructor
+from .test_tree_forest_transformer import TestTreeForestTransformer
 
 try:
     from .test_nearley.test_nearley import TestNearley


### PR DESCRIPTION
Has already been implemented for some time, but wasn't executed. It should pas both python2.7 and python3.