### PR TITLE
Add MistQL to projects using Lark

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Check out the [JSON tutorial](/docs/json_tutorial.md#conclusion) for more detail
  - [pytreeview](https://gitlab.com/parmenti/pytreeview) - a lightweight tree-based grammar explorer
  - [harmalysis](https://github.com/napulen/harmalysis) - A language for harmonic analysis and music theory
  - [gersemi](https://github.com/BlankSpruce/gersemi) - A CMake code formatter
+ - [MistQL](https://github.com/evinism/mistql) - A query language for JSON-like structures
 
 Using Lark? Send me a message and I'll add your project!
 


### PR DESCRIPTION
Adds [MistQL](https://github.com/evinism/mistql) as a project that uses Lark