### PR TITLE
fix tree_matcher when keep_all_tokens=True by setting sym.filter_out …

### DIFF
--- a/lark/load_grammar.py
+++ b/lark/load_grammar.py
@@ -630,7 +630,10 @@ class Grammar:
                 else:
                     exp_options = options
 
-                assert all(isinstance(x, Symbol) for x in expansion), expansion
+                for sym in expansion:
+                    assert isinstance(sym, Symbol)
+                    if sym.is_term and exp_options and exp_options.keep_all_tokens:
+                        sym.filter_out = False
                 rule = Rule(NonTerminal(name), expansion, i, alias, exp_options)
                 compiled_rules.append(rule)
 


### PR DESCRIPTION
…correctly.

Previously `filter_out` might have the wrong value. Inside of tree_matcher (and especially reconstructor) the rule options are not accessible. The easiest fix is to just make sure `sym.filter_out` is correct.

Failing example:

```
start: _A
_A: "a"
```

Wouldn't get reconstructed when `keep_all_tokens=True`