### PR TITLE
Remove package `lark-stubs` from `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ __version__ ,= re.findall('__version__: str = "(.*)"', open('lark/__init__.py').
 setup(
     name = "lark",
     version = __version__,
-    packages = ['lark', 'lark.parsers', 'lark.tools', 'lark.grammars', 'lark.__pyinstaller', 'lark-stubs'],
+    packages = ['lark', 'lark.parsers', 'lark.tools', 'lark.grammars', 'lark.__pyinstaller'],
 
     requires = [],
     install_requires = [],
@@ -20,7 +20,7 @@ setup(
         "atomic_cache": ["atomicwrites"],
     },
 
-    package_data = {'': ['*.md', '*.lark'], 'lark-stubs': ['*.pyi']},
+    package_data = {'': ['*.md', '*.lark']},
 
     test_suite = 'tests.__main__',
 


### PR DESCRIPTION
The package was removed in PR lark-parser/lark#926.  `pip` fails when trying to install lark upstream:

> error: package directory 'lark-stubs' does not exist

It does work with this change.