### PR TITLE
Support calling methods that doesn't match a rule name

### DIFF
--- a/lark/__init__.py
+++ b/lark/__init__.py
@@ -1,6 +1,6 @@
 from .utils import logger
 from .tree import Tree
-from .visitors import Transformer, Visitor, v_args, Discard, Transformer_NonRecursive
+from .visitors import Transformer, Visitor, v_args, Discard, Transformer_NonRecursive, call_for
 from .exceptions import (ParseError, LexError, GrammarError, UnexpectedToken,
                          UnexpectedInput, UnexpectedCharacters, UnexpectedEOF, LarkError)
 from .lexer import Token

--- a/tests/test_trees.py
+++ b/tests/test_trees.py
@@ -11,7 +11,7 @@ import functools
 from lark.tree import Tree
 from lark.lexer import Token
 from lark.visitors import Visitor, Visitor_Recursive, Transformer, Interpreter, visit_children_decor, v_args, Discard, Transformer_InPlace, \
-    Transformer_InPlaceRecursive, Transformer_NonRecursive, merge_transformers
+    Transformer_InPlaceRecursive, Transformer_NonRecursive, merge_transformers, call_for
 
 
 class TestTrees(TestCase):
@@ -446,6 +446,94 @@ class TestTrees(TestCase):
 
         with self.assertRaises(AttributeError):
             merge_transformers(T1(), module=T3())
+
+    def test_call_for_transformer(self):
+        t = Tree('add', [Tree('sub', [Tree('i', ['3']), Tree('f', ['1.1'])]), Tree('i', ['1'])])
+
+        class T(Transformer):
+            @call_for("i")
+            def int_(self, values) -> int:
+                return int(values[0])
+
+            @call_for("f")
+            def float_(self, values) -> float:
+                return float(values[0])
+
+            def sub(self, values):
+                return values[0] - values[1]
+
+            def add(self, values):
+                return sum(values)
+
+        res = T().transform(t)
+        self.assertEqual(res, 2.9)
+
+    def test_call_for_transformer_subclass(self):
+        t = Tree('add', [Tree('sub', [Tree('i', ['3']), Tree('f', ['1.1'])]), Tree('i', ['1'])])
+
+        class T(Transformer):
+            @call_for("i")
+            def int_(self, values) -> int:
+                return int(values[0])
+
+            def sub(self, values):
+                return values[0] - values[1]
+
+            def add(self, values):
+                return sum(values)
+
+        class TT(T):
+            @call_for("f")
+            def float_(self, values) -> float:
+                return float(values[0])
+
+        res = TT().transform(t)
+        self.assertEqual(res, 2.9)
+
+    def test_call_for_visitor(self):
+        t = Tree('add', [Tree('sub', [Tree('i', ['3']), Tree('f', ['1.1'])]), Tree('i', ['1'])])
+
+        class V(Visitor):
+            def __init__(self) -> None:
+                self.int_called = False
+                self.float_called = False
+
+            @call_for("i")
+            def int_(self, _) -> None:
+                self.int_called = True
+
+            @call_for("f")
+            def float_(self, _) -> None:
+                self.float_called = True
+
+        v = V()
+        v.visit(t)
+
+        self.assertTrue(v.int_called)
+        self.assertTrue(v.float_called)
+
+    def test_call_for_visitor_subclass(self):
+        t = Tree('add', [Tree('sub', [Tree('i', ['3']), Tree('f', ['1.1'])]), Tree('i', ['1'])])
+
+        class V(Visitor):
+            def __init__(self) -> None:
+                self.int_called = False
+                self.float_called = False
+
+            @call_for("i")
+            def int_(self, _) -> None:
+                self.int_called = True
+
+        class VV(V):
+            @call_for("f")
+            def float_(self, _) -> None:
+                self.float_called = True
+
+        v = VV()
+        v.visit(t)
+
+        self.assertTrue(v.int_called)
+        self.assertTrue(v.float_called)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
A working version that supports using a decorator to register a method to be called for a rule that does match the method name. It also supports things like a `A` inherits from `B`, which inherits from `Transformer`, and both `A` & `B` define overrides.

However, things get complicated with `merge_transformers()`. Since it will mutate `base_transformer` when given (explicitly documented behavior), copying over registered overrides needs to be done at the instance level instead of the class level. That in itself, is not a problem as an instance variable could be created in `__init__()`. The issue is that, nothing in the `Transformer` or `Visitor` inheritance chain currently defines an `__init__()`. This means that classes that do have an `__init__()`, likely don't call `super().__init__()` ([example in test cases](https://github.com/lark-parser/lark/blob/3affd85d10d7647876f5800d2e1f6c327936805d/tests/test_trees.py#L53)). This means the straightforward implementation would be a breaking change as `super().__init__()` would now be a requirement.

This is Python, so we can do a dynamic non-straightforward implementation, but I wanted to get some thought before I headed down that path.

Addresses #1066 