### PR TITLE
Allow parser option when using Lark standalone

### DIFF
--- a/lark/lark.py
+++ b/lark/lark.py
@@ -185,7 +185,7 @@ class LarkOptions(Serialize):
 
 # Options that can be passed to the Lark parser, even when it was loaded from cache/standalone.
 # These option are only used outside of `load_grammar`.
-_LOAD_ALLOWED_OPTIONS = {'postlex', 'transformer', 'use_bytes', 'debug', 'g_regex_flags', 'regex', 'propagate_positions', 'tree_class'}
+_LOAD_ALLOWED_OPTIONS = {'postlex', 'transformer', 'use_bytes', 'debug', 'g_regex_flags', 'regex', 'propagate_positions', 'tree_class', 'parser'}
 
 _VALID_PRIORITY_OPTIONS = ('auto', 'normal', 'invert', None)
 _VALID_AMBIGUITY_OPTIONS = ('auto', 'resolve', 'explicit', 'forest')


### PR DESCRIPTION
The standalone parser generated by Lark (and possibly also using it cached), does not allow the user to select the parser to be used and instead gives the error - `ValueError: Some options are not allowed when loading a Parser: {'parser'}`.