### PR TITLE
Make lark.lark parse the same grammar as load_grammar.py, and make grammar.md document it more fully.

### DIFF
--- a/docs/tree_construction.md
+++ b/docs/tree_construction.md
@@ -74,6 +74,7 @@ Lark will parse "((hello world))" as:
 The brackets do not appear in the tree by design. The words appear because they are matched by a named terminal.
 
 
+<a name="shaping_the_tree"></a>
 ## Shaping the tree
 
 Users can alter the automatic construction of the tree using a collection of grammar features.

--- a/lark/grammars/lark.lark
+++ b/lark/grammars/lark.lark
@@ -7,46 +7,66 @@ _item: rule
      | token
      | statement
 
-rule: RULE rule_params priority? ":" expansions
-token: TOKEN token_params priority? ":" expansions
+rule: RULE_MODIFIERS? RULE rule_params priority? ":" rule_expansions
+token: TOKEN priority? ":" token_expansions
 
 rule_params: ["{" RULE ("," RULE)* "}"]
-token_params: ["{" TOKEN ("," TOKEN)* "}"]
 
 priority: "." NUMBER
 
-statement: "%ignore" expansions                    -> ignore
+statement: "%ignore" ignore_token                  -> ignore
          | "%import" import_path ["->" name]       -> import
          | "%import" import_path name_list         -> multi_import
          | "%override" rule                        -> override_rule
+         | "%override" token                       -> override_token
          | "%declare" name+                        -> declare
+         | "%extend" rule                          -> extend_rule
+         | "%extend" token                         -> extend_token
+
+ignore_token: ignore_item [ OP | "~" NUMBER [".." NUMBER]]
+ignore_item: STRING | TOKEN | REGEXP
 
 !import_path: "."? name ("." name)*
 name_list: "(" name ("," name)* ")"
 
-?expansions: alias (_VBAR alias)*
+?rule_expansions: rule_alias (_VBAR rule_alias)*
 
-?alias: expansion ["->" RULE]
+?rule_inner_expansions: rule_expansion (_VBAR rule_expansion)*
 
-?expansion: expr*
+?rule_alias: rule_expansion ["->" RULE]
 
-?expr: atom [OP | "~" NUMBER [".." NUMBER]]
+?rule_expansion: rule_expr*
 
-?atom: "(" expansions ")"
-     | "[" expansions "]" -> maybe
-     | value
+?rule_expr: rule_atom [OP | "~" NUMBER [".." NUMBER]]
+?rule_atom: "(" rule_inner_expansions ")"
+          | "[" rule_inner_expansions "]" -> rule_maybe
+          | rule_value
 
-?value: STRING ".." STRING -> literal_range
-      | name
-      | (REGEXP | STRING) -> literal
-      | name "{" value ("," value)* "}" -> template_usage
+?rule_value: RULE "{" rule_value ("," rule_value)* "}" -> rule_template_usage
+           | RULE
+           | token_value
+
+?token_expansions: token_expansion (_VBAR token_expansion)*
+
+?token_expansion: token_expr*
+
+?token_expr: token_atom [OP | "~" NUMBER [".." NUMBER]]
+
+?token_atom: "(" token_expansions ")"
+           | "[" token_expansions "]" -> token_maybe
+           | token_value
+
+?token_value: STRING ".." STRING -> literal_range
+            | TOKEN
+            | (REGEXP | STRING) -> literal
 
 name: RULE
     | TOKEN
 
 _VBAR: _NL? "|"
 OP: /[+*]|[?](?![a-z])/
-RULE: /!?[_?]?[a-z][_a-z0-9]*/
+RULE: /_?[a-z][_a-z0-9]*/
+RULE_MODIFIERS: /!|![?](?=[a-z])|[?]!?(?=[a-z])/
 TOKEN: /_?[A-Z][_A-Z0-9]*/
 STRING: _STRING "i"?
 REGEXP: /\/(?!\/)(\\\/|\\\\|[^\/])*?\/[imslux]*/

