### PR TITLE
Linting to fix minor issues

### DIFF
--- a/examples/advanced/_json_parser.py
+++ b/examples/advanced/_json_parser.py
@@ -7,8 +7,6 @@ For an explanation, check out the JSON parser tutorial at /docs/json_tutorial.md
 
 (this is here for use by the other examples)
 """
-import sys
-
 from lark import Lark, Transformer, v_args
 
 json_grammar = r"""
@@ -61,4 +59,3 @@ json_parser = Lark(json_grammar, parser='lalr',
                    maybe_placeholders=False,
                    # Using an internal transformer is faster and more memory efficient
                    transformer=TreeToJson())
-

--- a/examples/advanced/qscintilla_json.py
+++ b/examples/advanced/qscintilla_json.py
@@ -13,7 +13,7 @@ Requirements:
 import sys
 import textwrap
 
-from PyQt5.Qt import *  # noqa
+from PyQt5.Qt import QColor, QApplication, QFont, QFontMetrics
 
 from PyQt5.Qsci import QsciScintilla
 from PyQt5.Qsci import QsciLexerCustom

--- a/lark/load_grammar.py
+++ b/lark/load_grammar.py
@@ -318,7 +318,7 @@ class EBNF_to_BNF(Transformer_InPlace):
         if mx < REPEAT_BREAK_THRESHOLD:
             return ST('expansions', [ST('expansion', [rule] * n) for n in range(mn, mx + 1)])
 
-        # For large repeat values, we break the repetition into sub-rules. 
+        # For large repeat values, we break the repetition into sub-rules.
         # We treat ``rule~mn..mx`` as ``rule~mn rule~0..(diff=mx-mn)``.
         # We then use small_factors to split up mn and diff up into values [(a, b), ...]
         # This values are used with the help of _add_repeat_rule and _add_repeat_rule_opt
@@ -1233,7 +1233,7 @@ class GrammarBuilder:
         tree = _parse_grammar(grammar_text, grammar_name)
 
         imports: Dict[Tuple[str, ...], Tuple[Optional[str], Dict[str, str]]] = {}
-          
+
         for stmt in tree.children:
             if stmt.data == 'import':
                 dotted_path, base_path, aliases = self._unpack_import(stmt, grammar_name)
@@ -1316,7 +1316,7 @@ class GrammarBuilder:
                 if self.used_files.get(joined_path, h) != h:
                     raise RuntimeError("Grammar file was changed during importing")
                 self.used_files[joined_path] = h
-                    
+
                 gb = GrammarBuilder(self.global_keep_all_tokens, self.import_paths, self.used_files)
                 gb.load_grammar(text, joined_path, mangle)
                 gb._remove_unused(map(mangle, aliases))
@@ -1390,7 +1390,7 @@ def verify_used_files(file_hashes):
                 text = pkgutil.get_data(*path).decode('utf-8')
         if text is None: # We don't know how to load the path. ignore it.
             continue
-            
+
         current = hashlib.md5(text.encode()).hexdigest()
         if old != current:
             logger.info("File %r changed, rebuilding Parser" % path)

--- a/lark/parsers/lalr_analysis.py
+++ b/lark/parsers/lalr_analysis.py
@@ -36,7 +36,6 @@ class ParseTable:
 
     def serialize(self, memo):
         tokens = Enumerator()
-        rules = Enumerator()
 
         states = {
             state: {tokens.get(token): ((1, arg.serialize(memo)) if action is Reduce else (0, arg))
@@ -286,7 +285,7 @@ class LALR_Analyzer(GrammarAnalyzer):
             for rp in state:
                 for start in self.lr0_start_states:
                     if rp.rule.origin.name == ('$root_' + start) and rp.is_satisfied:
-                        assert(not start in end_states)
+                        assert(start not in end_states)
                         end_states[start] = state
 
         _parse_table = ParseTable(states, { start: state.closure for start, state in self.lr0_start_states.items() }, end_states)

--- a/lark/parsers/lalr_parser.py
+++ b/lark/parsers/lalr_parser.py
@@ -3,7 +3,6 @@
 # Author: Erez Shinan (2017)
 # Email : erezshin@gmail.com
 from copy import deepcopy, copy
-from ..exceptions import UnexpectedInput, UnexpectedToken
 from ..lexer import Token
 from ..utils import Serialize
 
@@ -32,7 +31,7 @@ class LALR_Parser(Serialize):
 
     def serialize(self, memo):
         return self._parse_table.serialize(memo)
-    
+
     def parse_interactive(self, lexer, start):
         return self.parser.parse(lexer, start, start_interactive=True)
 
@@ -169,7 +168,7 @@ class _Parser:
         if start_interactive:
             return InteractiveParser(self, parser_state, parser_state.lexer)
         return self.parse_from_state(parser_state)
-    
+
 
     def parse_from_state(self, state):
         # Main LALR-parser loop

--- a/lark/reconstruct.py
+++ b/lark/reconstruct.py
@@ -1,7 +1,6 @@
 """Reconstruct text from a tree, based on Lark grammar"""
 
 from typing import List, Dict, Union, Callable, Iterable, Optional
-import unicodedata
 
 from .lark import Lark
 from .tree import Tree, ParseTree

--- a/lark/tree_matcher.py
+++ b/lark/tree_matcher.py
@@ -88,7 +88,7 @@ class TreeMatcher:
 
     def __init__(self, parser):
         # XXX TODO calling compile twice returns different results!
-        assert parser.options.maybe_placeholders == False
+        assert not parser.options.maybe_placeholders
         # XXX TODO: we just ignore the potential existence of a postlexer
         self.tokens, rules, _extra = parser.grammar.compile(parser.options.start, set())
 


### PR DESCRIPTION
I've been looking into the code to try to understand how hard it might be to make a C or Cython variant of this to speed up parsing. As a side effect I've done some minor linting. I've ignored style issues (whitespace etc...) and instead focused on things like unused variables, undefined names, etc...

Issues I've fixed in this PR are:

/home/joncrall/code/lark/lark/parsers/lalr_analysis.py:39:9: F841 local variable 'rules' is assigned to but never used
/home/joncrall/code/lark/lark/reconstruct.py:4:1: F401 'unicodedata' imported but unused
/home/joncrall/code/lark/lark/tree_matcher.py:91:50: E712 comparison to False should be 'if cond is False:' or 'if not cond:'
/home/joncrall/code/lark/lark/parsers/lalr_parser.py:12:1: F811 redefinition of unused 'UnexpectedInput' from line 6
/home/joncrall/code/lark/lark/parsers/lalr_parser.py:12:1: F811 redefinition of unused 'UnexpectedToken' from line 6
/home/joncrall/code/lark/lark/parsers/lalr_analysis.py:288:32: E713 test for membership should be 'not in'


There are a lot of other unused imports but I think those are mostly there to support the standalone functionality, so I didn't touch them.

EDIT: Looks like my editor also clobbered some trailing whitespace.


EDIT2: Also made some changes to the examples:
/home/joncrall/code/lark/examples/advanced/qscintilla_json.py:32:20: F405 'QColor' may be undefined, or defined from star imports: PyQt5.Qt (replaced the import * with explicit imports)
/home/joncrall/code/lark/examples/advanced/_json_parser.py:10:1: F401 'sys' imported but unused
