### PR TITLE
Have ininstance check match type of argument

### DIFF
--- a/lark/exceptions.py
+++ b/lark/exceptions.py
@@ -95,7 +95,7 @@ class UnexpectedInput(LarkError):
         """
         assert self.state is not None, "Not supported for this exception"
 
-        if isinstance(examples, dict):
+        if isinstance(examples, Mapping):
             examples = examples.items()
 
         candidate = (None, False)


### PR DESCRIPTION
Since not all `Mapping`s are `dict`s, mypy didn't understand the type of `example` on the following lines.