### PR TITLE
Make transformers composable

### DIFF
--- a/examples/advanced/advanced_transformers.py
+++ b/examples/advanced/advanced_transformers.py
@@ -1,3 +1,14 @@
+"""
+Transformer merging
+==================
+
+This example is intended to show how transformers can be merged in order to
+keep the individual steps clean and simple.
+
+.. note::
+    The imported rules will have to be aliased according to the file it is in.
+    (See `storage.lark` for an implementation of this idea.)
+"""
 from lark import Lark, Tree
 from json import dumps
 from lark.visitors import Transformer, merge_transformers, v_args

--- a/examples/advanced/advanced_transformers.py
+++ b/examples/advanced/advanced_transformers.py
@@ -1,0 +1,44 @@
+from lark import Lark, Tree
+from lark.visitors import Transformer, merge_transformers, v_args
+
+class JsonTreeToJson(Transformer):
+    @v_args(inline=True)
+    def string(self, s):
+        return s[1:-1].replace('\\"', '"')
+
+    array = list
+    pair = tuple
+    object = dict
+    number = v_args(inline=True)(float)
+
+    null = lambda self, _: None
+    true = lambda self, _: True
+    false = lambda self, _: False
+
+class CsvTreeToPandasDict(Transformer):
+    INT = int
+    FLOAT = float
+    SIGNED_FLOAT = float
+    WORD = str
+
+    def start(self, children):
+        data = {}
+
+        header = children[0].children
+        for heading in header:
+            data[heading] = []
+
+        for row in children[1:]:
+            for i, element in enumerate(row):
+                data[header[i]].append(element)
+
+if __name__ == "__main__":
+    merged = merge_transformers(csv=CsvTreeToPandasDict, json=JsonTreeToJson)
+    print(dir(merged))
+    parser = Lark.open("storage.lark")
+    tree = parser.parse("""# file lines author
+data.json 12 Robin
+data.csv  30 erezsh
+compiler.py 123123 Megalng
+""")
+    print("CSV data in pandas form:", merged.transform(tree))

--- a/examples/advanced/csv.lark
+++ b/examples/advanced/csv.lark
@@ -1,8 +1,8 @@
 start: header _NL row+
 header: "#" " "? (WORD _SEPARATOR?)+
 row: (_anything _SEPARATOR?)+ _NL
-_anything: INT | WORD | /[a-zA-z.;\\\/]+/ | FLOAT | SIGNED_FLOAT
-
+_anything: INT | WORD | NON_SEPARATOR_STRING | FLOAT | SIGNED_FLOAT
+NON_SEPARATOR_STRING: /[a-zA-z.;\\\/]+/
 _SEPARATOR: /[  ]+/
           | "\t"
           | ","

--- a/examples/advanced/csv.lark
+++ b/examples/advanced/csv.lark
@@ -1,0 +1,14 @@
+start: header _NL row+
+header: "#" " "? (WORD _SEPARATOR?)+
+row: (_anything _SEPARATOR?)+ _NL
+_anything: INT | WORD | /[a-zA-z.;\\\/]+/ | FLOAT | SIGNED_FLOAT
+
+_SEPARATOR: /[  ]+/
+          | "\t"
+          | ","
+
+%import common.NEWLINE -> _NL
+%import common.WORD
+%import common.INT
+%import common.FLOAT
+%import common.SIGNED_FLOAT

--- a/examples/advanced/json.lark
+++ b/examples/advanced/json.lark
@@ -1,0 +1,22 @@
+?start: value
+
+?value: object
+      | array
+      | string
+      | SIGNED_NUMBER      -> number
+      | "true"             -> true
+      | "false"            -> false
+      | "null"             -> null
+
+array  : "[" [value ("," value)*] "]"
+object : "{" [pair ("," pair)*] "}"
+pair   : string ":" value
+
+string : ESCAPED_STRING
+
+%import common.ESCAPED_STRING
+%import common.SIGNED_NUMBER
+%import common.WS
+
+%ignore WS
+

--- a/examples/advanced/json.lark
+++ b/examples/advanced/json.lark
@@ -8,15 +8,12 @@
       | "false"            -> false
       | "null"             -> null
 
-array  : "[" [value ("," value)*] "]"
-object : "{" [pair ("," pair)*] "}"
-pair   : string ":" value
+array  : "[" _WS? [value ("," _WS? value)*] "]"
+object : "{" _WS? [pair ("," _WS? pair)*] "}"
+pair   : string ":" _WS value
 
 string : ESCAPED_STRING
 
 %import common.ESCAPED_STRING
 %import common.SIGNED_NUMBER