--- a/tests/test_grammar_formal.py
+++ b/tests/test_grammar_formal.py
@@ -1,0 +1,169 @@
+from __future__ import absolute_import
+
+import os
+from unittest import TestCase, main
+
+from lark import lark, Lark, UnexpectedToken
+from lark.load_grammar import GrammarError
+
+
+# Based on TestGrammar, with lots of tests that can't be run elided.
+class TestGrammarFormal(TestCase):
+    def setUp(self):
+        lark_path = os.path.join(os.path.dirname(lark.__file__), 'grammars/lark.lark')
+        # lark_path = os.path.join(os.path.dirname(lark.__file__), 'grammars/lark.lark-ORIG')
+        with open(lark_path, 'r') as f:
+            self.lark_grammar = "\n".join(f.readlines())
+
+    def test_errors(self):
+        # raise NotImplementedError("Doesn't work yet.")
+        l = Lark(self.lark_grammar, parser="lalr")
+
+        # This is an unrolled form of the test_grammar.py:GRAMMAR_ERRORS tests, because the lark.lark messages vary.
+
+        # 'Incorrect type of value', 'a: 1\n'
+        self.assertRaisesRegex(UnexpectedToken, 'Unexpected token Token..NUMBER., .1..', l.parse, 'a: 1\n')
+        # 'Unclosed parenthesis', 'a: (\n'
+        self.assertRaisesRegex(UnexpectedToken, 'Unexpected token Token.._NL.,', l.parse, 'a: (\n')
+        # 'Unmatched closing parenthesis', 'a: )\n'
+        self.assertRaisesRegex(UnexpectedToken, 'Unexpected token Token..RPAR.', l.parse, 'a: )\n')
+        # 'Unmatched closing parenthesis', 'a: )\n'
+        self.assertRaisesRegex(UnexpectedToken, 'Unexpected token Token..RPAR.,', l.parse, 'a: )\n')
+        # 'Unmatched closing parenthesis', 'a: (\n'
+        self.assertRaisesRegex(UnexpectedToken, 'Unexpected token Token.._NL.,', l.parse, 'a: (\n')
+        # 'Expecting rule or terminal definition (missing colon)', 'a\n'
+        self.assertRaisesRegex(UnexpectedToken, 'Unexpected token Token.._NL.,', l.parse, 'a\n')
+        # 'Expecting rule or terminal definition (missing colon)', 'A\n'
+        self.assertRaisesRegex(UnexpectedToken, 'Unexpected token Token.._NL.,', l.parse, 'A\n')
+        # 'Expecting rule or terminal definition (missing colon)', 'a->\n'
+        self.assertRaisesRegex(UnexpectedToken, 'Unexpected token Token..__ANON_0., .->', l.parse, 'a->\n')
+        # 'Expecting rule or terminal definition (missing colon)', 'A->\n'
+        self.assertRaisesRegex(UnexpectedToken, 'Unexpected token Token..__ANON_0., .->', l.parse, 'A->\n')
+        # 'Expecting rule or terminal definition (missing colon)', 'a A\n'
+        self.assertRaisesRegex(UnexpectedToken, 'Unexpected token Token..TOKEN., .A..', l.parse, 'a A\n')
+        # 'Illegal name for rules or terminals', 'Aa:\n'
+        self.assertRaisesRegex(UnexpectedToken, 'Unexpected token Token..RULE., .a..', l.parse, 'Aa:\n')
+        # 'Alias expects lowercase name', 'a: -> "a"\n'
+        self.assertRaisesRegex(UnexpectedToken, 'Unexpected token Token..STRING., ."a"..', l.parse, 'a: -> "a"\n')
+        # 'Unexpected colon', 'a::\n'
+        self.assertRaisesRegex(UnexpectedToken, 'Unexpected token Token..COLON.,', l.parse, 'a::\n')
+        # 'Unexpected colon', 'a: b:\n'
+        self.assertRaisesRegex(UnexpectedToken, 'Unexpected token Token..COLON.,', l.parse, 'a: b:\n')
+        # 'Unexpected colon', 'a: B:\n'
+        self.assertRaisesRegex(UnexpectedToken, 'Unexpected token Token..COLON.,', l.parse, 'a: B:\n')
+        # 'Unexpected colon', 'a: "a":\n'
+        self.assertRaisesRegex(UnexpectedToken, 'Unexpected token Token..COLON.,', l.parse, 'a: "a":\n')
+        # 'Misplaced operator', 'a: b??'
+        self.assertRaisesRegex(UnexpectedToken, 'Unexpected token Token..OP., .\?..', l.parse, 'a: b??')
+        # 'Misplaced operator', 'a: b(?)'
+        self.assertRaisesRegex(UnexpectedToken, 'Unexpected token Token..OP., .\?..', l.parse, 'a: b(?)')
+        # 'Misplaced operator', 'a:+\n'
+        self.assertRaisesRegex(UnexpectedToken, 'Unexpected token Token..OP., .\+..', l.parse, 'a:+\n')
+        # 'Misplaced operator', 'a:?\n'
+        self.assertRaisesRegex(UnexpectedToken, 'Unexpected token Token..OP., .\?..', l.parse, 'a:?\n')
+        # 'Misplaced operator', 'a:*\n'
+        self.assertRaisesRegex(UnexpectedToken, 'Unexpected token Token..OP., .\*..', l.parse, 'a:*\n')
+        # 'Misplaced operator', 'a:|*\n'
+        self.assertRaisesRegex(UnexpectedToken, 'Unexpected token Token..OP., .\*..', l.parse, 'a:|*\n')
+        # 'Expecting option ("|") or a new rule or terminal definition', 'a:a\n()\n'
+        self.assertRaisesRegex(UnexpectedToken, 'Unexpected token Token..LPAR.,', l.parse, 'a:a\n()\n')
+        # 'Terminal names cannot contain dots', 'A.B\n'
+        self.assertRaisesRegex(UnexpectedToken, 'Unexpected token Token..TOKEN., .B..', l.parse, 'A.B\n')
+        # 'Expecting rule or terminal definition', '"a"\n'
+        self.assertRaisesRegex(UnexpectedToken, 'Unexpected token Token..STRING., ."a"..', l.parse, '"a"\n')
+        # '%import expects a name', '%import "a"\n'
+        self.assertRaisesRegex(UnexpectedToken, 'Unexpected token Token..STRING., ."a"..', l.parse, '%import "a"\n')
+        # '%ignore expects a value', '%ignore %import\n'
+        self.assertRaisesRegex(UnexpectedToken, 'Unexpected token Token..__ANON_2., .%import..', l.parse, '%ignore %import\n')
+
+    # def test_empty_literal(self):
+        # raise NotImplementedError("Breaks tests/test_parser.py:_TestParser:test_backslash2().")
+
+    # def test_ignore_name(self):
+        # raise NotImplementedError("Can't parse using parsed grammar.")
+
+    # def test_override_rule_1(self):
+        # raise NotImplementedError("Can't parse using parsed grammar.")
+
+    # def test_override_rule_2(self):
+        # raise NotImplementedError("Can't test semantics of grammar, only syntax.")
+
+    # def test_override_rule_3(self):
+        # raise NotImplementedError("Can't test semantics of grammar, only syntax.")
+
+    # def test_override_terminal(self):
+        # raise NotImplementedError("Can't parse using parsed grammar.")
+
+    # def test_extend_rule_1(self):
+        # raise NotImplementedError("Can't parse using parsed grammar.")
+
+    # def test_extend_rule_2(self):
+        # raise NotImplementedError("Can't test semantics of grammar, only syntax.")
+
+    # def test_extend_term(self):
+        # raise NotImplementedError("Can't parse using parsed grammar.")
+
+    # def test_extend_twice(self):
+        # raise NotImplementedError("Can't parse using parsed grammar.")
+
+    # def test_undefined_ignore(self):
+        # raise NotImplementedError("Can't parse using parsed grammar.")
+
+    def test_alias_in_terminal(self):
+        l = Lark(self.lark_grammar, parser="lalr")
+        g = """start: TERM
+            TERM: "a" -> alias
+            """
+        # self.assertRaisesRegex( GrammarError, "Aliasing not allowed in terminals", Lark, g)
+        self.assertRaisesRegex( UnexpectedToken, "Unexpected token Token.'__ANON_0', '->'.", l.parse, g)
+
+    # def test_undefined_rule(self):
+        # raise NotImplementedError("Can't test semantics of grammar, only syntax.")
+
+    # def test_undefined_term(self):
+        # raise NotImplementedError("Can't test semantics of grammar, only syntax.")
+
+    # def test_token_multiline_only_works_with_x_flag(self):
+        # raise NotImplementedError("Can't test regex flags in Lark grammar.")
+
+    # def test_import_custom_sources(self):
+        # raise NotImplementedError("Can't parse using parsed grammar.")
+
+    # def test_import_custom_sources2(self):
+        # raise NotImplementedError("Can't parse using parsed grammar.")
+
+    # def test_import_custom_sources3(self):
+        # raise NotImplementedError("Can't parse using parsed grammar.")
+
+    # def test_my_find_grammar_errors(self):
+        # raise NotImplementedError("Can't parse using parsed grammar.")
+
+    # def test_ranged_repeat_terms(self):
+        # raise NotImplementedError("Can't parse using parsed grammar.")
+
+    # def test_ranged_repeat_large(self):
+        # raise NotImplementedError("Can't parse using parsed grammar.")
+
+    # def test_large_terminal(self):
+        # raise NotImplementedError("Can't parse using parsed grammar.")
+
+    # def test_list_grammar_imports(self):
+        # raise NotImplementedError("Can't test semantics of grammar, only syntax.")
+
+    def test_inline_with_expand_single(self):
+        l = Lark(self.lark_grammar, parser="lalr")
+        grammar = r"""
+        start: _a
+        !?_a: "A"
+        """
+        # self.assertRaisesRegex(GrammarError, "Inlined rules (_rule) cannot use the ?rule modifier.", l.parse, grammar)
+        # TODO Is this really catching the right problem?
+        self.assertRaisesRegex(UnexpectedToken, "Unexpected token Token.'OP', '?'.", l.parse, grammar)
+
+
+    # def test_line_breaks(self):
+        # raise NotImplementedError("Can't parse using parsed grammar.")
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_lark_lark.py
+++ b/tests/test_lark_lark.py
@@ -1,0 +1,165 @@
+from __future__ import absolute_import
+
+import os
+from unittest import TestCase, main
+
+from lark import lark, Lark, UnexpectedToken
+from lark.load_grammar import GrammarError
+
+
+# Test that certain previous differences between load_grammar.py and 
+# grammars/lark.lark have been resolved.
+class TestLarkLark(TestCase):
+    def setUp(self):
+        lark_path = os.path.join(os.path.dirname(lark.__file__), 'grammars/lark.lark')
+        # lark_path = os.path.join(os.path.dirname(lark.__file__), 'grammars/lark.lark-ORIG')
+        self.lark_parser = Lark.open(lark_path, parser="lalr")
+
+    def test_01_no_alias_in_terminal_lg(self):
+        g = """start: TERM
+            TERM: "a" -> alias
+            """
+        self.assertRaisesRegex( GrammarError, "Aliasing not allowed in terminals", Lark, g)
+
+    def test_01_no_alias_in_terminal_ll(self):
+        g = """start: TERM
+            TERM: "a" -> alias
+            """
+        self.assertRaisesRegex( UnexpectedToken, "Unexpected token Token.'__ANON_0', '->'.", self.lark_parser.parse, g)
+
+    def test_02_no_rule_aliases_below_top_level_lg(self):
+        g = """start: rule
+            rule: ("a" -> alias
+                 | "b")
+            """
+        self.assertRaisesRegex( GrammarError, "Rule 'alias' used but not defined", Lark, g)
+
+    def test_02_no_rule_aliases_below_top_level_ll(self):
+        g = """start: rule
+            rule: ("a" -> alias
+                 | "b")
+            """
+        self.assertRaisesRegex( UnexpectedToken, "Unexpected token Token.'__ANON_0', '->'.", self.lark_parser.parse, g)
+
+    def test_03_ignore_single_token_lg(self):
+        g = """start: TERM
+        %ignore "a" "b" /c/
+        TERM: "d"
+        """
+        # This SHOULD raise some sort of error, but silently discards the extra tokens instead.
+        # self.assertRaises( UnexpectedToken, Lark, g)
+        Lark(g)
+
+    def test_03_ignore_single_token_ll(self):
+        g = """start: TERM
+        %ignore "a" "b" /c/
+        TERM: "d"
+        """
+        self.assertRaisesRegex( UnexpectedToken, "Unexpected token Token.'STRING', '.b.'.", self.lark_parser.parse, g)
+
+    def test_04_extend_rule_lg(self):
+        g = """
+            %import .grammars.ab (startab, A, B, expr)
+
+            %extend expr: B A
+        """
+        Lark(g, start='startab', source_path=__file__)
+
+    def test_04_extend_rule_ll(self):
+        g = """
+            %import .grammars.ab (startab, A, B, expr)
+
+            %extend expr: B A
+        """
+        self.lark_parser.parse(g)
+
+    def test_05_extend_term_lg(self):
+        g = """
+            %import .grammars.ab (startab, A, B, expr)
+
+            %extend A: "c"
+        """
+        Lark(g, start='startab', source_path=__file__)
+
+    def test_05_extend_term_ll(self):
+        g = """
+            %import .grammars.ab (startab, A, B, expr)
+
+            %extend A: "c"
+        """
+        self.lark_parser.parse(g)
+
+    def test_06_no_term_templates_lg(self):
+        g = """start: TERM
+        separated{x, sep}: x (sep x)* 
+        TERM: separated{"A", " "}
+        """
+        self.assertRaises( AssertionError, Lark, g)
+
+    def test_06_no_term_templates_ll(self):
+        g = """start: TERM
+        separated{x, sep}: x (sep x)* 
+        TERM: separated{"A", " "}
+        """
+        self.assertRaisesRegex( UnexpectedToken, "Unexpected token Token.'RULE', 'separated'.", self.lark_parser.parse, g)
+
+    def test_07_term_no_call_rule_lg(self):
+        g = """start: TERM
+        TERM: rule
+        rule: "a"
+        """
+        self.assertRaisesRegex( GrammarError, "Rules aren't allowed inside terminals", Lark, g)
+
+    def test_07_term_no_call_rule_ll(self):
+        g = """start: TERM
+        TERM: rule
+        rule: "a"
+        """
+        self.assertRaisesRegex( UnexpectedToken, "Unexpected token Token.'RULE', 'rule'.", self.lark_parser.parse, g)
+
+    def test_08_override_term_lg(self):
+        g = """
+            %import .grammars.ab (startab, A, B, expr)
+
+            %override A: "c"
+        """
+        Lark(g, start='startab', source_path=__file__)
+
+    def test_08_override_term_ll(self):
+        g = """
+            %import .grammars.ab (startab, A, B, expr)
+
+            %override A: "c"
+        """
+        self.lark_parser.parse(g)
+
+    def test_09_no_rule_modifiers_in_references_lg(self):
+        g = """start: rule1
+            rule1: !?rule2
+            rule2: "a"
+        """
+        self.assertRaisesRegex(GrammarError, "Expecting a value, at line 2 column 20", Lark, g)
+
+    def test_09_no_rule_modifiers_in_references_ll(self):
+        g = """start: rule1
+            rule1: !rule2
+            rule2: "a"
+        """
+        self.assertRaisesRegex( UnexpectedToken, "Unexpected token Token.'RULE_MODIFIERS', '!'.", self.lark_parser.parse, g)
+
+    def test_10_rule_modifier_query_bang_lg(self):
+        g = """start: rule1
+            rule1: rule2
+            ?!rule2: "a"
+        """
+        Lark(g)
+
+    def test_10_rule_modifier_query_bang_ll(self):
+        g = """start: rule1
+            rule1: rule2
+            ?!rule2: "a"
+        """
+        self.lark_parser.parse(g)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Make `lark.lark` parse the same grammar as `load_grammar.py`, and make `grammar.md` document it more fully.

