### PR TITLE
fix: Token now pattern matches correctly

### DIFF
--- a/lark/lexer.py
+++ b/lark/lexer.py
@@ -147,6 +147,8 @@ class Token(str):
     """
     __slots__ = ('type', 'start_pos', 'value', 'line', 'column', 'end_line', 'end_column', 'end_pos')
 
+    __match_args__ = ('type', 'value', 'start_pos', 'line', 'column', 'end_line', 'end_column', 'end_pos')
+
     type: str
     start_pos: int
     value: Any
@@ -156,9 +158,9 @@ class Token(str):
     end_column: int
     end_pos: int
 
-    def __new__(cls, type_, value, start_pos=None, line=None, column=None, end_line=None, end_column=None, end_pos=None):
+    def __new__(cls, type, value, start_pos=None, line=None, column=None, end_line=None, end_column=None, end_pos=None):
         inst = super(Token, cls).__new__(cls, value)
-        inst.type = type_
+        inst.type = type
         inst.start_pos = start_pos
         inst.value = value
         inst.line = line
@@ -178,6 +180,10 @@ class Token(str):
     @classmethod
     def new_borrow_pos(cls: Type[_T], type_: str, value: Any, borrow_t: 'Token') -> _T:
         return cls(type_, value, borrow_t.start_pos, borrow_t.line, borrow_t.column, borrow_t.end_line, borrow_t.end_column, borrow_t.end_pos)
+    
+    @property
+    def type_(self) -> str:
+        return self.type
 
     def __reduce__(self):
         return (self.__class__, (self.type, self.value, self.start_pos, self.line, self.column))

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, print_function
 
 import unittest
 import logging
+import sys
 from lark import logger
 
 from .test_trees import TestTrees
@@ -25,6 +26,9 @@ except ImportError:
 from .test_logger import Testlogger
 
 from .test_parser import *  # We define __all__ to list which TestSuites to run
+
+if sys.version_info >= (3, 10):
+    from .test_pattern_matching import TestPatternMatching
 
 logger.setLevel(logging.INFO)
 

--- a/tests/test_pattern_matching.py
+++ b/tests/test_pattern_matching.py
@@ -1,0 +1,52 @@
+from unittest import TestCase, main
+
+from lark import Token
+
+
+class TestPatternMatching(TestCase):
+    token = Token('A', 'a')
+
+    def setUp(self):
+        pass
+
+    def test_matches_with_string(self):
+        match self.token:
+            case 'a':
+                pass
+            case _:
+                assert False
+
+    def test_matches_with_str_positional_arg(self):
+        match self.token:
+            case str('a'):
+                pass
+            case _:
+                assert False
+    
+    def test_matches_with_token_positional_arg(self):
+        match self.token:
+            case Token('a'):
+                assert False
+            case Token('A'):
+                pass
+            case _:
+                assert False
+    
+    def test_matches_with_token_kwarg_type(self):
+        match self.token:
+            case Token(type='A'):
+                pass
+            case _:
+                assert False
+    
+    def test_matches_with_token_kwarg_type_(self):
+        match self.token:
+            case Token(type_='A'):
+                pass
+            case _:
+                assert False
+            
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
I've added fixes as per https://github.com/lark-parser/lark/issues/1180#issuecomment-1214921614. I don't think that the backward compatibility is possible in this case, as the original argument is positional, e.g.

``` python
Token(type_="TEST", value="test") # this will break no matter what, as positional arguments are not set properly

Token("TEST", "test") # this doesn't require any backwards compatibility changes
```

Please correct me if I'm missing something.

I've also added a bunch of tests (which only are run if the version is 3.10 or higher).
I wasn't sure how to use assert statements in structural pattern matching, but it does the job.

closes #1180