### PR TITLE
Improvements to type checking

### DIFF
--- a/lark/exceptions.py
+++ b/lark/exceptions.py
@@ -1,5 +1,6 @@
 from .utils import logger, NO_VALUE
-from typing import Dict, Iterable, Callable, Union, TypeVar, Tuple, Any, List, Set, Optional, Collection, TYPE_CHECKING
+from typing import Mapping, Iterable, Callable, Union, TypeVar, Tuple, Any, List, Set, Optional, Collection, \
+    TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .lexer import Token
@@ -73,7 +74,7 @@ class UnexpectedInput(LarkError):
             return (before + after + b'\n' + b' ' * len(before.expandtabs()) + b'^\n').decode("ascii", "backslashreplace")
 
     def match_examples(self, parse_fn: 'Callable[[str], Tree]', 
-                             examples: Union[Dict[T, Iterable[str]], Iterable[Tuple[T, Iterable[str]]]],
+                             examples: Union[Mapping[T, Iterable[str]], Iterable[Tuple[T, Iterable[str]]]],
                              token_type_match_fallback: bool=False,
                              use_accepts: bool=True
                          ) -> Optional[T]:

--- a/lark/tools/standalone.py
+++ b/lark/tools/standalone.py
@@ -30,7 +30,7 @@ from types import ModuleType
 from typing import (
     TypeVar, Generic, Type, Tuple, List, Dict, Iterator, Collection, Callable, Optional, FrozenSet, Any,
     Union, Iterable, IO, TYPE_CHECKING,
-    Pattern as REPattern, ClassVar, Set,
+    Pattern as REPattern, ClassVar, Set, Mapping
 )
 ###}
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ __version__ ,= re.findall('__version__: str = "(.*)"', open('lark/__init__.py').
 setup(
     name = "lark",
     version = __version__,
-    packages = ['lark', 'lark.parsers', 'lark.tools', 'lark.grammars', 'lark.__pyinstaller', 'lark-stubs'],
+    packages = ['lark', 'lark.parsers', 'lark.tools', 'lark.grammars', 'lark.__pyinstaller'],
 
     requires = [],
     install_requires = [],
@@ -20,7 +20,7 @@ setup(
         "atomic_cache": ["atomicwrites"],
     },
 
-    package_data = {'': ['*.md', '*.lark'], 'lark-stubs': ['*.pyi']},
+    package_data = {'': ['*.md', '*.lark'], 'lark': ['py.typed']},
 
     test_suite = 'tests.__main__',
 


### PR DESCRIPTION
- Improved/fixed the type of the ``examples`` parameter of the ``match_examples`` method of ``UnexpectedInput`` (Mapping vs. Dict)

- Added a py.typed marker file