### PR TITLE
Use explicit None return instead of relying on implicit None

### DIFF
--- a/lark/tree_templates.py
+++ b/lark/tree_templates.py
@@ -35,6 +35,8 @@ class TemplateConf:
         if isinstance(var, Tree) and var.data == 'var' and var.children[0].startswith('$'):
             return var.children[0].lstrip('$')
 
+        return None
+
 
     def _get_tree(self, template: TreeOrCode):
         if isinstance(template, str):


### PR DESCRIPTION
Resolves
```
lark/tree_templates.py:23: error: Missing return statement  [return]
```