### PR TITLE
Fixes invalid document link

### DIFF
--- a/examples/composition/README.rst
+++ b/examples/composition/README.rst
@@ -7,4 +7,6 @@ file format that allows both CSV and JSON to co-exist.
 We show how, by using namespaces, Lark grammars and their transformers can be fully reused -
 they don't need to care if their grammar is used directly, or being imported, or who is doing the importing.
 
-See `main.py <main.py>`_ for more details.
+See `main.py`_ for more details.
+
+.. _main.py: https://github.com/lark-parser/lark/blob/master/examples/composition/main.py

--- a/examples/grammars/README.rst
+++ b/examples/grammars/README.rst
@@ -3,4 +3,6 @@ Example Grammars
 
 This directory is a collection of lark grammars, taken from real world projects.
 
-- `Verilog <verilog.lark>`_ - Taken from https://github.com/circuitgraph/circuitgraph/blob/master/circuitgraph/parsing/verilog.lark
+- `Verilog`_ - Taken from https://github.com/circuitgraph/circuitgraph
+
+.. _Verilog: https://github.com/circuitgraph/circuitgraph/blob/main/circuitgraph/parsing/verilog.lark


### PR DESCRIPTION
Fixes invalid document link for https://github.com/lark-parser/lark/issues/1335.