### PR TITLE
Added `lark.lark` to the standardlib of grammars.

### DIFF
--- a/examples/lark_grammar.py
+++ b/examples/lark_grammar.py
@@ -7,13 +7,13 @@ A reference implementation of the Lark grammar (using LALR(1))
 import lark
 from pathlib import Path
 
-parser = lark.Lark.open('lark.lark', rel_to=__file__, parser="lalr")
-
 examples_path = Path(__file__).parent
 lark_path = Path(lark.__file__).parent
 
+parser = lark.Lark.open(lark_path / 'grammars/lark.lark', rel_to=__file__, parser="lalr")
+
+
 grammar_files = [
-    examples_path / 'lark.lark',
     examples_path / 'advanced/python2.lark',
     examples_path / 'advanced/python3.lark',
     examples_path / 'relative-imports/multiples.lark',
@@ -21,7 +21,11 @@ grammar_files = [
     examples_path / 'relative-imports/multiple3.lark',
     examples_path / 'tests/no_newline_at_end.lark',
     examples_path / 'tests/negative_priority.lark',
+    examples_path / 'standalone/json.lark',
     lark_path / 'grammars/common.lark',
+    lark_path / 'grammars/lark.lark',
+    lark_path / 'grammars/unicode.lark',
+    lark_path / 'grammars/python.lark',
 ]
 
 def test():

--- a/lark/grammars/lark.lark
+++ b/lark/grammars/lark.lark
@@ -45,7 +45,7 @@ OP: /[+*]|[?](?![a-z])/
 RULE: /!?[_?]?[a-z][_a-z0-9]*/
 TOKEN: /_?[A-Z][_A-Z0-9]*/
 STRING: _STRING "i"?
-REGEXP: /\/(?!\/)(\\\/|\\\\|[^\/\n])*?\/[imslux]*/
+REGEXP: /\/(?!\/)(\\\/|\\\\|[^\/])*?\/[imslux]*/
 _NL: /(\r?\n)+\s*/
 
 %import common.ESCAPED_STRING -> _STRING


### PR DESCRIPTION
This moves `lark.lark` into the `lark.grammars` folders. This means that it will be shiped with lark and can be used by packages that want to do something with lark grammars, like `lark-railroad` or the language server.

Since it is now in an even more official place than before, I added a check that tries to parse every grammar used inside the `_make_parser_tests`. This forces us to keep the grammar up-to-date. (as example, I already had to fix something in the grammar since we introduces multi line regex.) The cost of this check is minimal, but not zero. It adds (on my machine) ~2.5% to the total runtime.