### PR TITLE
Fix accepts

### DIFF
--- a/lark/exceptions.py
+++ b/lark/exceptions.py
@@ -245,9 +245,16 @@ class UnexpectedToken(ParseError, UnexpectedInput):
             self._accepts = self.interactive_parser and self.interactive_parser.accepts()
         return self._accepts
 
+    @property
+    def _safe_accepts(self):
+        try:
+            return self.accepts
+        except Exception:
+            return self.expected
+
     def __str__(self):
         message = ("Unexpected token %r at line %s, column %s.\n%s"
-                   % (self.token, self.line, self.column, self._format_expected(self.accepts or self.expected)))
+                   % (self.token, self.line, self.column, self._format_expected(self._safe_accepts or self.expected)))
         if self.token_history:
             message += "Previous tokens: %r\n" % self.token_history
 

--- a/lark/parsers/lalr_interactive_parser.py
+++ b/lark/parsers/lalr_interactive_parser.py
@@ -96,6 +96,9 @@ class InteractiveParser:
             if t.isupper(): # is terminal?
                 new_cursor = copy(self)
                 try:
+                    # We override the callbacks here because some Token callbacks might break
+                    # when passed an empty string, and we don't even want to use the result,
+                    # We are only interested in if this succeeds or not.
                     new_cursor.feed_token(Token(t, ''), _NoopCallbacks())
                 except UnexpectedToken:
                     pass

--- a/lark/parsers/lalr_parser.py
+++ b/lark/parsers/lalr_parser.py
@@ -113,12 +113,12 @@ class ParserState:
     def copy(self):
         return copy(self)
 
-    def feed_token(self, token, is_end=False):
+    def feed_token(self, token, is_end=False, override_callbacks=None):
         state_stack = self.state_stack
         value_stack = self.value_stack
         states = self.parse_conf.states
         end_state = self.parse_conf.end_state
-        callbacks = self.parse_conf.callbacks
+        callbacks = self.parse_conf.callbacks if override_callbacks is None else override_callbacks
 
         while True:
             state = state_stack[-1]

--- a/lark/utils.py
+++ b/lark/utils.py
@@ -8,9 +8,11 @@ import sys, re
 import logging
 logger: logging.Logger = logging.getLogger("lark")
 logger.addHandler(logging.StreamHandler())
-# Set to highest level, since we have some warnings amongst the code
+# Set to a high level, since we have some warnings amongst the code
 # By default, we should not output any log messages
-logger.setLevel(logging.CRITICAL)
+# We are using ERROR instead of CRITICAL since we want to report
+# about failed loading from cache.
+logger.setLevel(logging.ERROR)
 
 
 NO_VALUE = object()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -6,10 +6,7 @@ from lark import Lark, Tree, Transformer
 from lark.lexer import Lexer, Token
 import lark.lark as lark_module
 
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import BytesIO as StringIO
+from io import BytesIO as StringIO
 
 
 class MockFile(StringIO):

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -3,10 +3,7 @@ from contextlib import contextmanager
 from lark import Lark, logger
 from unittest import TestCase, main
 
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
+from io import StringIO
 
 @contextmanager
 def capture_log():

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -7,10 +7,7 @@ from lark import Lark
 from lark.tree import Tree
 from lark.tools import standalone
 
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
+from io import StringIO
 
 
 


### PR DESCRIPTION
Closes #1001 

Also does a bit of py2 cleanup, and changes the default logger level to `ERROR`. That change is only to keep the output of `.exception` in `Lark.__init__` when loading from cache fails.