### PR TITLE
Fix for Transformer.__default__ not called in tree-less LALR mode (Issue #1029)

### DIFF
--- a/lark/parse_tree_builder.py
+++ b/lark/parse_tree_builder.py
@@ -352,6 +352,8 @@ class ParseTreeBuilder:
     def create_callback(self, transformer=None):
         callbacks = {}
 
+        default_callback = getattr(transformer, '__default__', self.tree_class)
+
         for rule, wrapper_chain in self.rule_builders:
 
             user_callback_name = rule.alias or rule.options.template_source or rule.origin.name
@@ -363,7 +365,7 @@ class ParseTreeBuilder:
                 elif isinstance(transformer, Transformer_InPlace):
                     f = inplace_transformer(f)
             except AttributeError:
-                f = partial(self.tree_class, user_callback_name)
+                f = partial(default_callback, user_callback_name)
 
             for w in wrapper_chain:
                 f = w(f)

--- a/lark/parse_tree_builder.py
+++ b/lark/parse_tree_builder.py
@@ -352,7 +352,12 @@ class ParseTreeBuilder:
     def create_callback(self, transformer=None):
         callbacks = {}
 
-        default_callback = getattr(transformer, '__default__', self.tree_class)
+        default_handler = getattr(transformer, '__default__', None)
+        if default_handler:
+            def default_callback(data, children):
+                return default_handler(data, children, None)
+        else:
+            default_callback = self.tree_class
 
         for rule, wrapper_chain in self.rule_builders:
 


### PR DESCRIPTION
Example of usage:

```python
from lark import Lark, Transformer

BUILD_TREE = False  # Change to False to try tree-less LALR mode

grammar = r"""
    start: expr

    expr: A B
        | A expr B

    A: "a"
    B: "b"

    %import common.WS
    %ignore WS
"""

class AbTransformer(Transformer):
    def __default__(self, data, children, meta):
        print(f'__default__({data!r}, {children!r}, {meta!r})')
        return data

def parse(x):
    if BUILD_TREE:
        parser = Lark(grammar, parser='lalr')
        return AbTransformer().transform(parser.parse(x))
    else:
        parser = Lark(grammar, parser='lalr', transformer=AbTransformer())
        return parser.parse(x)

print(parse('a a a b b b'))  # should print "start"
```