### PR TITLE
Improve documentation of `v_args` `meta` option.

### DIFF
--- a/lark/visitors.py
+++ b/lark/visitors.py
@@ -534,6 +534,7 @@ def v_args(inline: bool = False, meta: bool = False, tree: bool = False, wrapper
 
                 @v_args(meta=True)
                 def mul(self, meta, children):
+                    logger.info(f'mul at line {meta.line}')
                     left, right = children
                     return left * right
 

--- a/lark/visitors.py
+++ b/lark/visitors.py
@@ -520,7 +520,7 @@ def v_args(inline: bool = False, meta: bool = False, tree: bool = False, wrapper
 
     Parameters:
         inline (bool, optional): Children are provided as ``*args`` instead of a list argument (not recommended for very long lists).
-        meta (bool, optional): Provides two arguments: ``children`` and ``meta`` (instead of just the first)
+        meta (bool, optional): Provides two arguments: ``meta`` and ``children`` (instead of just the latter)
         tree (bool, optional): Provides the entire tree as the argument, instead of the children.
         wrapper (function, optional): Provide a function to decorate all methods.
 
@@ -531,6 +531,11 @@ def v_args(inline: bool = False, meta: bool = False, tree: bool = False, wrapper
             class SolveArith(Transformer):
                 def add(self, left, right):
                     return left + right
+
+                @v_args(meta=True)
+                def mul(self, meta, children):
+                    left, right = children
+                    return left * right
 
 
             class ReverseNotation(Transformer_InPlace):


### PR DESCRIPTION
When using `@v_args(meta=True)`, visitor methods will receive a `meta` argument followed by a `children` argument in that order. The documentation previously described the arguments in the opposite order, which can be misleading to someone reading the docs, especially because there was no example of `@v_args(meta=True)`.

This updates the documentation to describe the arguments in the order they are passed in to the visitor methods, and adds a new example for `@v_args(meta=True)`.