### PR TITLE
Update lexer_state to lexer_thread to avoid deprecation warnings

### DIFF
--- a/lark/parsers/lalr_interactive_parser.py
+++ b/lark/parsers/lalr_interactive_parser.py
@@ -116,7 +116,7 @@ class InteractiveParser:
     def resume_parse(self):
         """Resume automated parsing from the current state.
         """
-        return self.parser.parse_from_state(self.parser_state, last_token=self.lexer_state.state.last_token)
+        return self.parser.parse_from_state(self.parser_state, last_token=self.lexer_thread.state.last_token)
 
 
 


### PR DESCRIPTION
When running pytest on modules that depend on Lark I'm getting 100s of deprecation warnings:

```
lib\site-packages\lark\parsers\lalr_interactive_parser.py:27: DeprecationWarning: lexer_state will be removed in subsequent releases. Use lexer_thread instead.
    warnings.warn("lexer_state will be removed in subsequent releases. Use lexer_thread instead.", DeprecationWarning)
```

Raised at:

https://github.com/lark-parser/lark/blob/7043c3ee20731ca297b93f1009e7474915d06c34/lark/parsers/lalr_interactive_parser.py#L24

These appear to come from the use of `lexer_state` within Lark. Updating to `lexer_thread` in `resume_parse` removes these errors. 