### PR TITLE
type stubs: A consistent type for `Token.value`

### DIFF
--- a/lark-stubs/lexer.pyi
+++ b/lark-stubs/lexer.pyi
@@ -81,7 +81,7 @@ class TerminalDef:
 class Token(str):
     type: str
     pos_in_stream: int
-    value: str
+    value: Any
     line: int
     column: int
     end_line: int
@@ -91,11 +91,11 @@ class Token(str):
     def __init__(self, type_: str, value: Any, pos_in_stream: int = None, line: int = None, column: int = None, end_line: int = None, end_column: int = None, end_pos: int = None):
         ...
 
-    def update(self, type_: Optional[str] = None, value: Optional[str] = None) -> Token:
+    def update(self, type_: Optional[str] = None, value: Optional[Any] = None) -> Token:
         ...
 
     @classmethod
-    def new_borrow_pos(cls: Type[_T], type_: str, value: str, borrow_t: Token) -> _T:
+    def new_borrow_pos(cls: Type[_T], type_: str, value: Any, borrow_t: Token) -> _T:
         ...
 
 


### PR DESCRIPTION
The Token's value is described as being a in the attribute list: https://github.com/lark-parser/lark/blob/460a221923317299422f14d87901dee1eb5f5fda/lark-stubs/lexer.pyi#L84 and as `Any` in `__init__` parameters:  https://github.com/lark-parser/lark/blob/460a221923317299422f14d87901dee1eb5f5fda/lark-stubs/lexer.pyi#L91

One of the recipes, [Use a transformer to parse integer tokens](https://github.com/lark-parser/lark/blob/master/docs/recipes.md#use-a-transformer-to-parse-integer-tokens), recommends to set it to other types. For that recipe to type-check, `Any` is the correct type.