### PR TITLE
fix(types): add some types based on MonkeyType

### DIFF
--- a/lark/parsers/lalr_parser.py
+++ b/lark/parsers/lalr_parser.py
@@ -30,7 +30,7 @@ class LALR_Parser(Serialize):
         inst.parser = _Parser(inst._parse_table, callbacks, debug)
         return inst
 
-    def serialize(self, memo = None) -> Dict[str, Any]:
+    def serialize(self, memo: Any = None) -> Dict[str, Any]:
         return self._parse_table.serialize(memo)
 
     def parse_interactive(self, lexer, start):

--- a/lark/parsers/lalr_parser.py
+++ b/lark/parsers/lalr_parser.py
@@ -3,8 +3,9 @@
 # Author: Erez Shinan (2017)
 # Email : erezshin@gmail.com
 from copy import deepcopy, copy
+from typing import Dict, Any
 from ..lexer import Token
-from ..utils import Serialize
+from ..utils import Serialize, SerializeMemoizer
 
 from .lalr_analysis import LALR_Analyzer, Shift, Reduce, IntParseTable
 from .lalr_interactive_parser import InteractiveParser
@@ -29,7 +30,7 @@ class LALR_Parser(Serialize):
         inst.parser = _Parser(inst._parse_table, callbacks, debug)
         return inst
 
-    def serialize(self, memo):
+    def serialize(self, memo = None) -> Dict[str, Any]:
         return self._parse_table.serialize(memo)
 
     def parse_interactive(self, lexer, start):

--- a/lark/utils.py
+++ b/lark/utils.py
@@ -2,7 +2,7 @@ import unicodedata
 import os
 from functools import reduce
 from collections import deque
-from typing import Callable, Iterator, List, Optional, Tuple, Type, TypeVar, Union, Dict, Any, TYPE_CHECKING
+from typing import Callable, Iterator, List, Optional, Tuple, Type, TypeVar, Union, Dict, Any, Sequence, TYPE_CHECKING
 
 ###{standalone
 # Can remove for python 3.7+ and from __future__ import annotations
@@ -172,7 +172,7 @@ def get_regexp_width(expr: str) -> Union[Tuple[int, int], List[int]]:
 _ID_START =    'Lu', 'Ll', 'Lt', 'Lm', 'Lo', 'Mn', 'Mc', 'Pc'
 _ID_CONTINUE = _ID_START + ('Nd', 'Nl',)
 
-def _test_unicode_category(s: str, categories: Union[Tuple[str, str, str, str, str, str, str, str], Tuple[str, str, str, str, str, str, str, str, str, str]]) -> bool:
+def _test_unicode_category(s: str, categories: Sequence[str]) -> bool:
     if len(s) != 1:
         return all(_test_unicode_category(char, categories) for char in s)
     return s == '_' or unicodedata.category(s) in categories

--- a/lark/utils.py
+++ b/lark/utils.py
@@ -31,7 +31,7 @@ NO_VALUE = object()
 T = TypeVar("T")
 
 
-def classify(seq: List[Any], key: Callable[[Any], Any], value: Optional[Callable[[Any], Any]]=None) -> Any:
+def classify(seq: List[Any], key: Optional[Callable[[Any], Any]] = None, value: Optional[Callable[[Any], Any]] = None) -> Any:
     d: Dict[Any, Any] = {}
     for item in seq:
         k = key(item) if (key is not None) else item
@@ -151,7 +151,7 @@ def get_regexp_width(expr: str) -> Union[Tuple[int, int], List[int]]:
             raise ImportError('`regex` module must be installed in order to use Unicode categories.', expr)
         regexp_final = expr
     try:
-        # TODO: bug? Returns an int?
+        # Fixed in next version (past 0.960) of typeshed
         return [int(x) for x in sre_parse.parse(regexp_final).getwidth()]   # type: ignore[attr-defined]
     except sre_constants.error:
         if not _has_regex:


### PR DESCRIPTION
Typing is a bit too sparse to run mypyc, so I've tried to fill in a couple of modules (lark.py and utils.py) with the help of monkeytype. This is based on what was seen running the tests more than what things should be, so input and cleanup would be helpful!
