### PR TITLE
Run tests against Python 3.10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9.0-rc - 3.9, pypy2, pypy3]
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10.0-rc - 3.10, pypy2, pypy3]
 
     steps:
       - uses: actions/checkout@v2

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34, py35, py36, py37, py38, py39, pypy, pypy3
+envlist = py27, py34, py35, py36, py37, py38, py39, py310, pypy, pypy3
 skip_missing_interpreters=true
 
 [travis]


### PR DESCRIPTION
Stable release is expected on 2021-10-04, see https://www.python.org/dev/peps/pep-0619/#release-schedule