### PR TITLE
Remove ineffective description-file key from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,4 @@ zip_safe=
 universal = 1
 
 [metadata]
-description-file = README.md
 license_file = LICENSE
-


### PR DESCRIPTION
Hi,
setuptools warns that:
> UserWarning: Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead

This key doesn't seem to do anything unless you use pbr so I simply dropped it.