### PR TITLE
Generic tree typing

### DIFF
--- a/lark/__init__.py
+++ b/lark/__init__.py
@@ -1,5 +1,5 @@
 from .utils import logger
-from .tree import Tree
+from .tree import Tree, ParseTree
 from .visitors import Transformer, Visitor, v_args, Discard, Transformer_NonRecursive
 from .exceptions import (ParseError, LexError, GrammarError, UnexpectedToken,
                          UnexpectedInput, UnexpectedCharacters, UnexpectedEOF, LarkError)

--- a/lark/lark.py
+++ b/lark/lark.py
@@ -7,6 +7,7 @@ from typing import (
 )
 if TYPE_CHECKING:
     from .parsers.lalr_interactive_parser import InteractiveParser
+    from .tree import ParseTree
     from .visitors import Transformer
     if sys.version_info >= (3, 8):
         from typing import Literal
@@ -591,7 +592,7 @@ class Lark(Serialize):
         """
         return self.parser.parse_interactive(text, start=start)
 
-    def parse(self, text: str, start: Optional[str]=None, on_error: 'Optional[Callable[[UnexpectedInput], bool]]'=None) -> Tree:
+    def parse(self, text: str, start: Optional[str]=None, on_error: 'Optional[Callable[[UnexpectedInput], bool]]'=None) -> 'ParseTree':
         """Parse the given text, according to the options provided.
 
         Parameters:

--- a/lark/reconstruct.py
+++ b/lark/reconstruct.py
@@ -4,7 +4,7 @@ from typing import List, Dict, Union, Callable, Iterable, Optional
 import unicodedata
 
 from .lark import Lark
-from .tree import Tree
+from .tree import Tree, ParseTree
 from .visitors import Transformer_InPlace
 from .lexer import Token, PatternStr, TerminalDef
 from .grammar import Terminal, NonTerminal, Symbol
@@ -94,7 +94,7 @@ class Reconstructor(TreeMatcher):
             else:
                 yield item
 
-    def reconstruct(self, tree: Tree, postproc: Optional[Callable[[Iterable[str]], Iterable[str]]]=None, insert_spaces: bool=True) -> str:
+    def reconstruct(self, tree: ParseTree, postproc: Optional[Callable[[Iterable[str]], Iterable[str]]]=None, insert_spaces: bool=True) -> str:
         x = self._reconstruct(tree)
         if postproc:
             x = postproc(x)

--- a/lark/tree.py
+++ b/lark/tree.py
@@ -183,17 +183,17 @@ class SlottedTree(Tree):
     __slots__ = 'data', 'children', 'rule', '_meta'
 
 
-def pydot__tree_to_png(tree: Tree[Any], filename: str, rankdir: 'Literal["TB", "LR", "BT", "RL"]'="LR", **kwargs) -> None:
+def pydot__tree_to_png(tree: Tree, filename: str, rankdir: 'Literal["TB", "LR", "BT", "RL"]'="LR", **kwargs) -> None:
     graph = pydot__tree_to_graph(tree, rankdir, **kwargs)
     graph.write_png(filename)
 
 
-def pydot__tree_to_dot(tree: Tree[Any], filename, rankdir="LR", **kwargs):
+def pydot__tree_to_dot(tree: Tree, filename, rankdir="LR", **kwargs):
     graph = pydot__tree_to_graph(tree, rankdir, **kwargs)
     graph.write(filename)
 
 
-def pydot__tree_to_graph(tree: Tree[Any], rankdir="LR", **kwargs):
+def pydot__tree_to_graph(tree: Tree, rankdir="LR", **kwargs):
     """Creates a colorful image that represents the tree (data+children, without meta)
 
     Possible values for `rankdir` are "TB", "LR", "BT", "RL", corresponding to

--- a/lark/tree.py
+++ b/lark/tree.py
@@ -36,6 +36,7 @@ class Meta:
 
 
 _Leaf_T = TypeVar("_Leaf_T")
+Branch = Union[_Leaf_T, 'Tree[_Leaf_T]']
 
 
 class Tree(Generic[_Leaf_T]):
@@ -52,9 +53,9 @@ class Tree(Generic[_Leaf_T]):
     """
 
     data: str
-    children: 'List[Union[_Leaf_T, Tree[_Leaf_T]]]'
+    children: 'List[Branch[_Leaf_T]]'
 
