### PR TITLE
Adding Power support(ppc64le) with ci and testing to the project for architecture independent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 dist: xenial
+arch:
+  - amd64
+  - ppc64le
 language: python
 python:
   - "2.7"
@@ -10,6 +13,12 @@ python:
   - "3.9-dev"
   - "pypy2.7-6.0"
   - "pypy3.5-6.0"
+jobs:
+  exclude:
+   - arch : ppc64le
+     python : "pypy2.7-6.0"
+   - arch : ppc64le
+     python : "pypy3.5-6.0"
 install: pip install tox-travis
 script:
   - tox


### PR DESCRIPTION
I am part of IBM team and working on porting power arch to packages as continuous integration & testing.

This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing,We typically build applications for customers and ISVs, and while we don't use this package directly,

we do count on all of the packages in debian/ubuntu to build other packages. So we more likely have this as a second or third level dependency and couldn't tell you explicitly which features we use or our usage model,For more info tag @gerrith3.

Pls verify and merge
