### PR TITLE
setup.cfg: Replace deprecated license_file with license_files

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [metadata]
-license_file = LICENSE
+license_files = LICENSE
 python_requires = >=3.6


### PR DESCRIPTION
Replace the deprecated `license_file` key with `license_files`. The latter has the same semantics and is available since setuptools 42.0.0 (that lark already requires).