### PR TITLE
Earley custom lexer implementation

### DIFF
--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -20,20 +20,7 @@ except ImportError:
 
 from .test_logger import Testlogger
 
-from .test_parser import (
-        TestLalrStandard,
-        TestEarleyStandard,
-        TestCykStandard,
-        TestLalrContextual,
-        TestEarleyDynamic,
-        TestLalrCustom,
-
-        # TestFullEarleyStandard,
-        TestFullEarleyDynamic,
-        TestFullEarleyDynamic_complete,
-
-        TestParsers,
-        )
+from .test_parser import * # We define __all__ to list which TestSuites to run
 
 logger.setLevel(logging.INFO)
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2361,7 +2361,7 @@ def _make_parser_test(LEXER, PARSER):
                 self.assertEqual(a.line, 1)
                 self.assertEqual(b.line, 2)
 
-        @unittest.skipIf(PARSER=='cyk', "match_examples() not supported for CYK")
+        @unittest.skipIf(PARSER=='cyk' or LEXER=='custom_old', "match_examples() not supported for CYK/old custom lexer")
         def test_match_examples(self):
             p = _Lark(r"""
                 start: "a" "b" "c"


### PR DESCRIPTION
This is the 'easy plug'. It is probably a good idea to refactor 'parser_frontends' at some point at a large scale.

This PR also contains a few changes to the tests that were discovered while fixing this. (most notable: ('earley', 'dynamic_complete') wasn't run). It for that guarantees that all auto generated tests will be run.