### PR TITLE
Part 1: doc restructure, introduce categories

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,9 +6,32 @@
 Welcome to Lark's documentation!
 ================================
 
+
+Lark is a modern parsing library for Python. Lark can parse any context-free grammar.
+
+Lark provides:
+
+- Advanced grammar language, based on EBNF
+- Three parsing algorithms to choose from: Earley, LALR(1) and CYK
+- Automatic tree construction, inferred from your grammar
+- Fast unicode lexer with regexp support, and automatic line-counting
+
+Refer to the section :doc:`features` for more information.
+
+
+Install Lark
+--------------
+
+.. code:: bash
+
+   $ pip install lark
+
+
+-------
+
 .. toctree::
    :maxdepth: 2
-   :caption: Tutorial
+   :caption: First steps
 
    json_tutorial
    examples/index
@@ -30,12 +53,12 @@ Welcome to Lark's documentation!
 
    philosophy
    parsers
+   resources
 
 
 .. toctree::
    :maxdepth: 2
    :caption: Reference
-   :hidden:
 
    grammar
    tree_construction
@@ -43,86 +66,3 @@ Welcome to Lark's documentation!
    visitors
    forest
    tools
-
-
-
-
-Lark is a modern parsing library for Python. Lark can parse any context-free grammar.
-
-Lark provides:
-
-- Advanced grammar language, based on EBNF
-- Three parsing algorithms to choose from: Earley, LALR(1) and CYK
-- Automatic tree construction, inferred from your grammar
-- Fast unicode lexer with regexp support, and automatic line-counting
-
-
-Install Lark
---------------
-
-.. code:: bash
-
-   $ pip install lark
-
-Syntax Highlighting
--------------------
-
--  `Sublime Text & TextMate`_
--  `Visual Studio Code`_ (Or install through the vscode plugin system)
--  `Intellij & PyCharm`_
--  `Vim`_
--  `Atom`_
-
-.. _Sublime Text & TextMate: https://github.com/lark-parser/lark_syntax
-.. _Visual Studio Code: https://github.com/lark-parser/vscode-lark
-.. _Intellij & PyCharm: https://github.com/lark-parser/intellij-syntax-highlighting
-.. _Vim: https://github.com/lark-parser/vim-lark-syntax
-.. _Atom: https://github.com/Alhadis/language-grammars
-
-Resources
----------
-
--  :doc:`philosophy`
--  :doc:`features`
--  `Examples`_
--  `Third-party examples`_
--  `Online IDE`_
--  Tutorials
-
-   -  `How to write a DSL`_ - Implements a toy LOGO-like language with
-      an interpreter
-   -  :doc:`json_tutorial` - Teaches you how to use Lark
-   -  Unofficial
-
-      -  `Program Synthesis is Possible`_ - Creates a DSL for Z3
-      -  `Using Lark to Parse Text - Robin Reynolds-Haertle (PyCascades 2023) <https://www.youtube.com/watch?v=CeOtqlh0UuQ>`_ (video presentation)
-
--  Guides
-
-   -  :doc:`how_to_use`
-   -  :doc:`how_to_develop`
-
--  Reference
-
-   -  :doc:`grammar`
-   -  :doc:`tree_construction`
-   -  :doc:`visitors`
-   -  :doc:`forest`
-   -  :doc:`classes`
-   -  :doc:`tools`
-   -  `Cheatsheet (PDF)`_
-
--  Discussion
-
-   -  `Gitter`_
-   -  `Forum (Google Groups)`_
-
-
-.. _Examples: https://github.com/lark-parser/lark/tree/master/examples
-.. _Third-party examples: https://github.com/ligurio/lark-grammars
-.. _Online IDE: https://lark-parser.org/ide
-.. _How to write a DSL: http://blog.erezsh.com/how-to-write-a-dsl-in-python-with-lark/
-.. _Program Synthesis is Possible: https://www.cs.cornell.edu/~asampson/blog/minisynth.html
-.. _Cheatsheet (PDF): _static/lark_cheatsheet.pdf
-.. _Gitter: https://gitter.im/lark-parser/Lobby
-.. _Forum (Google Groups): https://groups.google.com/forum/#!forum/lark-parser

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,23 +8,28 @@ Welcome to Lark's documentation!
 
 .. toctree::
    :maxdepth: 2
-   :caption: Overview
-   :hidden:
+   :caption: Tutorial
 
-   philosophy
+   json_tutorial
+   examples/index
    features
-   parsers
+
 
 .. toctree::
    :maxdepth: 2
-   :caption: Tutorials & Guides
-   :hidden:
+   :caption: How-to guides
 
-   json_tutorial
+   recipes
    how_to_use
    how_to_develop
-   recipes
-   examples/index
+
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Addendum
+
+   philosophy
+   parsers
 
 
 .. toctree::
@@ -38,6 +43,7 @@ Welcome to Lark's documentation!
    visitors
    forest
    tools
+
 
 
 

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -1,0 +1,41 @@
+# Resources
+
+-  [philosophy](philosophy.md)
+-  [features](features.md)
+-  [Examples](https://github.com/lark-parser/lark/tree/master/examples)
+-  [Third-party examples](https://github.com/ligurio/lark-grammars)
+-  [Online IDE](https://lark-parser.org/ide)
+-  Tutorials
+
+   -  [How to write a DSL](http://blog.erezsh.com/how-to-write-a-dsl-in-python-with-lark/) - Implements a toy LOGO-like language with
+      an interpreter
+   -  :doc:`json_tutorial` - Teaches you how to use Lark
+   -  Unofficial
+
+      -  [Program Synthesis is Possible](https://www.cs.cornell.edu/~asampson/blog/minisynth.html) - Creates a DSL for Z3
+      -  [Using Lark to Parse Text - Robin Reynolds-Haertle (PyCascades 2023)](https://www.youtube.com/watch?v=CeOtqlh0UuQ) (video presentation)
+
+- Syntax Highlighting
+
+   - [Sublime Text & TextMate](https://github.com/lark-parser/lark_syntax)
+   - [Visual Studio Code](https://github.com/lark-parser/vscode-lark) (Or install through the vscode plugin system)
+   -  [Intellij & PyCharm](https://github.com/lark-parser/intellij-syntax-highlighting)
+   -  [Vim](https://github.com/lark-parser/vim-lark-syntax)
+   -  [Atom](https://github.com/Alhadis/language-grammars)
+
+-  Reference
+
+   -  [Cheatsheet (PDF)](_static/lark_cheatsheet.pdf)
+<!--
+   -  [grammar](grammar.md)
+   -  [tree_construction](tree_construction.md)
+   -  :doc:`visitors.rst`
+   -  :doc:`forest.rst`
+   -  :doc:`classes.rst`
+   -  [tools](tools.md) -->
+   
+
+-  Discussion
+
+   -  [Gitter](https://gitter.im/lark-parser/Lobby)
+   -  [Forum (Google Groups)](https://groups.google.com/forum/#!forum/lark-parser)


### PR DESCRIPTION
Based on the discussions on issue #1360, this PR contains the following changes for part 1:

* Introduce the categories "First steps", how-to guides (recipes), addendum, and references based on the Diátaxis doc framework
* Clean up the first page and move some resources into `resources.md` file.

I've compiled it with `make html` but got some warnings. However, it seems, they are exist in the master branch as well.

Let me know what you think, @erezsh.