### PR TITLE
Improved expected tokens returned in UnexpectedToken.

### DIFF
--- a/lark/exceptions.py
+++ b/lark/exceptions.py
@@ -197,7 +197,7 @@ class UnexpectedCharacters(LexError, UnexpectedInput):
         message = "No terminal matches '%s' in the current parser context, at line %d col %d" % (self.char, self.line, self.column)
         message += '\n\n' + self._context
         if self.allowed:
-            message += self._format_expected(self.allowed)
+            message += self._format_expected(sorted(self.allowed))
         if self.token_history:
             message += '\nPrevious tokens: %s\n' % ', '.join(repr(t) for t in self.token_history)
         return message
@@ -247,8 +247,9 @@ class UnexpectedToken(ParseError, UnexpectedInput):
         return self._accepts
 
     def __str__(self):
+        expected_str = self._format_expected(sorted(self.accepts or self.expected))
         message = ("Unexpected token %r at line %s, column %s.\n%s"
-                   % (self.token, self.line, self.column, self._format_expected(self.accepts or self.expected)))
+                   % (self.token, self.line, self.column, expected_str))
         if self.token_history:
             message += "Previous tokens: %r\n" % self.token_history
 

--- a/lark/lark.py
+++ b/lark/lark.py
@@ -66,6 +66,7 @@ class LarkOptions(Serialize):
     edit_terminals: Optional[Callable[[TerminalDef], TerminalDef]]
     import_paths: 'List[Union[str, Callable[[Union[None, str, PackageResource], str], Tuple[str, str]]]]'
     source_path: Optional[str]
+    accurate_exceptions: bool
 
     OPTIONS_DOC = """
     **===  General Options  ===**
@@ -136,6 +137,8 @@ class LarkOptions(Serialize):
             A List of either paths or loader functions to specify from where grammars are imported
     source_path
             Override the source of from where the grammar was loaded. Useful for relative imports and unconventional grammar loading
+    accurate_exceptions
+            Provides better errors for the lalr parser, but may result in worse performance.
     **=== End of Options ===**
     """
     if __doc__:
@@ -169,6 +172,7 @@ class LarkOptions(Serialize):
         'use_bytes': False,
         'import_paths': [],
         'source_path': None,
+        'accurate_exceptions': False,
     }
 
     def __init__(self, options_dict):

--- a/lark/parser_frontends.py
+++ b/lark/parser_frontends.py
@@ -151,7 +151,8 @@ def create_contextual_lexer(lexer_conf, parser, postlex):
 
 def create_lalr_parser(lexer_conf, parser_conf, options=None):
     debug = options.debug if options else False
-    return LALR_Parser(parser_conf, debug=debug)
+    accurate_exceptions = options.accurate_exceptions if options else False
+    return LALR_Parser(parser_conf, debug=debug, accurate_exceptions=accurate_exceptions)
 
 
 create_earley_parser = NotImplemented

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2302,6 +2302,23 @@ def _make_parser_test(LEXER, PARSER):
             self.assertEqual(p.parse("a").children, ['a', None, None])
             self.assertEqual(p.parse("abc").children, ['a', 'b', 'c'])
 
+        @unittest.skipIf(PARSER=='cyk', "Empty rules")
+        def test_expected_tokens(self):
+            grammar = """
+            start: base base "c"
+            base: "a" ("b" base)?
+            """
+
+            l = _Lark(grammar)
+            # The following string should be accepted
+            l.parse("aabac")
+
+            # The following string has an unexpected token
+            with self.assertRaises((UnexpectedToken, UnexpectedCharacters)) as e:
+                l.parse("aaa")
+            # The error message should include B as a possible next token
+            expect_message = "Expected one of: \n\t* B\n\t* C\n"
+            assert str(e.exception).endswith(expect_message)
 
         def test_escaped_string(self):
             "Tests common.ESCAPED_STRING"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2309,7 +2309,7 @@ def _make_parser_test(LEXER, PARSER):
             base: "a" ("b" base)?
             """
 
-            l = _Lark(grammar)
+            l = _Lark(grammar, accurate_exceptions=True)
             # The following string should be accepted
             l.parse("aabac")
 


### PR DESCRIPTION
In some cases, LALR returns a wrong list of expected tokens in the case of `UnexpectedToken`.

For example, processing the input `aaa` in the grammar:

```
start: base base "c"
base: "a" ("b" base)?
```

returns only "c" as a possible replacement for the third "a", while "b" is also a valid option (as in `aabac`)