### PR TITLE
Remove unneeded python version compatibility functionality

### DIFF
--- a/lark/tools/__init__.py
+++ b/lark/tools/__init__.py
@@ -1,10 +1,6 @@
 import sys
 from argparse import ArgumentParser, FileType
-try:
-    from textwrap import indent
-except ImportError:
-    def indent(text, prefix):
-        return ''.join(prefix + line for line in text.splitlines(True))
+from textwrap import indent
 from logging import DEBUG, INFO, WARN, ERROR
 import warnings
 

--- a/lark/tree.py
+++ b/lark/tree.py
@@ -1,9 +1,3 @@
-
-try:
-    from future_builtins import filter  # type: ignore
-except ImportError:
-    pass
-
 import sys
 from copy import deepcopy
 


### PR DESCRIPTION
Since the minimum supported version is now 3.6, it is safe to directly depend on [textwrap.indent()](https://docs.python.org/3/library/textwrap.html#textwrap.indent) since it was added in 3.3.

Resolves
```
lark/tools/__init__.py:6: error: All conditional function variants must have identical signatures  [misc]
```

Also remove code to make `filter()` produce an iterator in python 2. 