### PR TITLE
Annotate collections which are hard to infer types for

### DIFF
--- a/lark/lexer.py
+++ b/lark/lexer.py
@@ -478,7 +478,7 @@ class ContextualLexer(Lexer):
         trad_conf = copy(conf)
         trad_conf.terminals = terminals
 
-        lexer_by_tokens = {}
+        lexer_by_tokens: Dict[FrozenSet[str], BasicLexer] = {}
         self.lexers = {}
         for state, accepts in states.items():
             key = frozenset(accepts)

--- a/lark/load_grammar.py
+++ b/lark/load_grammar.py
@@ -1067,8 +1067,8 @@ class GrammarBuilder:
         self.import_paths = import_paths or []
         self.used_files = used_files or {}
 
-        self._definitions = {}
-        self._ignore_names = []
+        self._definitions: Dict[str, Definition] = {}
+        self._ignore_names: List[str] = []
 
     def _grammar_error(self, is_term, msg, *names):
         args = {}
@@ -1210,7 +1210,7 @@ class GrammarBuilder:
     def load_grammar(self, grammar_text: str, grammar_name: str="<?>", mangle: Optional[Callable[[str], str]]=None) -> None:
         tree = _parse_grammar(grammar_text, grammar_name)
 
-        imports = {}
+        imports: Dict[Tuple[str, ...], Tuple[Optional[str], Dict[str, str]]] = {}
         for stmt in tree.children:
             if stmt.data == 'import':
                 dotted_path, base_path, aliases = self._unpack_import(stmt, grammar_name)


### PR DESCRIPTION
Resolves
```
lark/lexer.py:481: error: Need type annotation for "lexer_by_tokens" (hint: "lexer_by_tokens: Dict[<type>, <type>] = ...")  [var-annotated]
lark/load_grammar.py:1070: error: Need type annotation for "_definitions" (hint: "_definitions: Dict[<type>, <type>] = ...")  [var-annotated]
lark/load_grammar.py:1071: error: Need type annotation for "_ignore_names" (hint: "_ignore_names: List[<type>] = ...")  [var-annotated]
lark/load_grammar.py:1213: error: Need type annotation for "imports" (hint: "imports: Dict[<type>, <type>] = ...")  [var-annotated]
```
They all seem to be cases where updates to the collection happen outside of the function or in odd branches of code paths.