### PR TITLE
Added `%extend`

### DIFF
--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -302,3 +302,22 @@ Useful for implementing an inheritance pattern when importing grammars.
 // Add hex support to my_grammar
 %override number: NUMBER | /0x\w+/
 ```
+
+### %extend
+
+Extend the definition of a rule or terminal, e.g. add a new option on what it can match, like when separated with `|`.
+
+Useful for splitting up a definition of a complex rule with many different options over multiple files.
+
+Can also be used to implement a plugin system where a core grammar is extended by others.
+
+
+**Example:**
+```perl
+%import my_grammar (start, NUMBER)
+
+// Add hex support to my_grammar
+%extend NUMBER: /0x\w+/
+```
+
+For both `%extend` and `%override`, there is not requirement for a rule/terminal to come from another file, but that is probably the most common usecase

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -291,7 +291,7 @@ Declare a terminal without defining it. Useful for plugins.
 
 ### %override
 
-Override a rule, affecting all the rules that refer to it.
+Override a rule or terminals, affecting all references to it, even in imported grammars.
 
 Useful for implementing an inheritance pattern when importing grammars.
 

--- a/lark/grammars/lark.lark
+++ b/lark/grammars/lark.lark
@@ -15,7 +15,8 @@ priority: "." NUMBER
 statement: "%ignore" expansions                    -> ignore
          | "%import" import_path ["->" name]       -> import
          | "%import" import_path name_list         -> multi_import
-         | "%override" rule                        -> override_rule
+         | "%override" (rule|token)                -> override
+         | "%extend" (rule|token)                  -> extend
          | "%declare" name+                        -> declare
 
 !import_path: "."? name ("." name)*

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import sys
 from unittest import TestCase, main
 
-from lark import Lark, Token
+from lark import Lark, Token, Tree
 from lark.load_grammar import GrammarLoader, GrammarError
 
 
@@ -40,12 +40,30 @@ class TestGrammar(TestCase):
             
             %import .grammars.ab (startab, A, B)
             
-            %override A: "C"
-            %override B: "D"
+            %override A: "c"
+            %override B: "d"
         """, start='startab', source_path=__file__)
 
-        a = p.parse('CD')
-        self.assertEqual(a.children[0].children, [Token('A', 'C'), Token('B', 'D')])
+        a = p.parse('cd')
+        self.assertEqual(a.children[0].children, [Token('A', 'c'), Token('B', 'd')])
+
+    def test_extend_rule(self):
+        p = Lark("""
+            %import .grammars.ab (startab, A, B, expr)
+
+            %extend expr: B A
+        """, start='startab', source_path=__file__)
+        a = p.parse('abab')
+        self.assertEqual(a.children[0].children, ['a', Tree('expr', ['b', 'a']), 'b'])
+
+    def test_extend_term(self):
+        p = Lark("""
+            %import .grammars.ab (startab, A, B, expr)
+            
+            %extend A: "c"
+        """, start='startab', source_path=__file__)
+        a = p.parse('acbb')
+        self.assertEqual(a.children[0].children, ['a', Tree('expr', ['c', 'b']), 'b'])
 
 
 

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import sys
 from unittest import TestCase, main
 
-from lark import Lark
+from lark import Lark, Token
 from lark.load_grammar import GrammarLoader, GrammarError
 
 
@@ -21,7 +21,7 @@ class TestGrammar(TestCase):
                 else:
                     assert False, "example did not raise an error"
 
-    def test_override(self):
+    def test_override_rule(self):
         # Overrides the 'sep' template in existing grammar to add an optional terminating delimiter
         # Thus extending it beyond its original capacity
         p = Lark("""
@@ -29,11 +29,23 @@ class TestGrammar(TestCase):
 
             %override sep{item, delim}: item (delim item)* delim?
             %ignore " "
-        """)
+        """, source_path=__file__)
 
         a = p.parse('[1, 2, 3]')
         b = p.parse('[1, 2, 3, ]')
         assert a == b
+
+    def test_override_terminal(self):
+        p = Lark("""
+            
+            %import .grammars.ab (startab, A, B)
+            
+            %override A: "C"
+            %override B: "D"
+        """, start='startab', source_path=__file__)
+
+        a = p.parse('CD')
+        self.assertEqual(a.children[0].children, [Token('A', 'C'), Token('B', 'D')])
 
 
 


### PR DESCRIPTION
Second point in #803.

Here it becomes very apparent that the current approach creates a lot of duplicate code. A complete refactor of the `GrammarLoader` class is in my opinion a good idea. (Especially breaking up `.load_grammar` to allow them to be reused in other parts more easier).

Based on #804.