### PR TITLE
Fix confusing import in examples

### DIFF
--- a/examples/advanced/extend_python.py
+++ b/examples/advanced/extend_python.py
@@ -8,7 +8,7 @@ to add new syntax to the example Python grammar.
 """
 
 from lark.lark import Lark
-from python_parser import PythonIndenter
+from lark.indenter import PythonIndenter
 
 GRAMMAR = r"""
 %import python (compound_stmt, single_input, file_input, eval_input, test, suite, _NEWLINE, _INDENT, _DEDENT, COMMENT)


### PR DESCRIPTION
Somehow `extend_python.py` imported `PythonIndenter` not from `lark.indenter`, but from `python_parser.py`, which then imported it from `lark.indenter`. As far as I see, this doesn't make any sense.

This PR changes `extend_python.py` to directly import from `lark.indenter` and doesn't change any functionality (as far as I understand).