-%import common.WS
-
-%ignore WS
-
+%import common.WS -> _WS

--- a/examples/advanced/storage.lark
+++ b/examples/advanced/storage.lark
@@ -1,5 +1,8 @@
 start: csv__start
      | json__start
 
+// Renaming of the import variables is required, as they
+// receive the namespace of this folder.
+// See: https://github.com/lark-parser/lark/pull/973#issuecomment-907287565
 %import .csv.start -> csv__start
 %import .json.start -> json__start

--- a/examples/advanced/storage.lark
+++ b/examples/advanced/storage.lark
@@ -2,7 +2,7 @@ start: csv__start
      | json__start
 
 // Renaming of the import variables is required, as they
-// receive the namespace of this folder.
+// receive the namespace of this file.
 // See: https://github.com/lark-parser/lark/pull/973#issuecomment-907287565
 %import .csv.start -> csv__start
 %import .json.start -> json__start

--- a/examples/advanced/storage.lark
+++ b/examples/advanced/storage.lark
@@ -1,5 +1,5 @@
-start: _csv_start
-     | _json_start
+start: csv__start
+     | json__start
 
-%import .csv.start -> _csv_start
-%import .json.start -> _json_start
+%import .csv.start -> csv__start
+%import .json.start -> json__start

--- a/examples/advanced/storage.lark
+++ b/examples/advanced/storage.lark
@@ -1,0 +1,5 @@
+start: _csv_start
+     | _json_start
+
+%import .csv.start -> _csv_start
+%import .json.start -> _json_start

--- a/lark/visitors.py
+++ b/lark/visitors.py
@@ -194,7 +194,7 @@ def merge_transformers(base_transformer=None, **kwargs):
                     set(base_transformer.__dict__.keys()))
             for key in intersection:
                 assert transformer.__dict__[key] == base_transformer.__dict__[key], \
-                        f"Property '{key}' already exists on the base transformer"
+                        "Property '{key}' already exists on the base transformer".format(key=key)
             base_transformer.__dict__.update(transformer.__dict__)
 
         for attr in dir(transformer):
@@ -203,7 +203,7 @@ def merge_transformers(base_transformer=None, **kwargs):
             if callable(method):
                 if not method_name in dir(Transformer()):
                     assert not method_name in dir(base_transformer), \
-                        f"Method '{method_name}' already present in base transformer"
+                        "Method '{method_name}' already present in base transformer".format(method_name=method_name)
                     setattr(base_transformer, prefix + attr, method)
 
     return base_transformer

--- a/lark/visitors.py
+++ b/lark/visitors.py
@@ -185,11 +185,24 @@ def merge_transformers(base_transformer=Transformer(), **kwargs):
     """
     for prefix, transformer in kwargs.items():
         prefix += "__"
+
+        if transformer.__dict__ != base_transformer.__dict__:
+            intersection = set(transformer.__dict__.keys()).intersection(
+                    set(base_transformer.__dict__.keys()))
+            for key in intersection:
+                assert transformer.__dict__[key] == base_transformer.__dict__[key], \
+                        f"Property '{key}' already exists on the base transformer"
+            base_transformer.__dict__.update(transformer.__dict__)
+
         for attr in dir(transformer):
+            method_name = prefix + attr
             method = getattr(transformer, attr)
             if callable(method):
-                if not prefix + attr in dir(base_transformer):
+                if not method_name in dir(Transformer()):
+                    assert not method_name in dir(base_transformer), \
+                        f"Method '{method_name}' already present in base transformer"
                     setattr(base_transformer, prefix + attr, method)
+
     return base_transformer
 
 

--- a/lark/visitors.py
+++ b/lark/visitors.py
@@ -149,11 +149,10 @@ class Transformer(_Decoratable):
         return token
 
 
-def merge_transformers(base_transformer=None, infix="__", **kwargs):
+def merge_transformers(base_transformer=None, **kwargs):
     """
     Paramaters:
         :param base_transformer: Transformer that all other transformers will be added to.
-        :param infix: String that will sit between the key and the method name. (e.g. `merge_transformers(infix="_a_", module=T())` will result in a Transformer that has the methods of `T()` prefixed with `"module_a_"`).
         :param \**kwargs: Key-value arguments providing the prefix for the methods of the transformer and the Transformers themselves.
 
     Compose a new transformer from a base and the in the `**kwargs` provided Transformer instances.
