### PR TITLE
Annotate base_func

### DIFF
--- a/lark/visitors.py
+++ b/lark/visitors.py
@@ -457,10 +457,13 @@ class _VArgsWrapper:
     Otherwise, we use the original function mirroring the behaviour without a __get__.
     We also have the visit_wrapper attribute to be used by Transformers.
     """
+    base_func: Callable
+
     def __init__(self, func: Callable, visit_wrapper: Callable[[Callable, str, list, Any], Any]):
         if isinstance(func, _VArgsWrapper):
             func = func.base_func
-        self.base_func = func
+        # https://github.com/python/mypy/issues/708
+        self.base_func = func  # type: ignore[assignment]
         self.visit_wrapper = visit_wrapper
         update_wrapper(self, func)
 


### PR DESCRIPTION
It appears that mypy didn't know the instance variable existed yet because it hadn't had a value assigned to it yet. Another option would be to simply add an annotation to tell mypy what the type should be, but that ran into [this error.](https://github.com/python/mypy/issues/708) 

Resolves
```
lark/visitors.py:462: error: Cannot determine type of "base_func"  [has-type]
```