### PR TITLE
Move iter_subtrees_topdown into standalone

### DIFF
--- a/lark/tree.py
+++ b/lark/tree.py
@@ -142,6 +142,20 @@ class Tree(Generic[_Leaf_T]):
         del queue
         return reversed(list(subtrees.values()))
 
+    def iter_subtrees_topdown(self):
+        """Breadth-first iteration.
+
+        Iterates over all the subtrees, return nodes in order like pretty() does.
+        """
+        stack = [self]
+        while stack:
+            node = stack.pop()
+            if not isinstance(node, Tree):
+                continue
+            yield node
+            for child in reversed(node.children):
+                stack.append(child)
+
     def find_pred(self, pred: 'Callable[[Tree[_Leaf_T]], bool]') -> 'Iterator[Tree[_Leaf_T]]':
         """Returns all nodes of the tree that evaluate pred(node) as true."""
         return filter(pred, self.iter_subtrees())
@@ -178,20 +192,6 @@ class Tree(Generic[_Leaf_T]):
             else:
                 if pred(c):
                     yield c
-
-    def iter_subtrees_topdown(self):
-        """Breadth-first iteration.
-
-        Iterates over all the subtrees, return nodes in order like pretty() does.
-        """
-        stack = [self]
-        while stack:
-            node = stack.pop()
-            if not isinstance(node, Tree):
-                continue
-            yield node
-            for child in reversed(node.children):
-                stack.append(child)
 
     def __deepcopy__(self, memo):
         return type(self)(self.data, deepcopy(self.children, memo), meta=self._meta)


### PR DESCRIPTION
Hiya! When trying to use `iter_subtrees_topdown` from a generated parser, I found it wasn't there. It looks like that's because it's defined outside the standalone template delimiters, so I just nudged it up some, which fixed the issue for me.