@@ -191,6 +190,7 @@ def merge_transformers(base_transformer=None, infix="__", **kwargs):
     In the above code block `regular_transformer` and `composed_transformer`
     should behave identically.
     """
+    infix = "__"
 
     if base_transformer is None:
         base_transformer = Transformer()

--- a/lark/visitors.py
+++ b/lark/visitors.py
@@ -125,6 +125,44 @@ class Transformer(_Decoratable):
         children = list(self._transform_children(tree.children))
         return self._call_userfunc(tree, children)
 
+    def merge(self, other, prefix=""):
+        """
+        Add the methods of other transformer to this one.
+
+        This method is meant to aid in the maintenance of imports.
+
+        Example:
+        ```python
+        class T1(Transformer):
+            def method_on_main_grammar(self, children):
+                # Do something
+                pass
+
+            def imported_grammar__method(self, children):
+                # Do something else
+                pass
+
+        class TMain(Transformer):
+            def method_on_main_grammar(self, children):
+                # Do something
+                pass
+
+        class TImportedGrammar(Transformer):
+            def method(self, children):
+                # Do something else
+                pass
+
+        regular_transformer = T1()
+        composed_transformer = TMain().merge(TImportedGrammar(),
+                                             prefix="imported_grammar")
+        ```
+        In the above code block `regular_transformer` and `composed_transformer`
+        should behave identically.
+        """
+        for attr, val in other.__dict__.items():
+            if not attr in Transformer().__dict__.keys():
+                setattr(self, prefix + attr, val)
+
     def transform(self, tree):
         "Transform the given tree, and return the final result"
         return self._transform_tree(tree)

--- a/lark/visitors.py
+++ b/lark/visitors.py
@@ -125,44 +125,6 @@ class Transformer(_Decoratable):
         children = list(self._transform_children(tree.children))
         return self._call_userfunc(tree, children)
 
-    def merge(self, other, prefix=""):
-        """
-        Add the methods of other transformer to this one.
-
-        This method is meant to aid in the maintenance of imports.
-
-        Example:
-        ```python
-        class T1(Transformer):
-            def method_on_main_grammar(self, children):
-                # Do something
-                pass
-
-            def imported_grammar__method(self, children):
-                # Do something else
-                pass
-
-        class TMain(Transformer):
-            def method_on_main_grammar(self, children):
-                # Do something
-                pass
-
-        class TImportedGrammar(Transformer):
-            def method(self, children):
-                # Do something else
-                pass
-
-        regular_transformer = T1()
-        composed_transformer = TMain().merge(TImportedGrammar(),
-                                             prefix="imported_grammar")
-        ```
-        In the above code block `regular_transformer` and `composed_transformer`
-        should behave identically.
-        """
-        for attr, val in other.__dict__.items():
-            if not attr in Transformer().__dict__.keys():
-                setattr(self, prefix + attr, val)
-
     def transform(self, tree):
         "Transform the given tree, and return the final result"
         return self._transform_tree(tree)
@@ -185,6 +147,50 @@ class Transformer(_Decoratable):
         Can be overridden. Defaults to returning the token as-is.
         """
         return token
+
+
+def merge_transformers(base_transformer=Transformer(), **kwargs):
+    """
+    Add the methods of other transformer to this one.
+
+    This method is meant to aid in the maintenance of imports.
+
+    Example:
+    ```python
+    class T1(Transformer):
+        def method_on_main_grammar(self, children):
+            # Do something
+            pass
+
+        def imported_grammar__method(self, children):
+            # Do something else
+            pass
+
+    class TMain(Transformer):
+        def method_on_main_grammar(self, children):
+            # Do something
+            pass
+
+    class TImportedGrammar(Transformer):
+        def method(self, children):
+            # Do something else
+            pass
+
+    regular_transformer = T1()
+    composed_transformer = merge_transformers(TMain(),
+                                              imported_grammar=TImportedGrammar())
+    ```
+    In the above code block `regular_transformer` and `composed_transformer`
+    should behave identically.
+    """
+    for prefix, transformer in kwargs.items():
+        prefix += "__"
+        for attr in dir(transformer):
+            method = getattr(transformer, attr)
+            if callable(method):
+                if not prefix + attr in dir(base_transformer):
+                    setattr(base_transformer, prefix + attr, method)
+    return base_transformer
 
 
 class InlineTransformer(Transformer):   # XXX Deprecated

--- a/lark/visitors.py
+++ b/lark/visitors.py
@@ -189,16 +189,18 @@ def merge_transformers(base_transformer=None, **kwargs):
     for prefix, transformer in kwargs.items():
         prefix += "__"
 
