### PR TITLE
Specify minimum expected type in class methods

### DIFF
--- a/lark/lark.py
+++ b/lark/lark.py
@@ -226,7 +226,7 @@ _VALID_PRIORITY_OPTIONS = ('auto', 'normal', 'invert', None)
 _VALID_AMBIGUITY_OPTIONS = ('auto', 'resolve', 'explicit', 'forest')
 
 
-_T = TypeVar('_T')
+_T = TypeVar('_T', bound="Lark")
 
 class Lark(Serialize):
     """Main interface for the library.

--- a/lark/lexer.py
+++ b/lark/lexer.py
@@ -124,7 +124,7 @@ class TerminalDef(Serialize):
         else:
             return self.name
 
-_T = TypeVar('_T')
+_T = TypeVar('_T', bound="Token")
 
 class Token(str):
     """A string with meta-information, that is produced by the lexer.


### PR DESCRIPTION
Since the type was generic, mypy couldn't know what the `__init__()` looked like. The first concrete class that it does have information on that is a parent is `object`, which doesn't take any arguments.

Resolves
```
ark/lexer.py:180: error: Too many arguments for "object"  [call-arg]
lark/lark.py:540: error: Too many arguments for "object"  [call-arg]
lark/lark.py:558: error: Too many arguments for "object"  [call-arg]
```