### PR TITLE
type stubs: Allows `v_args` to decorate a class.

### DIFF
--- a/lark-stubs/visitors.pyi
+++ b/lark-stubs/visitors.pyi
@@ -7,7 +7,7 @@ from .tree import Tree
 _T = TypeVar('_T')
 _R = TypeVar('_R')
 _FUNC = Callable[..., _T]
-_DECORED = Union[_FUNC, type]
+_DECORATED = Union[_FUNC, type]
 
 class Transformer(ABC, Generic[_T]):
 
@@ -76,7 +76,7 @@ def v_args(
     inline: bool = False,
     meta: bool = False,
     tree: bool = False
-) -> Callable[[_DECORED], _DECORED]:
+) -> Callable[[_DECORATED], _DECORATED]:
     ...
 
 

--- a/lark-stubs/visitors.pyi
+++ b/lark-stubs/visitors.pyi
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 
-from typing import TypeVar, Tuple, List, Callable, Generic, Type
+from typing import TypeVar, Tuple, List, Callable, Generic, Type, Union
 from abc import ABC
 from .tree import Tree
 
 _T = TypeVar('_T')
 _R = TypeVar('_R')
 _FUNC = Callable[..., _T]
-
+_DECORED = Union[_FUNC, type]
 
 class Transformer(ABC, Generic[_T]):
 
@@ -76,7 +76,7 @@ def v_args(
     inline: bool = False,
     meta: bool = False,
     tree: bool = False
-) -> Callable[[_FUNC], _FUNC]:
+) -> Callable[[_DECORED], _DECORED]:
     ...
 
 


### PR DESCRIPTION
v_args is described as taking a callbable as argument: https://github.com/lark-parser/lark/blob/36a7b050c11c49a168f2710bdb8a75f66c573ff4/lark-stubs/visitors.pyi#L75-L79
Yet the documentation states it can decorate a class: https://github.com/lark-parser/lark/blob/5b30ba484105b66f4596ada259a9d96d679d8d8c/lark/visitors.py#L417-L418