-        for attr in dir(transformer):
-            method_name = prefix + attr
-            method = getattr(transformer, attr)
-            if callable(method):
-                if not method_name in dir(Transformer()):
-                    if method_name in dir(base_transformer):
-                        raise AttributeError(
-                            ("Method '{method_name}' already present "
-                             "in base transformer").format(method_name=method_name))
-                    setattr(base_transformer, prefix + attr, method)
+        for method_name in dir(transformer):
+            method = getattr(transformer, method_name)
+            if not callable(method):
+                continue
+            if method_name in dir(Transformer()):
+                continue
+            new_method_name = prefix + method_name
+            if prefix + method_name in dir(base_transformer):
+                raise AttributeError(
+                    ("Method '{new_method_name}' already present in base "
+                     "transformer").format(new_method_name=new_method_name))
+            setattr(base_transformer, new_method_name, method)
 
     return base_transformer
 

--- a/lark/visitors.py
+++ b/lark/visitors.py
@@ -149,7 +149,7 @@ class Transformer(_Decoratable):
         return token
 
 
-def merge_transformers(base_transformer=Transformer(), **kwargs):
+def merge_transformers(base_transformer=None, **kwargs):
     """
     Add the methods of other transformer to this one.
 
@@ -183,6 +183,9 @@ def merge_transformers(base_transformer=Transformer(), **kwargs):
     In the above code block `regular_transformer` and `composed_transformer`
     should behave identically.
     """
+
+    if base_transformer is None:
+        base_transformer = Transformer()
     for prefix, transformer in kwargs.items():
         prefix += "__"
 

--- a/lark/visitors.py
+++ b/lark/visitors.py
@@ -201,7 +201,7 @@ def merge_transformers(base_transformer=None, **kwargs):
             method = getattr(transformer, method_name)
             if not callable(method):
                 continue
-            if method_name in dir(Transformer()):
+            if method_name.startswith("_") or method_name == "transform":
                 continue
             new_method_name = prefix + method_name
             if prefix + method_name in dir(base_transformer):

--- a/lark/visitors.py
+++ b/lark/visitors.py
@@ -149,11 +149,19 @@ class Transformer(_Decoratable):
         return token
 
 