Fixes #391, #1382, #1384.

- All scenarios have tests in new file `tests/test_lark_lark.py`.  Each test passed `load_grammar.py` and failed `lark.lark` before these changes, and passed both after.  All existing un-skipped unit tests continue to pass after these changes.  The skipped Earley tests have not been checked. 

- Updates to the formal Lark grammar (`lark/grammars/lark.lark`) to make it match the actual parser (`lark/load_grammar.py`)
 1. Token aliases (_e.g._, `NAME_1 -> NAME_2`) are no longer allowed.
    - `load_grammar.py` appears to accept them, but forces the new name to be a rule-name.
    - `tests/test_grammar.py.test_alias_in_terminal` says they should raise a `GrammarError`.
    - Making this change necessitated splitting the shared `expansions` rule, and all the rules it calls, into `rule_expansions` and `token_expansions` (and similarly named rules for them to call).
 1. Rule aliases (`name_1 -> name_2`) are now only valid for alternates at the top-level of a rule.
    - load_grammar.py accepts them at all levels, but as Issue #1355 points out, they are not supported below the top level.
 1. The item in a `%ignore` directive must now be a single token.
    - `load_grammar.py` accepts multiple tokens, but only processes the first.
  1. The `%extend` directive is now defined for rules.
  1. The `%extend` directive is now defined for tokens.
  1. Token templates are no longer allowed (at least until Issue #555 is resolved).
  1. Tokens can no longer include rules.
  1. The `%override` directive now supports overriding token definitions.
  1. Rule modifiers are no longer allowed in rule references (_e.g._, `rule1: !?rule2`)
  1. Rule modifiers are now allowed to be `?!`, in addition to the existing `!`, `?`, and `!?`.

* Several tests in `tests/tests/test_grammar.py` have been copied to new file ` tests/test_grammar_formal.py` and updated to parse using `lark.lark` instead of `load_grammar.py`.  Only the tests that verify how the Lark grammar is parsed could be implemented.  Those that verify how a Lark-generated parser operates could not, because there's no (easy?) way to create a parser from the parse tree.

* Oddities not changed:
  * Literal ranges are defined in both `lark.lark` and `load_grammar.py` as `STRING`s, but must actually be single characters.
    * `load_grammar.py` initially accepts multi-character strings, but later rejects them.
	* Attempting to replace `STRING ".." STRING` in `lark.lark` with `/./ ".." /./` failed, as Lark accepts Unicode escapes as strings (_e.g._ `test_unicode_literal_range_escape2` uses `"\U0000FFFF".."\U00010002"`).
	* Attempting to replace `STRING ".." STRING` in `lark.lark` with `/.|"\\U[0-9a-fA-F]+"/ ".." /.|"\\U[0-9a-fA-F]+"/` failed, causing lots of unrelated tests to fail.
  * `load_grammar.py` does not allow `STRING` tokens to be empty (_i.e._, `""`).  There is no (easy?) way to prevent that in lark.lark.  The obvious answer, adding `/(?<!"")/`, broke `tests/test_parser.py._TestParser.test_backslash2`.
