### PR TITLE
fix: remove Python 2 legacy packaging code

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,3 @@
-[global]
-zip_safe=
-
-[bdist_wheel]
-universal = 1
-
 [metadata]
 license_file = LICENSE
+python_requires = >=3.6


### PR DESCRIPTION
A small update to packaging code; universal=True/1 is only used to replace the `py3` tag with `py2.py3`, which is incorrect since 1.0. Also adding `python_requires` - this should always be set as soon as a python version is dropped, as pip will back-solve to find the final release that has a passing `python_requires` for the current Python version. 

If you are interested, I'd recommend moving to static configuration (everything in setup.cfg or pyproject.toml). I'd recommend reading https://scikit-hep.org/developer/packaging or https://packaging.python.org/en/latest/tutorials/packaging-projects/ for the classic way to do this, or https://scikit-hep.org/developer/pep621 for the new way. (We are working on transitioning packaging.python.org to the PEP 621 method as well in the near future).

My initial goal was to see if mypyc would provide the same speedup for CPython that PyPy provided, but there are some missing static types[^1]. :'( I did compare a few versions of Python 3 to see if the faster CPython project really is working. I've got a fast computer and I wasn't able to generate a matching json file (2.9 MB for me), but here are the relative timings for the slowest parser if you were curious:

| Version       | Time |
|---------------|------|
| CPython 3.6   | 46.34 secs |
| CPython 3.9   | 42.05 secs |
| CPython 3.10  | 37.25 secs | 
| CPython 3.11b1| 29.31 secs |
| PyPy 3.7      | 8.46 secs |

[^1]: there might actually be enough to try it!