### PR TITLE
Add user to cache filename; better handle cache load/save failures

### DIFF
--- a/lark/lark.py
+++ b/lark/lark.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+import getpass
 import sys, os, pickle, hashlib
 import tempfile
 import types
@@ -308,7 +309,7 @@ class Lark(Serialize):
                     if self.options.cache is not True:
                         raise ConfigurationError("cache argument must be bool or str")
                         
-                    cache_fn = tempfile.gettempdir() + '/.lark_cache_%s_%s_%s.tmp' % (cache_md5, *sys.version_info[:2])
+                    cache_fn = tempfile.gettempdir() + "/.lark_cache_%s_%s_%s_%s.tmp" % (getpass.getuser(), cache_md5, *sys.version_info[:2])
 
                 if FS.exists(cache_fn):
                     logger.debug('Loading grammar from cache: %s', cache_fn)

--- a/lark/lark.py
+++ b/lark/lark.py
@@ -328,7 +328,7 @@ class Lark(Serialize):
                     # The cache file doesn't exist; parse and compose the grammar as normal
                     pass
                 except Exception: # We should probably narrow done which errors we catch here.
-                    logger.exception("Failed to load Lark from cache: %r. We will try to carry on." % cache_fn)
+                    logger.exception("Failed to load Lark from cache: %r. We will try to carry on.", cache_fn)
                     
                     # In theory, the Lark instance might have been messed up by the call to `_load`.
                     # In practice the only relevant thing that might have been overriden should be `options`
@@ -424,11 +424,14 @@ class Lark(Serialize):
 
         if cache_fn:
             logger.debug('Saving grammar to cache: %s', cache_fn)
-            with FS.open(cache_fn, 'wb') as f:
-                assert cache_md5 is not None
-                f.write(cache_md5.encode('utf8') + b'\n')
-                pickle.dump(used_files, f)
-                self.save(f, _LOAD_ALLOWED_OPTIONS)
+            try:
+                with FS.open(cache_fn, 'wb') as f:
+                    assert cache_md5 is not None
+                    f.write(cache_md5.encode('utf8') + b'\n')
+                    pickle.dump(used_files, f)
+                    self.save(f, _LOAD_ALLOWED_OPTIONS)
+            except Exception:
+                logger.exception("Failed to save Lark to cache: %r.", cache_fn)
 
     if __doc__:
         __doc__ += "\n\n" + LarkOptions.OPTIONS_DOC

--- a/lark/lark.py
+++ b/lark/lark.py
@@ -309,7 +309,15 @@ class Lark(Serialize):
                     if self.options.cache is not True:
                         raise ConfigurationError("cache argument must be bool or str")
                         
-                    cache_fn = tempfile.gettempdir() + "/.lark_cache_%s_%s_%s_%s.tmp" % (getpass.getuser(), cache_md5, *sys.version_info[:2])
+                    try:
+                        username = getpass.getuser()
+                    except Exception:
+                        # The exception raised may be ImportError or OSError in
+                        # the future.  For the cache, we don't care about the
+                        # specific reason - we just want a username.
+                        username = "unknown"
+
+                    cache_fn = tempfile.gettempdir() + "/.lark_cache_%s_%s_%s_%s.tmp" % (username, cache_md5, *sys.version_info[:2])
 
                 old_options = self.options
                 try:

--- a/lark/lark.py
+++ b/lark/lark.py
@@ -311,26 +311,28 @@ class Lark(Serialize):
                         
                     cache_fn = tempfile.gettempdir() + "/.lark_cache_%s_%s_%s_%s.tmp" % (getpass.getuser(), cache_md5, *sys.version_info[:2])
 
-                if FS.exists(cache_fn):
-                    logger.debug('Loading grammar from cache: %s', cache_fn)
-                    # Remove options that aren't relevant for loading from cache
-                    for name in (set(options) - _LOAD_ALLOWED_OPTIONS):
-                        del options[name]
+                old_options = self.options
+                try:
                     with FS.open(cache_fn, 'rb') as f:
-                        old_options = self.options
-                        try:
-                            file_md5 = f.readline().rstrip(b'\n')
-                            cached_used_files = pickle.load(f)
-                            if file_md5 == cache_md5.encode('utf8') and verify_used_files(cached_used_files):
-                                cached_parser_data = pickle.load(f)
-                                self._load(cached_parser_data, **options)
-                                return
-                        except Exception: # We should probably narrow done which errors we catch here.
-                            logger.exception("Failed to load Lark from cache: %r. We will try to carry on." % cache_fn)
-                            
-                            # In theory, the Lark instance might have been messed up by the call to `_load`.
-                            # In practice the only relevant thing that might have been overriden should be `options`
-                            self.options = old_options
+                        logger.debug('Loading grammar from cache: %s', cache_fn)
+                        # Remove options that aren't relevant for loading from cache
+                        for name in (set(options) - _LOAD_ALLOWED_OPTIONS):
+                            del options[name]
+                        file_md5 = f.readline().rstrip(b'\n')
+                        cached_used_files = pickle.load(f)
+                        if file_md5 == cache_md5.encode('utf8') and verify_used_files(cached_used_files):
+                            cached_parser_data = pickle.load(f)
+                            self._load(cached_parser_data, **options)
+                            return
+                except FileNotFoundError:
+                    # The cache file doesn't exist; parse and compose the grammar as normal
+                    pass
+                except Exception: # We should probably narrow done which errors we catch here.
+                    logger.exception("Failed to load Lark from cache: %r. We will try to carry on." % cache_fn)
+                    
+                    # In theory, the Lark instance might have been messed up by the call to `_load`.
+                    # In practice the only relevant thing that might have been overriden should be `options`
+                    self.options = old_options
 
 
             # Parse the grammar file and compose the grammars

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -29,8 +29,11 @@ class MockFS:
     def __init__(self):
         self.files = {}
 
-    def open(self, name, mode=None):
+    def open(self, name, mode="r", **kwargs):
         if name not in self.files:
+            if "r" in mode:
+                # If we are reading from a file, it should already exist
+                raise FileNotFoundError(name)
             f = self.files[name] = MockFile()
         else:
             f = self.files[name]


### PR DESCRIPTION
## Context

Closes #1178 

## Description

This is my attempt at fixing the issue I reported (#1178) regarding cache files generated by different users on the same system.

Consider this a proposal - I'd be happy to adjust it to your preference.

Three main changes were made:
* Added `$USER` (via `getpass.getuser()`) to the cache filename (77d8277)
* Moved the `try/except` block to include cache load / `open(cache_fn)` (1c36098)
   * This means that if, for any reason, the cache file fails to load, the normal loading procedure can continue
* Wrapped the cache save section in a `try/except` block and a similar `logger.exception` message (835e6923239ee2ecee9a6dc6637a2cd73065e38a)
   * I believe cache save failures should not be fatal