### PR TITLE
Raise a GrammarError on empty string literal.

### DIFF
--- a/lark/load_grammar.py
+++ b/lark/load_grammar.py
@@ -448,6 +448,9 @@ def _literal_to_pattern(literal):
 
     s = eval_escaping(x)
 
+    if s == "":
+        raise GrammarError("Can't have empty terminals (offending literal: %s)" % literal.value)
+
     if literal.type == 'STRING':
         s = s.replace('\\\\', '\\')
         return PatternStr(s, flags, raw=literal.value)

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -22,6 +22,10 @@ class TestGrammar(TestCase):
                 else:
                     assert False, "example did not raise an error"
 
+    def test_empty_literal(self):
+        # Issues #888
+        self.assertRaises(GrammarError, Lark, "start: \"\"")
+
     def test_override_rule(self):
         # Overrides the 'sep' template in existing grammar to add an optional terminating delimiter
         # Thus extending it beyond its original capacity


### PR DESCRIPTION
Closes #888.

Previously empty string literals instead failed when trying to create a name because we try to access the `[0]` element, which of course doesn't exist. I can't really imagine a situation where empty literals are useful, so I decided to instead raise the correct exception now.