### PR TITLE
Refactored all likely exceptions to inherit from LarkError

### DIFF
--- a/lark-stubs/exceptions.pyi
+++ b/lark-stubs/exceptions.pyi
@@ -9,6 +9,10 @@ class LarkError(Exception):
     pass
 
 
+class ConfigurationError(LarkError, ValueError):
+    pass
+
+
 class GrammarError(LarkError):
     pass
 

--- a/lark/exceptions.py
+++ b/lark/exceptions.py
@@ -14,9 +14,6 @@ class ConfigurationError(LarkError, ValueError):
 class GrammarError(LarkError):
     pass
 
-class GrammarError_Value(LarkError):
-    pass
-
 
 class ParseError(LarkError):
     pass

--- a/lark/exceptions.py
+++ b/lark/exceptions.py
@@ -7,7 +7,14 @@ class LarkError(Exception):
     pass
 
 
+class ConfigurationError(LarkError, ValueError):
+    pass
+
+
 class GrammarError(LarkError):
+    pass
+
+class GrammarError_Value(LarkError):
     pass
 
 

--- a/lark/lexer.py
+++ b/lark/lexer.py
@@ -366,7 +366,7 @@ class TraditionalLexer(Lexer):
                 if t.type in self.callback:
                     t = self.callback[t.type](t)
                     if not isinstance(t, Token):
-                        raise ValueError("Callbacks must return a token (returned %r)" % t)
+                        raise LexError("Callbacks must return a token (returned %r)" % t)
                 lex_state.last_token = t
                 return t
             else:

--- a/lark/utils.py
+++ b/lark/utils.py
@@ -1,6 +1,5 @@
 import os
 from functools import reduce
-from ast import literal_eval
 from collections import deque
 
 ###{standalone
@@ -224,31 +223,6 @@ class Enumerator(Serialize):
         assert len(r) == len(self.enums)
         return r
 
-
-def eval_escaping(s):
-    w = ''
-    i = iter(s)
-    for n in i:
-        w += n
-        if n == '\\':
-            try:
-                n2 = next(i)
-            except StopIteration:
-                raise ValueError("Literal ended unexpectedly (bad escaping): `%r`" % s)
-            if n2 == '\\':
-                w += '\\\\'
-            elif n2 not in 'uxnftr':
-                w += '\\'
-            w += n2
-    w = w.replace('\\"', '"').replace("'", "\\'")
-
-    to_eval = "u'''%s'''" % w
-    try:
-        s = literal_eval(to_eval)
-    except SyntaxError as e:
-        raise ValueError(s, e)
-
-    return s
 
 
 def combine_alternatives(lists):


### PR DESCRIPTION
Also improved some error messages.

Adds `ConfigurationError` to complement `GrammarError`.

Based on #773 by @ThatXliner 