### PR TITLE
Run tests against Python 3.12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04   # See https://github.com/actions/setup-python/issues/544
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "pypy-3.7"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.7"]
 
     steps:
       - uses: actions/checkout@v3

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint, type, py36, py37, py38, py39, py310, py311, pypy3
+envlist = lint, type, py36, py37, py38, py39, py310, py311, py312, pypy3
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
https://blog.python.org/2023/10/python-3120-final-now-available.html