### PR TITLE
Add `py.typed` to `MANIFEST.in`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include README.md LICENSE docs/* examples/*.py examples/*.png examples/*.lark tests/*.py tests/*.lark tests/grammars/* tests/test_nearley/*.py tests/test_nearley/grammars/*
+include README.md LICENSE docs/* examples/*.py examples/*.png examples/*.lark tests/*.py tests/*.lark tests/grammars/* tests/test_nearley/*.py tests/test_nearley/grammars/* lark/py.typed


### PR DESCRIPTION
Based on a suggestion in https://github.com/lark-parser/lark/pull/1106#issuecomment-1032981598

See also https://github.com/urllib3/urllib3/blob/485c0da0f6cdb789cd319518b31a4059245b5c06/MANIFEST.in#L1 for an example

Obsoletes #1106 
Fixes #1105 