-def merge_transformers(base_transformer=None, **kwargs):
+def merge_transformers(base_transformer=None, infix="__", **kwargs):
     """
-    Add the methods of other transformer to this one.
+    Paramaters:
+        :param base_transformer: Transformer that all other transformers will be added to.
+        :param infix: String that will sit between the key and the method name. (e.g. `merge_transformers(infix="_a_", module=T())` will result in a Transformer that has the methods of `T()` prefixed with `"module_a_"`).
+        :param \**kwargs: Key-value arguments providing the prefix for the methods of the transformer and the Transformers themselves.
 
-    This method is meant to aid in the maintenance of imports.
+    Compose a new transformer from a base and the in the `**kwargs` provided Transformer instances.
+
+    The key should match the grammar file that the Transformer is supposed to manipulate.
+
+    This method is meant to aid the composing of large transformers that
+    manipulate grammars that cross multiple lark files.
 
     Example:
     ```python
@@ -187,7 +195,7 @@ def merge_transformers(base_transformer=None, **kwargs):
     if base_transformer is None:
         base_transformer = Transformer()
     for prefix, transformer in kwargs.items():
-        prefix += "__"
+        prefix += infix
 
         for method_name in dir(transformer):
             method = getattr(transformer, method_name)

--- a/lark/visitors.py
+++ b/lark/visitors.py
@@ -189,21 +189,15 @@ def merge_transformers(base_transformer=None, **kwargs):
     for prefix, transformer in kwargs.items():
         prefix += "__"
 
-        if transformer.__dict__ != base_transformer.__dict__:
-            intersection = set(transformer.__dict__.keys()).intersection(
-                    set(base_transformer.__dict__.keys()))
-            for key in intersection:
-                assert transformer.__dict__[key] == base_transformer.__dict__[key], \
-                        "Property '{key}' already exists on the base transformer".format(key=key)
-            base_transformer.__dict__.update(transformer.__dict__)
-
         for attr in dir(transformer):
             method_name = prefix + attr
             method = getattr(transformer, attr)
             if callable(method):
                 if not method_name in dir(Transformer()):
-                    assert not method_name in dir(base_transformer), \
-                        "Method '{method_name}' already present in base transformer".format(method_name=method_name)
+                    if method_name in dir(base_transformer):
+                        raise AttributeError(
+                            ("Method '{method_name}' already present "
+                             "in base transformer").format(method_name=method_name))
                     setattr(base_transformer, prefix + attr, method)
 
     return base_transformer

--- a/tests/test_trees.py
+++ b/tests/test_trees.py
@@ -294,7 +294,6 @@ class TestTrees(TestCase):
 
         try:
             composed = merge_transformers(T1(), module=T4())
-            print(dir(composed))
         except AttributeError:
             self.fail("Should be able to add classes that do not conflict")
 

--- a/tests/test_trees.py
+++ b/tests/test_trees.py
@@ -285,29 +285,8 @@ class TestTrees(TestCase):
         t1_res = T1().transform(tree)
         composed_res = merge_transformers(T2(), module=T3()).transform(tree)
         self.assertEqual(t1_res, composed_res)
-        with self.assertRaises(AssertionError) as cm:
+        with self.assertRaises(AttributeError):
             merge_transformers(T1(), module=T3())
-        self.assertEqual(str(cm.exception),
-                         "Method 'module__main' already present in base transformer")
-
-        t2 = T2()
-        t3 = T3()
-        t2.shared = "A"
-        t3.shared = "A"
-        t3.not_shared = "B"
-        try:
-            composed = merge_transformers(t2, module=t3)
-        except AssertionError:
-            self.fail("Should not fail to merge transformers with identical properties")
-
-        self.assertEqual(composed.shared, "A")
-        self.assertEqual(composed.not_shared, "B")
-
-        t2.shared = "B"
-        with self.assertRaises(AssertionError) as cm2:
-            merge_transformers(t2, module=t3)
-        self.assertEqual(str(cm2.exception),
-                         "Property 'shared' already exists on the base transformer")
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_trees.py
+++ b/tests/test_trees.py
@@ -282,11 +282,21 @@ class TestTrees(TestCase):
                     prod *= child
                 return prod
 
+        class T4(Transformer):
+            def other_aspect(self, children):
+                pass
+
         t1_res = T1().transform(tree)
         composed_res = merge_transformers(T2(), module=T3()).transform(tree)
         self.assertEqual(t1_res, composed_res)
         with self.assertRaises(AttributeError):
             merge_transformers(T1(), module=T3())
+
+        try:
+            composed = merge_transformers(T1(), module=T4())
+            print(dir(composed))
+        except AttributeError:
+            self.fail("Should be able to add classes that do not conflict")
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_trees.py
+++ b/tests/test_trees.py
@@ -9,7 +9,7 @@ import functools
 from lark.tree import Tree
 from lark.lexer import Token
 from lark.visitors import Visitor, Visitor_Recursive, Transformer, Interpreter, visit_children_decor, v_args, Discard, Transformer_InPlace, \
-    Transformer_InPlaceRecursive, Transformer_NonRecursive
+    Transformer_InPlaceRecursive, Transformer_NonRecursive, merge_transformers
 
 
 class TestTrees(TestCase):
@@ -233,21 +233,60 @@ class TestTrees(TestCase):
 
         x = MyTransformer().transform( t )
         self.assertEqual(x, t2)
-    
+
     def test_transformer_variants(self):
         tree = Tree('start', [Tree('add', [Token('N', '1'), Token('N', '2')]), Tree('add', [Token('N', '3'), Token('N', '4')])])
         for base in (Transformer, Transformer_InPlace, Transformer_NonRecursive, Transformer_InPlaceRecursive):
             class T(base):
                 def add(self, children):
                     return sum(children)
-                
+
                 def N(self, token):
                     return int(token)
-            
+
             copied = copy.deepcopy(tree)
             result = T().transform(copied)
             self.assertEqual(result, Tree('start', [3, 7]))
 
+    def test_merge_transformers(self):
+        tree = Tree('start', [
+            Tree('main', [
+                Token("A", '1'), Token("B", '2')
+            ]),
+            Tree("module__main", [
+                Token("A", "2"), Token("B", "3")
+            ])
+        ])
+
+        class T1(Transformer):
+            A = int
+            B = int
+            main = sum
+            start = list
+            def module__main(self, children):
+                print("running T1")
+                prod = 1
+                for child in children:
+                    prod *= child
+                return prod
+
+        class T2(Transformer):
+            A = int
+            B = int
+            main = sum
+            start = list
+
+        class T3(Transformer):
+            def main(self, children):
+                print("running T3")
+                prod = 1
+                for child in children:
+                    prod *= child
+                return prod
+
+        t1_res = T1().transform(tree)
+        composed_res = merge_transformers(T2(), module=T3()).transform(tree)
+        self.assertEqual(t1_res, composed_res)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
In order to be able to allow Transformers to be maintainable over larger projects with lots of imports, it might be useful to be able to merge multiple transformers into one. I present here a minimal implementation for a method on transformers that would be able to do that. 

One issue that I see immediately is that methods on transformers already have a dedicated functionality (manipulate trees), so it would be better to keep the Transformer class as sparse as possible. Maybe instead of adding a method, it should be an independent function, though that would go against the OOP pattern.