### PR TITLE
Sort Options inside a TerminalTree

### DIFF
--- a/lark/load_grammar.py
+++ b/lark/load_grammar.py
@@ -614,6 +614,10 @@ class TerminalTreeToPattern(Transformer_NonRecursive):
         if len(exps) == 1:
             return exps[0]
 
+        # Do a bit of sorting to make sure that the longest option is returned
+        # (Python's re module otherwise prefers just 'l' when given (l|ll) and both could match)
+        exps.sort(key=lambda x: (-x.max_width, -x.min_width, -len(x.value)))
+
         pattern = '(?:%s)' % ('|'.join(i.to_regexp() for i in exps))
         return _make_joined_pattern(pattern, {i.flags for i in exps})
 

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -247,10 +247,8 @@ class TestGrammar(TestCase):
         self.assertRaises(UnexpectedInput, l.parse, u'A' * 8192)
 
     def test_large_terminal(self):
-        # TODO: The `reversed` below is required because otherwise the regex engine is happy
-        #       with just parsing 9 from the string 999 instead of consuming the longest
         g = "start: NUMBERS\n"
-        g += "NUMBERS: " + '|'.join('"%s"' % i for i in reversed(range(0, 1000)))
+        g += "NUMBERS: " + '|'.join('"%s"' % i for i in range(0, 1000))
 
         l = Lark(g, parser='lalr')
         for i in (0, 9, 99, 999):


### PR DESCRIPTION
Fixes the problem mentioned at the end of #970 and also inside of #977 (And I think it was mentioned in gitter in the last few days)

Note: This only fixes it for the common case, e.g. a direct listing of multiple options on after the other (e.g. `"a" | "ab"`). It probably doesn't fix it reliable when nesting is involved.

I think the sort key `(-x.max_width, -x.min_width, -len(x.value))` is correct/good enough, but I am not sure.