### PR TITLE
Remove duplicate definition of PythonIndenter

### DIFF
--- a/lark/indenter.py
+++ b/lark/indenter.py
@@ -110,12 +110,3 @@ class PythonIndenter(Indenter):
     tab_len = 8
 
 ###}
-
-
-class PythonIndenter(Indenter):
-    NL_type = '_NEWLINE'
-    OPEN_PAREN_types = ['LPAR', 'LSQB', 'LBRACE']
-    CLOSE_PAREN_types = ['RPAR', 'RSQB', 'RBRACE']
-    INDENT_type = '_INDENT'
-    DEDENT_type = '_DEDENT'
-    tab_len = 8


### PR DESCRIPTION
Some how this bit of code [got copied](https://github.com/lark-parser/lark/commit/ebb15f75721a161feb293c4dcdc613c04539d9eb) over [twice](https://github.com/lark-parser/lark/commit/6985acd9f8d808c4ced362a8ad9bd08cd3f4b035)