### PR TITLE
Include `py.typed` file in package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,6 @@ universal = 1
 
 [metadata]
 license_file = LICENSE
+
+[options.package_data]
+* = py.typed


### PR DESCRIPTION
Might fix #1105
See https://mypy.readthedocs.io/en/stable/installed_packages.html#creating-pep-561-compatible-packages