### PR TITLE
Unfreeze interegular

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         "regex": ["regex"],
         "nearley": ["js2py"],
         "atomic_cache": ["atomicwrites"],
-        "interegular": ["interegular==0.2.4"],
+        "interegular": ["interegular>=0.2.6,<0.3.0"],
     },
 
     package_data = {'': ['*.md', '*.lark'], 'lark': ['py.typed']},

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,3 @@
-interegular==0.2.4
+interegular>=0.2.6,<0.3.0
 Js2Py==0.68
 regex


### PR DESCRIPTION
require at least 0.2.6. Limit above to 0.3.0 for potential changes in API

Sorry for that, forgot to test with old python versions. Now CI is setup and this shouldn't happen again.