### PR TITLE
refactor: add 'usedforsecurity=False' arg to hashlib.md5 usage

### DIFF
--- a/lark/lark.py
+++ b/lark/lark.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
         
 from .exceptions import ConfigurationError, assert_config, UnexpectedInput
 from .utils import Serialize, SerializeMemoizer, FS, isascii, logger
-from .load_grammar import load_grammar, FromPackageLoader, Grammar, verify_used_files, PackageResource
+from .load_grammar import load_grammar, FromPackageLoader, Grammar, verify_used_files, PackageResource, md5_digest
 from .tree import Tree
 from .common import LexerConf, ParserConf, _ParserArgType, _LexerArgType
 
@@ -301,7 +301,7 @@ class Lark(Serialize):
                 options_str = ''.join(k+str(v) for k, v in options.items() if k not in unhashable)
                 from . import __version__
                 s = grammar + options_str + __version__ + str(sys.version_info[:2])
-                cache_md5 = hashlib.new("md5", s.encode('utf8'), usedforsecurity=False).hexdigest()
+                cache_md5 = md5_digest(s)
 
                 if isinstance(self.options.cache, str):
                     cache_fn = self.options.cache

--- a/lark/lark.py
+++ b/lark/lark.py
@@ -301,7 +301,7 @@ class Lark(Serialize):
                 options_str = ''.join(k+str(v) for k, v in options.items() if k not in unhashable)
                 from . import __version__
                 s = grammar + options_str + __version__ + str(sys.version_info[:2])
-                cache_md5 = hashlib.md5(s.encode('utf8')).hexdigest()
+                cache_md5 = hashlib.new("md5", s.encode('utf8'), usedforsecurity=False).hexdigest()
 
                 if isinstance(self.options.cache, str):
                     cache_fn = self.options.cache

--- a/lark/load_grammar.py
+++ b/lark/load_grammar.py
@@ -1413,7 +1413,9 @@ def md5_digest(s: str) -> str:
     """Get the md5 digest of a string
 
     Supports the `usedforsecurity` argument for Python 3.9+ to allow running on
-    a FIPS-enabled system. Use of the `new` constructor here prevents Python 3.8
-    and below from raising an exception when passing in the argument.
+    a FIPS-enabled system.
     """
-    return hashlib.new("md5", s.encode('utf8'), usedforsecurity=False).hexdigest()
+    if sys.version_info >= (3, 9):
+        return hashlib.md5(s.encode('utf8'), usedforsecurity=False).hexdigest()
+    else:
+        return hashlib.md5(s.encode('utf8')).hexdigest()

--- a/lark/load_grammar.py
+++ b/lark/load_grammar.py
@@ -1312,7 +1312,7 @@ class GrammarBuilder:
             except IOError:
                 continue
             else:
-                h = hashlib.md5(text.encode('utf8')).hexdigest()
+                h = hashlib.new("md5", text.encode("utf8"), usedforsecurity=False).hexdigest()
                 if self.used_files.get(joined_path, h) != h:
                     raise RuntimeError("Grammar file was changed during importing")
                 self.used_files[joined_path] = h
@@ -1391,7 +1391,7 @@ def verify_used_files(file_hashes):
         if text is None: # We don't know how to load the path. ignore it.
             continue
 
-        current = hashlib.md5(text.encode()).hexdigest()
+        current = hashlib.new("md5", text.encode(), usedforsecurity=False).hexdigest()
         if old != current:
             logger.info("File %r changed, rebuilding Parser" % path)
             return False

--- a/lark/load_grammar.py
+++ b/lark/load_grammar.py
@@ -1312,7 +1312,7 @@ class GrammarBuilder:
             except IOError:
                 continue
             else:
-                h = hashlib.new("md5", text.encode("utf8"), usedforsecurity=False).hexdigest()
+                h = md5_digest(text)
                 if self.used_files.get(joined_path, h) != h:
                     raise RuntimeError("Grammar file was changed during importing")
                 self.used_files[joined_path] = h
@@ -1391,7 +1391,7 @@ def verify_used_files(file_hashes):
         if text is None: # We don't know how to load the path. ignore it.
             continue
 
-        current = hashlib.new("md5", text.encode(), usedforsecurity=False).hexdigest()
+        current = md5_digest(text)
         if old != current:
             logger.info("File %r changed, rebuilding Parser" % path)
             return False
@@ -1407,3 +1407,13 @@ def load_grammar(grammar, source, import_paths, global_keep_all_tokens):
     builder = GrammarBuilder(global_keep_all_tokens, import_paths)
     builder.load_grammar(grammar, source)
     return builder.build(), builder.used_files
+
+
+def md5_digest(s: str) -> str:
+    """Get the md5 digest of a string
+
+    Supports the `usedforsecurity` argument for Python 3.9+ to allow running on
+    a FIPS-enabled system. Use of the `new` constructor here prevents Python 3.8
+    and below from raising an exception when passing in the argument.
+    """
+    return hashlib.new("md5", s.encode('utf8'), usedforsecurity=False).hexdigest()


### PR DESCRIPTION
This argument was introduced in Python 3.9, but using `hashlib.new()` prevents <3.9 versions from throwing an exception.

Tested running locally against 3.7, 3.9, and 3.10.

Closes #1187 