### PR TITLE
Remove non-standard `__path__` modification.

### DIFF
--- a/lark/load_grammar.py
+++ b/lark/load_grammar.py
@@ -25,7 +25,6 @@ from .tree import Tree, SlottedTree as ST
 from .visitors import Transformer, Visitor, v_args, Transformer_InPlace, Transformer_NonRecursive
 inline_args = v_args(inline=True)
 
-__path__ = os.path.dirname(__file__)
 IMPORT_PATHS = ['grammars']
 
 EXT = '.lark'

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -39,7 +39,6 @@ from lark.indenter import Indenter
 
 __all__ = ['TestParsers']
 
-__path__ = os.path.dirname(__file__)
 def _read(n, *args):
     with open(os.path.join(__path__, n), *args) as f:
         return f.read()


### PR DESCRIPTION
`__path__` of a package is treated as iterable, whose elements are search paths of submodules.

The assignment here seems to not have any effect and could cause trouble during the importing. It could be `[os.path.dirname(__file__)]`, but that's still the default value of the value.