### PR TITLE
Support for Python-style comments in Lark grammar

### DIFF
--- a/lark/grammars/lark.lark
+++ b/lark/grammars/lark.lark
@@ -1,3 +1,6 @@
+# Lark grammar of Lark's syntax
+# Note: Lark is not bootstrapped, its parser is implemented in load_grammar.py
+
 start: (_item? _NL)* _item?
 
 _item: rule
@@ -53,7 +56,7 @@ _NL: /(\r?\n)+\s*/
 %import common.SIGNED_INT -> NUMBER
 %import common.WS_INLINE
 
-COMMENT: /\s*/ "//" /[^\n]/*
+COMMENT: /\s*/ "//" /[^\n]/* | /\s*/ "#" /[^\n]/*
 
 %ignore WS_INLINE
 %ignore COMMENT

--- a/lark/load_grammar.py
+++ b/lark/load_grammar.py
@@ -94,7 +94,7 @@ TERMINALS = {
     '_NL': r'(\r?\n)+\s*',
     '_NL_OR': r'(\r?\n)+\s*\|',
     'WS': r'[ \t]+',
-    'COMMENT': r'\s*//[^\n]*',
+    'COMMENT': r'\s*//[^\n]*|\s*#[^\n]*',
     'BACKSLASH': r'\\[ ]*\n',
     '_TO': '->',
     '_IGNORE': r'%ignore',


### PR DESCRIPTION
Given that 
- most (all?) editors are unaware of Lark's syntax
- most lark grammars live in Python strings 
- most editors will use # when asked to comment lines or blocks within Lark strings (eg Pycharm's CTRL+D)
- commenting lines and blocks is frequently done while developing a grammar  (debugging...)
- adding this style of comments should not break existing grammars

I propose in this small PR to enable Python-style comments in Lark grammars. If accepted, I'll do another PR to reflect that in documentation. 