### PR TITLE
Add exclude in coverage for `if TYPE_CHECKING:` branches

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,3 +16,9 @@ exclude = [
 [[tool.mypy.overrides]]
 module = [ "js2py" ]
 ignore_missing_imports = true
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "if TYPE_CHECKING:"
+]


### PR DESCRIPTION
A small addition to the cleanup PR that should increase coverage by ignoring code that is never supposed to be executed. See https://github.com/nedbat/coveragepy/issues/831

I decided to add the code to `pyproject.toml` instead of adding another config file. The required tomli lib should be installed by default by `pytest`