### PR TITLE
Fix Tree.scan_values() type stub

### DIFF
--- a/lark-stubs/tree.pyi
+++ b/lark-stubs/tree.pyi
@@ -40,7 +40,7 @@ class Tree:
     def expand_kids_by_index(self, *indices: int) -> None:
         ...
 
-    def scan_values(self, pred: Callable[[Union[str, Tree]], bool]) -> List[str]:
+    def scan_values(self, pred: Callable[[Union[str, Tree]], bool]) -> Iterator[str]:
         ...
 
     def iter_subtrees(self) -> Iterator[Tree]:


### PR DESCRIPTION
Currently, the type stub for the `Tree`'s `scan_values()` method says that it returns a `List`. However, it actually returns a `Generator`. This is problem when trying to actually use `scan_values()` with type checking, because the type checker throws an error with the use of generator functions like `next()`, but list actions like indexing create runtime errors. This pull request just changes the type stub to match the actual function.

Note that I chose to use `Iterator` instead of `Generator` to follow the convention of the rest of the file. The method `iter_subtrees_topdown()` also returns a generator, but the type stub says `Iterator`. Since generators are just syntactic sugar for iterators, I think this is okay.