### PR TITLE
Load pyodide from JsDelivr in the IDE app

### DIFF
--- a/docs/ide/app.html
+++ b/docs/ide/app.html
@@ -4,7 +4,7 @@
 	<meta charset="UTF-8">
 
     <!-- flip comment below to use local pyodide -->
-    <script src="https://pyodide-cdn2.iodide.io/v0.15.0/full/pyodide.js"></script>
+    <script src="https://cdn.jsdelivr.net/pyodide/v0.15.0/full/pyodide.js"></script>
     <!-- <script src="./pyodide/pyodide.js"></script> -->
 
     <link rel="stylesheet" href="https://unpkg.com/purecss@1.0.1/build/base-min.css">

--- a/docs/ide/app.html
+++ b/docs/ide/app.html
@@ -4,6 +4,10 @@
 	<meta charset="UTF-8">
 
     <!-- flip comment below to use local pyodide -->
+    <script type="text/javascript">
+          // set the pyodide files URL (packages.json, pyodide.asm.data etc)
+          window.languagePluginUrl = 'https://cdn.jsdelivr.net/pyodide/v0.15.0/full/';
+    </script>
     <script src="https://cdn.jsdelivr.net/pyodide/v0.15.0/full/pyodide.js"></script>
     <!-- <script src="./pyodide/pyodide.js"></script> -->
 


### PR DESCRIPTION
Following https://pyodide.readthedocs.io/en/latest/changelog.html#version-0-16-1, it's preferable to use JsDelivr instead of the previous CDN for pyodide.  The pyodide version can likely be updated separately.