### PR TITLE
Prevent unreadable exceptions.

### DIFF
--- a/lark/exceptions.py
+++ b/lark/exceptions.py
@@ -120,7 +120,9 @@ class UnexpectedInput(LarkError):
 
     def _format_expected(self, expected):
         if self._terminals_by_name:
-            expected = [self._terminals_by_name[t_name].user_repr() for t_name in expected]
+            expected = [self._terminals_by_name[t_name].user_repr()
+                            if t_name in self.termiansl_by_name else t_name
+                        for t_name in expected]
         return "Expected one of: \n\t* %s\n" % '\n\t* '.join(expected)
 
 


### PR DESCRIPTION
we said 't_name should always be in `terminals_by_name`'. Well, isn't the case when the expected set contains wither `$END` or a `%declared` terminal.