-    def __init__(self, data: str, children: 'List[Union[_Leaf_T, Tree[_Leaf_T]]]', meta: Optional[Meta]=None) -> None:
+    def __init__(self, data: str, children: 'List[Branch[_Leaf_T]]', meta: Optional[Meta]=None) -> None:
         self.data = data
         self.children = children
         self._meta = meta
@@ -135,7 +136,7 @@ class Tree(Generic[_Leaf_T]):
             kid = self.children[i]
             self.children[i:i+1] = kid.children
 
-    def scan_values(self, pred: 'Callable[[Union[_Leaf_T, Tree[_Leaf_T]]], bool]') -> Iterator[_Leaf_T]:
+    def scan_values(self, pred: 'Callable[[Branch[_Leaf_T]], bool]') -> Iterator[_Leaf_T]:
         """Return all values in the tree that evaluate pred(value) as true.
 
         This can be used to find all the tokens in the tree.
@@ -171,7 +172,7 @@ class Tree(Generic[_Leaf_T]):
     def copy(self) -> 'Tree[_Leaf_T]':
         return type(self)(self.data, self.children)
 
-    def set(self, data: str, children: 'List[Union[_Leaf_T, Tree[_Leaf_T]]]') -> None:
+    def set(self, data: str, children: 'List[Branch[_Leaf_T]]') -> None:
         self.data = data
         self.children = children
 

--- a/lark/tree.py
+++ b/lark/tree.py
@@ -7,10 +7,10 @@ except ImportError:
 import sys
 from copy import deepcopy
 
-from typing import List, Callable, Iterator, Union, Optional, TYPE_CHECKING
+from typing import List, Callable, Iterator, Union, Optional, Generic, TypeVar, Any, TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from .lexer import TerminalDef
+    from .lexer import TerminalDef, Token
     if sys.version_info >= (3, 8):
         from typing import Literal
     else:
@@ -35,7 +35,10 @@ class Meta:
         self.empty = True
 
 
-class Tree(object):
+_Leaf_T = TypeVar("_Leaf_T")
+
+
+class Tree(Generic[_Leaf_T]):
     """The main tree class.
 
     Creates a new tree, and stores "data" and "children" in attributes of the same name.
