### PR TITLE
codespell: move and adjust configuration to pyproject.toml, fix few new typos

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,23 @@
+# Codespell configuration is within pyproject.toml
+---
+name: Codespell
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,9 @@ repos:
       exclude: '(^tests/.*\.lark|\.svg)$'
 
 - repo: https://github.com/codespell-project/codespell
-  rev: v2.2.2
+  # Configuration for codespell is in pyproject.toml
+  rev: v2.2.6
   hooks:
     - id: codespell
-      args: ["-L", "nd,iif,ot,datas"]
+      additional_dependencies:
+        - tomli

--- a/README.md
+++ b/README.md
@@ -194,3 +194,4 @@ Questions about code are best asked on [gitter](https://gitter.im/lark-parser/Lo
 For anything else, I can be reached by email at erezshin at gmail com.
 
  -- [Erez](https://github.com/erezsh)
+Installating

--- a/docs/_static/sppf/sppf.html
+++ b/docs/_static/sppf/sppf.html
@@ -161,7 +161,7 @@ $ E ::= E + E \mid 1 $.</p>
 
 <p>Packed nodes $(t,k)$ have one or two children. The right child is a symbol node $(x,k,i)$ and the left child (if it exists) is a symbol or intermediate node with label $(s,j,k)$, where $j \leq k \leq i$. Packed nodes have always exactly one parent which is a symbol node or intermediate node.</p>
 
-<p>It is useful to observe that the SPPF is a bipartite graph, with on the one hand the set of intermediate and symbol nodes and on the other hand the set of packed nodes. Therefore edges always go from a node of the first type to a node of the second type, or the other way round. As a consequence, cyles in the SPPF are always of even length.</p>
+<p>It is useful to observe that the SPPF is a bipartite graph, with on the one hand the set of intermediate and symbol nodes and on the other hand the set of packed nodes. Therefore edges always go from a node of the first type to a node of the second type, or the other way round. As a consequence, cycles in the SPPF are always of even length.</p>
 
 <h2 id="transformation-to-an-abstract-syntax-tree">Transformation to an abstract syntax tree</h2>
 

--- a/examples/composition/main.py
+++ b/examples/composition/main.py
@@ -15,7 +15,7 @@ file format that allows both CSV and JSON to co-exist.
    The resulting transformer can evaluate both JSON and CSV in the parse tree.
 
   The methods of each transformer are renamed into their appropriate namespace, using the given prefix.
-  This approach allows full re-use: the transformers don't need to care if their grammar is used directly,
+  This approach allows full reuse: the transformers don't need to care if their grammar is used directly,
   or being imported, or who is doing the importing.
 
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,3 +95,9 @@ exclude_lines = [
 ]
 [tool.pyright]
 include = ["lark"]
+
+[tool.codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = '.git,*.pdf,*.svg'
+check-hidden = true
+ignore-words-list = 'nd,iif,ot,datas,foor'


### PR DESCRIPTION
Best to have configuration(s) in central place so people could just use `codespell` without pre-commit

TODOs

- [ ] remove TMP commit with typo after having verified that pre-commit does catch it. If does -- also remove that added workflow