### PR TITLE
Adjust imports for Python 3.11

### DIFF
--- a/lark/utils.py
+++ b/lark/utils.py
@@ -113,8 +113,13 @@ try:
 except ImportError:
     regex = None
 
-import sre_parse
-import sre_constants
+try:  # Python 3.11
+    import re._parser as sre_parse
+    import re._constants as sre_constants
+except ImportError:
+    import sre_parse
+    import sre_constants
+
 categ_pattern = re.compile(r'\\p{[A-Za-z_]+}')
 
 def get_regexp_width(expr):

--- a/lark/utils.py
+++ b/lark/utils.py
@@ -113,10 +113,10 @@ try:
 except ImportError:
     regex = None
 
-try:  # Python 3.11
+if sys.version_info >= (3, 11):
     import re._parser as sre_parse
     import re._constants as sre_constants
-except ImportError:
+else:
     import sre_parse
     import sre_constants
 


### PR DESCRIPTION
sre_parse and sre_constants are deprecated in 3.11, see https://github.com/python/cpython/issues/91308

This fixes a `DeprecationWarning` when running `python3 -Wall -c "import lark"` with Python 3.11.0a7.

I couldn't run the tests on Python 3.11 due to https://github.com/PiotrDabkowski/Js2Py/issues/282, but it looks like at least lark works without deprecation warnings with this change.