@@ -49,9 +52,9 @@ class Tree(object):
     """
 
     data: str
-    children: 'List[Union[str, Tree]]'
+    children: 'List[Union[_Leaf_T, Tree[_Leaf_T]]]'
 
-    def __init__(self, data: str, children: 'List[Union[str, Tree]]', meta: Optional[Meta]=None) -> None:
+    def __init__(self, data: str, children: 'List[Union[_Leaf_T, Tree[_Leaf_T]]]', meta: Optional[Meta]=None) -> None:
         self.data = data
         self.children = children
         self._meta = meta
@@ -100,7 +103,7 @@ class Tree(object):
     def __hash__(self) -> int:
         return hash((self.data, tuple(self.children)))
 
-    def iter_subtrees(self) -> 'Iterator[Tree]':
+    def iter_subtrees(self) -> 'Iterator[Tree[_Leaf_T]]':
         """Depth-first iteration.
 
         Iterates over all the subtrees, never returning to the same node twice (Lark's parse-tree is actually a DAG).
@@ -109,17 +112,18 @@ class Tree(object):
         subtrees = OrderedDict()
         for subtree in queue:
             subtrees[id(subtree)] = subtree
-            queue += [c for c in reversed(subtree.children)
+            # Reason for type ignore https://github.com/python/mypy/issues/10999
+            queue += [c for c in reversed(subtree.children)  # type: ignore
                       if isinstance(c, Tree) and id(c) not in subtrees]
 
         del queue
         return reversed(list(subtrees.values()))
 
-    def find_pred(self, pred: 'Callable[[Tree], bool]') -> 'Iterator[Tree]':
+    def find_pred(self, pred: 'Callable[[Tree[_Leaf_T]], bool]') -> 'Iterator[Tree[_Leaf_T]]':
         """Returns all nodes of the tree that evaluate pred(node) as true."""
         return filter(pred, self.iter_subtrees())
 
-    def find_data(self, data: str) -> 'Iterator[Tree]':
+    def find_data(self, data: str) -> 'Iterator[Tree[_Leaf_T]]':
         """Returns all nodes of the tree whose data equals the given data."""
         return self.find_pred(lambda t: t.data == data)
 
@@ -131,7 +135,7 @@ class Tree(object):
             kid = self.children[i]
             self.children[i:i+1] = kid.children
 
-    def scan_values(self, pred: 'Callable[[Union[str, Tree]], bool]') -> Iterator[str]:
+    def scan_values(self, pred: 'Callable[[Union[_Leaf_T, Tree[_Leaf_T]]], bool]') -> Iterator[_Leaf_T]:
         """Return all values in the tree that evaluate pred(value) as true.
 
         This can be used to find all the tokens in the tree.
@@ -164,30 +168,32 @@ class Tree(object):
     def __deepcopy__(self, memo):
         return type(self)(self.data, deepcopy(self.children, memo), meta=self._meta)
 
-    def copy(self) -> 'Tree':
+    def copy(self) -> 'Tree[_Leaf_T]':
         return type(self)(self.data, self.children)
 
-    def set(self, data: str, children: 'List[Union[str, Tree]]') -> None:
+    def set(self, data: str, children: 'List[Union[_Leaf_T, Tree[_Leaf_T]]]') -> None:
         self.data = data
         self.children = children
 
+
+ParseTree = Tree['Token']
 
 
 class SlottedTree(Tree):
     __slots__ = 'data', 'children', 'rule', '_meta'
 
 
-def pydot__tree_to_png(tree: Tree, filename: str, rankdir: 'Literal["TB", "LR", "BT", "RL"]'="LR", **kwargs) -> None:
+def pydot__tree_to_png(tree: Tree[Any], filename: str, rankdir: 'Literal["TB", "LR", "BT", "RL"]'="LR", **kwargs) -> None:
     graph = pydot__tree_to_graph(tree, rankdir, **kwargs)
     graph.write_png(filename)
 
 
-def pydot__tree_to_dot(tree, filename, rankdir="LR", **kwargs):
+def pydot__tree_to_dot(tree: Tree[Any], filename, rankdir="LR", **kwargs):
     graph = pydot__tree_to_graph(tree, rankdir, **kwargs)
     graph.write(filename)
 
 
-def pydot__tree_to_graph(tree, rankdir="LR", **kwargs):
+def pydot__tree_to_graph(tree: Tree[Any], rankdir="LR", **kwargs):
     """Creates a colorful image that represents the tree (data+children, without meta)
 
     Possible values for `rankdir` are "TB", "LR", "BT", "RL", corresponding to

--- a/lark/visitors.py
+++ b/lark/visitors.py
@@ -314,6 +314,12 @@ class Interpreter(_Decoratable, ABC, Generic[_Return_T, _Leaf_T]):
     """
 
     def visit(self, tree: Tree[_Leaf_T]) -> _Return_T:
+        # There are no guarantees on the type of the value produced by calling a user func for a
+        # child will produce. So only annotate the public method and use an internal method when
+        # visiting child trees.
+        return self._visit_tree(tree)
+
+    def _visit_tree(self, tree: Tree[_Leaf_T]):
         f = getattr(self, tree.data)
         wrapper = getattr(f, 'visit_wrapper', None)
         if wrapper is not None:
@@ -321,8 +327,8 @@ class Interpreter(_Decoratable, ABC, Generic[_Return_T, _Leaf_T]):
         else:
             return f(tree)
 
-    def visit_children(self, tree: Tree[_Leaf_T]) -> List[_Return_T]:
-        return [self.visit(child) if isinstance(child, Tree) else child
+    def visit_children(self, tree: Tree[_Leaf_T]) -> List:
+        return [self._visit_tree(child) if isinstance(child, Tree) else child
                 for child in tree.children]
 
     def __getattr__(self, name):

--- a/lark/visitors.py
+++ b/lark/visitors.py
@@ -3,7 +3,7 @@ from abc import ABC
 from functools import wraps
 
 from .utils import smart_decorator, combine_alternatives
-from .tree import Tree
+from .tree import Tree, Branch
 from .exceptions import VisitError, GrammarError
 from .lexer import Token
 
@@ -206,7 +206,7 @@ class Transformer_NonRecursive(Transformer):
     def transform(self, tree: Tree[_Leaf_T]) -> _Return_T:
         # Tree to postfix
         rev_postfix = []
-        q: List[Union[_Leaf_T, Tree[_Leaf_T]]] = [tree]
+        q: List[Branch[_Leaf_T]] = [tree]
         while q:
             t = q.pop()
             rev_postfix.append(t)

--- a/lark/visitors.py
+++ b/lark/visitors.py
@@ -138,7 +138,10 @@ class Transformer(_Decoratable, ABC, Generic[_Return_T, _Leaf_T]):
         "Transform the given tree, and return the final result"
         return self._transform_tree(tree)
 
-    def __mul__(self: 'Transformer[Tree[_Leaf_U], _Leaf_T]', other: 'Transformer[_Return_V, _Leaf_U]') -> 'TransformerChain[_Return_V, _Leaf_T]':
+    def __mul__(
+            self: 'Transformer[Tree[_Leaf_U], _Leaf_T]',
+            other: 'Union[Transformer[_Return_V, _Leaf_U], TransformerChain[_Return_V, _Leaf_U]]'
+    ) -> 'TransformerChain[_Return_V, _Leaf_T]':
         """Chain two transformers together, returning a new transformer.
         """
         return TransformerChain(self, other)
@@ -160,9 +163,9 @@ class Transformer(_Decoratable, ABC, Generic[_Return_T, _Leaf_T]):
 
 class TransformerChain(Generic[_Return_T, _Leaf_T]):
 
-    transformers: Tuple[Transformer, ...]
+    transformers: 'Tuple[Union[Transformer, TransformerChain], ...]'
 
-    def __init__(self, *transformers: Transformer) -> None:
+    def __init__(self, *transformers: 'Union[Transformer, TransformerChain]') -> None:
         self.transformers = transformers
 
     def transform(self, tree: Tree[_Leaf_T]) -> _Return_T:
@@ -170,7 +173,10 @@ class TransformerChain(Generic[_Return_T, _Leaf_T]):
             tree = t.transform(tree)
         return cast(_Return_T, tree)
 
-    def __mul__(self: 'TransformerChain[Tree[_Leaf_U], _Leaf_T]', other: Transformer[_Return_V, _Leaf_U]) -> 'TransformerChain[_Return_V, _Leaf_T]':
+    def __mul__(
+            self: 'TransformerChain[Tree[_Leaf_U], _Leaf_T]',
+            other: 'Union[Transformer[_Return_V, _Leaf_U], TransformerChain[_Return_V, _Leaf_U]]'
+    ) -> 'TransformerChain[_Return_V, _Leaf_T]':
         return TransformerChain(*self.transformers + (other,))
 
 

--- a/lark/visitors.py
+++ b/lark/visitors.py
@@ -55,7 +55,7 @@ class _Decoratable:
         return cls
 
 
-class Transformer(_Decoratable, ABC, Generic[_Return_T, _Leaf_T]):
+class Transformer(_Decoratable, ABC, Generic[_Leaf_T, _Return_T]):
     """Transformers visit each node of the tree, and run the appropriate method on it according to the node's data.
 
     Methods are provided by the user via inheritance, and called according to ``tree.data``.
@@ -139,9 +139,9 @@ class Transformer(_Decoratable, ABC, Generic[_Return_T, _Leaf_T]):
         return self._transform_tree(tree)
 
     def __mul__(
-            self: 'Transformer[Tree[_Leaf_U], _Leaf_T]',
-            other: 'Union[Transformer[_Return_V, _Leaf_U], TransformerChain[_Return_V, _Leaf_U]]'
-    ) -> 'TransformerChain[_Return_V, _Leaf_T]':
+            self: 'Transformer[_Leaf_T, Tree[_Leaf_U]]',
+            other: 'Union[Transformer[_Leaf_U, _Return_V], TransformerChain[_Leaf_U, _Return_V,]]'
+    ) -> 'TransformerChain[_Leaf_T, _Return_V]':
         """Chain two transformers together, returning a new transformer.
         """
         return TransformerChain(self, other)
@@ -161,7 +161,7 @@ class Transformer(_Decoratable, ABC, Generic[_Return_T, _Leaf_T]):
         return token
 
 
-class TransformerChain(Generic[_Return_T, _Leaf_T]):
+class TransformerChain(Generic[_Leaf_T, _Return_T]):
 
     transformers: 'Tuple[Union[Transformer, TransformerChain], ...]'
 
@@ -174,9 +174,9 @@ class TransformerChain(Generic[_Return_T, _Leaf_T]):
         return cast(_Return_T, tree)
 
     def __mul__(
-            self: 'TransformerChain[Tree[_Leaf_U], _Leaf_T]',
-            other: 'Union[Transformer[_Return_V, _Leaf_U], TransformerChain[_Return_V, _Leaf_U]]'
-    ) -> 'TransformerChain[_Return_V, _Leaf_T]':
+            self: 'TransformerChain[_Leaf_T, Tree[_Leaf_U]]',
+            other: 'Union[Transformer[_Leaf_U, _Return_V], TransformerChain[_Leaf_U, _Return_V]]'
+    ) -> 'TransformerChain[_Leaf_T, _Return_V]':
         return TransformerChain(*self.transformers + (other,))
 
 
