### PR TITLE
Update lexer option docs

### DIFF
--- a/lark/lark.py
+++ b/lark/lark.py
@@ -114,7 +114,7 @@ class LarkOptions(Serialize):
             Decides whether or not to use a lexer stage
 
             - "auto" (default): Choose for me based on the parser
-            - "basic": Use a basic lexer
+            - "standard": Use a basic lexer
             - "contextual": Stronger lexer (only works with parser="lalr")
             - "dynamic": Flexible and powerful (only with parser="earley")
             - "dynamic_complete": Same as dynamic, but tries *every* variation of tokenizing possible.


### PR DESCRIPTION
Current docs list `basic` as a lexer option, but this raises a configuration error exception:

`lark.exceptions.ConfigurationError: Got 'basic', expected one of ('standard', 'contextual', 'dynamic', 'dynamic_complete')`

Updated the docs to reflect that `standard` should be used instead.