### PR TITLE
Add "_" as a valid name for Python grammar in non-match contexts

### DIFF
--- a/lark/grammars/python.lark
+++ b/lark/grammars/python.lark
@@ -277,7 +277,7 @@ _NEWLINE: ( /\r?\n[\t ]*/ | COMMENT )+
 
 // Python terminals
 
-!name: NAME | "match" | "case"
+!name: NAME | "match" | "case" | "_"
 NAME: /[^\W\d]\w*/
 COMMENT: /#[^\n]*/
 


### PR DESCRIPTION
Previously, the example Python grammar wouldn't parse text like:
```
for _ in foo:
  pass
```