@@ -307,7 +307,7 @@ class Visitor_Recursive(VisitorBase, Generic[_Leaf_T]):
         return tree
 
 
-class Interpreter(_Decoratable, ABC, Generic[_Return_T, _Leaf_T]):
+class Interpreter(_Decoratable, ABC, Generic[_Leaf_T, _Return_T]):
     """Interpreter walks the tree starting at the root.
 
     Visits the tree, starting with the root and finally the leaves (top-down)

--- a/lark/visitors.py
+++ b/lark/visitors.py
@@ -199,7 +199,7 @@ class Transformer_NonRecursive(Transformer):
 
     def transform(self, tree: Tree[_Leaf_T]) -> _Return_T:
         # Tree to postfix
-        rev_postfix: List[Union[_Leaf_T, Tree[_Leaf_T]]] = []
+        rev_postfix = []
         q: List[Union[_Leaf_T, Tree[_Leaf_T]]] = [tree]
         while q:
             t = q.pop()
@@ -208,7 +208,7 @@ class Transformer_NonRecursive(Transformer):
                 q += t.children
 
         # Postfix to tree
-        stack: List[Union[_Leaf_T, _Return_T]] = []
+        stack: List = []
         for x in reversed(rev_postfix):
             if isinstance(x, Tree):
                 size = len(x.children)
@@ -224,7 +224,10 @@ class Transformer_NonRecursive(Transformer):
                 stack.append(x)
 
         result, = stack  # We should have only one tree remaining
-        return result
+        # There are no guarantees on the type of the value produced by calling a user func for a
+        # child will produce. This means type system can't statically know that the final result is
+        # _Return_T. As a result a cast is required.
+        return cast(_Return_T, result)
 
 
 class Transformer_InPlaceRecursive(Transformer):

--- a/lark/visitors.py
+++ b/lark/visitors.py
@@ -1,4 +1,5 @@
 from typing import TypeVar, Tuple, List, Callable, Generic, Type, Union, Optional, cast
+
 from abc import ABC
 from functools import wraps
 
@@ -9,9 +10,14 @@ from .lexer import Token
 
 ###{standalone
 from inspect import getmembers, getmro
+import sys
+if sys.version_info >= (3, 8):
+    from typing import Protocol
+else:
+    from typing_extensions import Protocol
 
-_Return_T = TypeVar('_Return_T')
-_Return_V = TypeVar('_Return_V')
+_Return_T = TypeVar('_Return_T', covariant=True)
+_Return_V = TypeVar('_Return_V', covariant=True)
 _Leaf_T = TypeVar('_Leaf_T')
 _Leaf_U = TypeVar('_Leaf_U')
 _R = TypeVar('_R')
@@ -53,6 +59,21 @@ class _Decoratable:
 
     def __class_getitem__(cls, _):
         return cls
+
+
+class ITransformer(Protocol[_Leaf_T, _Return_T]):
+    """Base interface for classes that can transform a Tree"""
+
+    def transform(self, tree: Tree[_Leaf_T]) -> _Return_T:
+        """Transform the given tree, and return the final result"""
+        pass
+
+    def __mul__(
+            self: 'ITransformer[_Leaf_T, Tree[_Leaf_U]]',
+            other: 'ITransformer[_Leaf_U, _Return_V]'
+    ) -> 'ITransformer[_Leaf_T, _Return_V]':
+        """Chain two transformers together, returning a new transformer."""
+        pass
 
 
 class Transformer(_Decoratable, ABC, Generic[_Leaf_T, _Return_T]):
@@ -140,8 +161,8 @@ class Transformer(_Decoratable, ABC, Generic[_Leaf_T, _Return_T]):
 
     def __mul__(
             self: 'Transformer[_Leaf_T, Tree[_Leaf_U]]',
-            other: 'Union[Transformer[_Leaf_U, _Return_V], TransformerChain[_Leaf_U, _Return_V,]]'
-    ) -> 'TransformerChain[_Leaf_T, _Return_V]':
+            other: ITransformer[_Leaf_U, _Return_V]
+    ) -> ITransformer[_Leaf_T, _Return_V]:
         """Chain two transformers together, returning a new transformer.
         """
         return TransformerChain(self, other)
@@ -163,9 +184,9 @@ class Transformer(_Decoratable, ABC, Generic[_Leaf_T, _Return_T]):
 
 class TransformerChain(Generic[_Leaf_T, _Return_T]):
 
-    transformers: 'Tuple[Union[Transformer, TransformerChain], ...]'
+    transformers: Tuple[ITransformer, ...]
 
-    def __init__(self, *transformers: 'Union[Transformer, TransformerChain]') -> None:
+    def __init__(self, *transformers: ITransformer) -> None:
         self.transformers = transformers
 
     def transform(self, tree: Tree[_Leaf_T]) -> _Return_T:
@@ -175,8 +196,8 @@ class TransformerChain(Generic[_Leaf_T, _Return_T]):
 
     def __mul__(
             self: 'TransformerChain[_Leaf_T, Tree[_Leaf_U]]',
-            other: 'Union[Transformer[_Leaf_U, _Return_V], TransformerChain[_Leaf_U, _Return_V]]'
-    ) -> 'TransformerChain[_Leaf_T, _Return_V]':
+            other: ITransformer[_Leaf_U, _Return_V]
+    ) -> ITransformer[_Leaf_T, _Return_V]:
         return TransformerChain(*self.transformers + (other,))
 
 

--- a/setup.py
+++ b/setup.py
@@ -4,12 +4,12 @@ except ImportError:
     import re
 from setuptools import find_packages, setup
 
-__version__ ,= re.findall('__version__ = "(.*)"', open('lark/__init__.py').read())
+__version__ ,= re.findall('__version__: str = "(.*)"', open('lark/__init__.py').read())
 
 setup(
     name = "lark-parser",
     version = __version__,
-    packages = ['lark', 'lark.parsers', 'lark.tools', 'lark.grammars', 'lark.__pyinstaller', 'lark-stubs'],
+    packages = ['lark', 'lark.parsers', 'lark.tools', 'lark.grammars', 'lark.__pyinstaller'],
 
     requires = [],
     install_requires = [],
@@ -20,7 +20,7 @@ setup(
         "atomic_cache": ["atomicwrites"],
     },
 
-    package_data = {'': ['*.md', '*.lark'], 'lark-stubs': ['*.pyi']},
+    package_data = {'': ['*.md', '*.lark']},
 
     test_suite = 'tests.__main__',
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     packages = ['lark', 'lark.parsers', 'lark.tools', 'lark.grammars', 'lark.__pyinstaller'],
 
     requires = [],
-    install_requires = ['typing_extensions >= 3.7, < 5.0; python_version < "3.8"'],
+    install_requires = [],
 
     extras_require = {
         "regex": ["regex"],

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     packages = ['lark', 'lark.parsers', 'lark.tools', 'lark.grammars', 'lark.__pyinstaller'],
 
     requires = [],
-    install_requires = [],
+    install_requires = ['typing_extensions >= 3.7, < 5.0; python_version < "3.8"'],
 
     extras_require = {
         "regex": ["regex"],

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,2 @@
 Js2Py==0.68
 regex
-typing_extensions >= 3.7, < 5.0; python_version < "3.8"

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,3 @@
 Js2Py==0.68
 regex
+typing_extensions >= 3.7, < 5.0; python_version < "3.8"


### PR DESCRIPTION
* Updates the type information for `Tree` so that it is generic based on the type of the child leaf.
* Adjusts the various classes that operate on trees to also understand the type of trees they can operate on.
* Add `ParseTree` alias so that it is easy to refer to tree produced by the lark parser.

The changes don't introduce any new `mypy` errors, but there is one case where more type information demonstrated an existing inconsistency.

Addresses #966 