### PR TITLE
Made trees iterable (and indexable)

### DIFF
--- a/lark-stubs/tree.pyi
+++ b/lark-stubs/tree.pyi
@@ -58,15 +58,15 @@ class Tree:
     def __hash__(self) -> int:
         ...
 
+    def __iter__(self) -> Iterator[Union[str, Tree]]:
+        ...
+
 
 class SlottedTree(Tree):
     pass
 
 
 def pydot__tree_to_png(
-    tree: Tree,
-    filename: str,
-    rankdir: Literal["TB", "LR", "BT", "RL"] = ...,
-    **kwargs
+    tree: Tree, filename: str, rankdir: Literal["TB", "LR", "BT", "RL"] = ..., **kwargs
 ) -> None:
     ...

--- a/lark-stubs/tree.pyi
+++ b/lark-stubs/tree.pyi
@@ -61,6 +61,9 @@ class Tree:
     def __iter__(self) -> Iterator[Union[str, Tree]]:
         ...
 
+    def __getitem__(self, key) -> Union[str, Tree]:
+        ...
+
 
 class SlottedTree(Tree):
     pass

--- a/lark/tree.py
+++ b/lark/tree.py
@@ -98,6 +98,8 @@ class Tree(object):
     def find_data(self, data):
         """Returns all nodes of the tree whose data equals the given data."""
         return self.find_pred(lambda t: t.data == data)
+    def __iter__(self):
+        return (child for child in self.children)
 
 ###}
 

--- a/lark/tree.py
+++ b/lark/tree.py
@@ -101,6 +101,9 @@ class Tree(object):
     def __iter__(self):
         return (child for child in self.children)
 
+    def __getitem__(self, index):
+        return self.children[index]
+
 ###}
 
     def expand_kids_by_index(self, *indices):


### PR DESCRIPTION
Because I don't want to keep on doing `tree.children`.

See https://gitter.im/lark-parser/Lobby?at=5fbc8970e6f2b51c68b28a22

Without this, I'm doing things like

```python
    def declare(self, tree):
        return "%declare " + " ".join(
            map(
                operator.itemgetter(0),
                map(operator.attrgetter("children"), tree),
            )
        )
```
and 
```python
def single_import(self, tree):
    (tree,) = tree
    tree = tree.children
    return "%import " + str(tree[0].children[0]) + "." + str(tree[2].children[0])
```