### PR TITLE
Grammar builder

### DIFF
--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -302,3 +302,22 @@ Useful for implementing an inheritance pattern when importing grammars.
 // Add hex support to my_grammar
 %override number: NUMBER | /0x\w+/
 ```
+
+### %extend
+
+Extend the definition of a rule or terminal, e.g. add a new option on what it can match, like when separated with `|`.
+
+Useful for splitting up a definition of a complex rule with many different options over multiple files.
+
+Can also be used to implement a plugin system where a core grammar is extended by others.
+
+
+**Example:**
+```perl
+%import my_grammar (start, NUMBER)
+
+// Add hex support to my_grammar
+%extend NUMBER: /0x\w+/
+```
+
+For both `%extend` and `%override`, there is not requirement for a rule/terminal to come from another file, but that is probably the most common usecase

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -291,7 +291,7 @@ Declare a terminal without defining it. Useful for plugins.
 
 ### %override
 
-Override a rule, affecting all the rules that refer to it.
+Override a rule or terminals, affecting all references to it, even in imported grammars.
 
 Useful for implementing an inheritance pattern when importing grammars.
 

--- a/examples/advanced/grammar_building.py
+++ b/examples/advanced/grammar_building.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+
+from lark.indenter import Indenter
+from lark.lark import Lark
+from lark.load_grammar import GrammarBuilder
+
+MATCH_GRAMMAR = ('match', """
+
+%extend compound_stmt: match_stmt
+
+match_stmt: "match" test ":" cases
+
+cases: _NEWLINE _INDENT case+ _DEDENT
+
+case: "case" test ":" suite // test is not quite correct. 
+
+""", ('compound_stmt', 'test', 'suite', '_DEDENT', '_INDENT', '_NEWLINE'))
+
+EXTENSIONS = (MATCH_GRAMMAR,)
+
+builder = GrammarBuilder()
+
+builder.load_grammar((Path(__file__).with_name('python3.lark')).read_text(), 'python3')
+
+for name, ext_grammar, needed_names in EXTENSIONS:
+    mangle = builder.get_mangle(name, dict(zip(needed_names, needed_names)))
+    builder.load_grammar(ext_grammar, name, mangle)
+
+grammar = builder.build()
+
+
+class PythonIndenter(Indenter):
+    NL_type = '_NEWLINE'
+    OPEN_PAREN_types = ['LPAR', 'LSQB', 'LBRACE']
+    CLOSE_PAREN_types = ['RPAR', 'RSQB', 'RBRACE']
+    INDENT_type = '_INDENT'
+    DEDENT_type = '_DEDENT'
+    tab_len = 8
+
+
+parser = Lark(grammar, parser='lalr', start=['single_input', 'file_input', 'eval_input'], postlex=PythonIndenter())
+
+tree = parser.parse(r"""
+
+a = 5
+
+def name(n):
+    match n:
+        case 1:
+            print("one")
+        case 2:
+            print("two")
+        case _:
+            print("number is to big") 
+
+name(a)
+""", start='file_input')
+
+print(tree.pretty())

--- a/lark-stubs/__init__.pyi
+++ b/lark-stubs/__init__.pyi
@@ -4,6 +4,7 @@ from .tree import *
 from .visitors import *
 from .exceptions import *
 from .lexer import *
+from .load_grammar import *
 from .lark import *
 from logging import Logger as _Logger
 

--- a/lark-stubs/grammar.pyi
+++ b/lark-stubs/grammar.pyi
@@ -1,0 +1,9 @@
+from typing import Optional, Tuple
+
+
+class RuleOptions:
+    keep_all_tokens: bool
+    expand1: bool
+    priority: int
+    template_source: Optional[str]
+    empty_indices: Tuple[bool, ...]

--- a/lark-stubs/lark.pyi
+++ b/lark-stubs/lark.pyi
@@ -8,6 +8,7 @@ from .visitors import Transformer
 from .lexer import Token, Lexer, TerminalDef
 from .tree import Tree
 from .exceptions import UnexpectedInput
+from .load_grammar import Grammar
 
 _T = TypeVar('_T')
 
@@ -54,13 +55,14 @@ class FromPackageLoader:
 class Lark:
     source_path: str
     source_grammar: str
+    grammar: Grammar
     options: LarkOptions
     lexer: Lexer
     terminals: List[TerminalDef]
 
     def __init__(
         self,
-        grammar: Union[str, IO[str]],
+        grammar: Union[Grammar, str, IO[str]],
         *,
         start: Union[None, str, List[str]] = "start",
         parser: Literal["earley", "lalr", "cyk"] = "auto",

--- a/lark-stubs/load_grammar.pyi
+++ b/lark-stubs/load_grammar.pyi
@@ -1,0 +1,28 @@
+from typing import List, Tuple, Union, Callable, Dict, Optional
+
+from lark import Tree
+from lark.grammar import RuleOptions
+
+
+class Grammar:
+    rule_defs: List[Tuple[str, Tuple[str, ...], Tree, RuleOptions]]
+    term_defs: List[Tuple[str, Tuple[Tree, int]]]
+    ignore: List[str]
+
+
+class GrammarBuilder:
+    global_keep_all_tokens: bool
+    import_paths: List[Union[str, Callable]]
+
+    def __init__(self, global_keep_all_tokens=..., import_paths=...): ...
+
+    def load_grammar(self, grammar_text: str, grammar_name: str = ..., mangle: Callable[[str], str] = None): ...
+
+    def do_import(self, dotted_path: Tuple[str, ...], base_path: Optional[str], aliases: Dict[str, str],
+                  base_mangle: Callable[[str], str] = None):  ...
+
+    def get_mangle(self, prefix: str, aliases: Dict[str, str], base_mangle: Callable[[str], str] = None): ...
+
+    def check(self): ...
+
+    def build(self) -> Grammar: ...

--- a/lark-stubs/reconstruct.pyi
+++ b/lark-stubs/reconstruct.pyi
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from typing import List, Dict, Union
+from typing import List, Dict, Union, Callable
 from .lark import Lark
 from .tree import Tree
 from .visitors import Transformer_InPlace
@@ -30,7 +30,7 @@ class MakeMatchTree:
 
 class Reconstructor:
 
-    def __init__(self, parser: Lark, term_subs: Dict[str, str] = ...):
+    def __init__(self, parser: Lark, term_subs: Dict[str, Callable[[str], str]] = ...):
         ...
 
     def reconstruct(self, tree: Tree) -> str:

--- a/lark/grammars/common.lark
+++ b/lark/grammars/common.lark
@@ -55,5 +55,5 @@ NEWLINE: (CR? LF)+
 // Comments
 SH_COMMENT: /#[^\n]*/
 CPP_COMMENT: /\/\/[^\n]*/
-C_COMMENT: "/*" /.*?/s "*/"
+C_COMMENT: "/*" /(.|\n)*?/ "*/"
 SQL_COMMENT: /--[^\n]*/

--- a/lark/load_grammar.py
+++ b/lark/load_grammar.py
@@ -960,7 +960,7 @@ class GrammarBuilder:
         base = self._definitions[name][1]
 
         while len(base.children) == 2:
-            assert isinstance(base.children[0], Tree) and base.children[0].data == 'expansions', tree
+            assert isinstance(base.children[0], Tree) and base.children[0].data == 'expansions', base
             base = base.children[0]
         base.children.insert(0, exp)
 

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -4,7 +4,7 @@ import sys
 from unittest import TestCase, main
 
 from lark import Lark, Token, Tree
-from lark.load_grammar import GrammarLoader, GrammarError
+from lark.load_grammar import GrammarError, GRAMMAR_ERRORS
 
 
 class TestGrammar(TestCase):
@@ -12,7 +12,7 @@ class TestGrammar(TestCase):
         pass
 
     def test_errors(self):
-        for msg, examples in GrammarLoader.ERRORS:
+        for msg, examples in GRAMMAR_ERRORS:
             for example in examples:
                 try:
                     p = Lark(example)

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import sys
 from unittest import TestCase, main
 
-from lark import Lark, Token
+from lark import Lark, Token, Tree
 from lark.load_grammar import GrammarLoader, GrammarError
 
 
@@ -40,12 +40,30 @@ class TestGrammar(TestCase):
             
             %import .grammars.ab (startab, A, B)
             
-            %override A: "C"
-            %override B: "D"
+            %override A: "c"
+            %override B: "d"
         """, start='startab', source_path=__file__)
 
-        a = p.parse('CD')
-        self.assertEqual(a.children[0].children, [Token('A', 'C'), Token('B', 'D')])
+        a = p.parse('cd')
+        self.assertEqual(a.children[0].children, [Token('A', 'c'), Token('B', 'd')])
+
+    def test_extend_rule(self):
+        p = Lark("""
+            %import .grammars.ab (startab, A, B, expr)
+
+            %extend expr: B A
+        """, start='startab', source_path=__file__)
+        a = p.parse('abab')
+        self.assertEqual(a.children[0].children, ['a', Tree('expr', ['b', 'a']), 'b'])
+
+    def test_extend_term(self):
+        p = Lark("""
+            %import .grammars.ab (startab, A, B, expr)
+            
+            %extend A: "c"
+        """, start='startab', source_path=__file__)
+        a = p.parse('acbb')
+        self.assertEqual(a.children[0].children, ['a', Tree('expr', ['c', 'b']), 'b'])
 
 
 

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import sys
 from unittest import TestCase, main
 
-from lark import Lark
+from lark import Lark, Token
 from lark.load_grammar import GrammarLoader, GrammarError
 
 
@@ -21,7 +21,7 @@ class TestGrammar(TestCase):
                 else:
                     assert False, "example did not raise an error"
 
-    def test_override(self):
+    def test_override_rule(self):
         # Overrides the 'sep' template in existing grammar to add an optional terminating delimiter
         # Thus extending it beyond its original capacity
         p = Lark("""
@@ -29,11 +29,23 @@ class TestGrammar(TestCase):
 
             %override sep{item, delim}: item (delim item)* delim?
             %ignore " "
-        """)
+        """, source_path=__file__)
 
         a = p.parse('[1, 2, 3]')
         b = p.parse('[1, 2, 3, ]')
         assert a == b
+
+    def test_override_terminal(self):
+        p = Lark("""
+            
+            %import .grammars.ab (startab, A, B)
+            
+            %override A: "C"
+            %override B: "D"
+        """, start='startab', source_path=__file__)
+
+        a = p.parse('CD')
+        self.assertEqual(a.children[0].children, [Token('A', 'C'), Token('B', 'D')])
 
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1961,7 +1961,7 @@ def _make_parser_test(LEXER, PARSER):
 
             p = _Lark(grammar, import_paths=[custom_loader])
             self.assertEqual(p.parse('ab'),
-                             Tree('start', [Tree('startab', [Tree('ab__expr', [Token('ab__A', 'a'), Token('ab__B', 'b')])])]))
+                             Tree('start', [Tree('startab', [Tree('ab__expr', [Token('AB__A', 'a'), Token('AB__B', 'b')])])]))
 
             grammar = """
             start: rule_to_import

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1961,7 +1961,7 @@ def _make_parser_test(LEXER, PARSER):
 
             p = _Lark(grammar, import_paths=[custom_loader])
             self.assertEqual(p.parse('ab'),
-                             Tree('start', [Tree('startab', [Tree('ab__expr', [Token('AB__A', 'a'), Token('AB__B', 'b')])])]))
+                             Tree('start', [Tree('startab', [Tree('ab__expr', [Token('ab__A', 'a'), Token('ab__B', 'b')])])]))
 
             grammar = """
             start: rule_to_import


### PR DESCRIPTION
This is in the direction I want to imagine this interface to look like.

The first push only contains code that does the same as the old code, not defining a new API (it also still contains `GrammarLoader` to easily check for changed behavior. But the entire class can be removed before this PR is finished)


(Maybe you can tell why the tests are failing?)