### PR TITLE
Correctly put terminals into non-capturing groups when combining them

### DIFF
--- a/lark/load_grammar.py
+++ b/lark/load_grammar.py
@@ -625,7 +625,7 @@ class TerminalTreeToPattern(Transformer_NonRecursive):
         if len(items) == 1:
             return items[0]
 
-        pattern = ''.join(i.to_regexp() for i in items)
+        pattern = ''.join(f'(?:{i.to_regexp()})' for i in items)
         return _make_joined_pattern(pattern, {i.flags for i in items})
 
     def expansions(self, exps: List[Pattern]) -> Pattern:
@@ -636,7 +636,7 @@ class TerminalTreeToPattern(Transformer_NonRecursive):
         # (Python's re module otherwise prefers just 'l' when given (l|ll) and both could match)
         exps.sort(key=lambda x: (-x.max_width, -x.min_width, -len(x.value)))
 
-        pattern = '(?:%s)' % ('|'.join(i.to_regexp() for i in exps))
+        pattern = '(?:%s)' % ('|'.join(f'(?:{i.to_regexp()})' for i in exps))
         return _make_joined_pattern(pattern, {i.flags for i in exps})
 
     def expr(self, args) -> Pattern:
@@ -652,7 +652,7 @@ class TerminalTreeToPattern(Transformer_NonRecursive):
                 op = "{%d,%d}" % (mn, mx)
         else:
             assert len(args) == 2
-        return PatternRE('(?:%s)%s' % (inner.to_regexp(), op), inner.flags)
+        return PatternRE(f'(?:{inner.to_regexp()}){op}', inner.flags)
 
     def maybe(self, expr):
         return self.expr(expr + ['?'])

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -257,6 +257,19 @@ class TestGrammar(TestCase):
         self.assertRaises(UnexpectedInput, l.parse, u'A' * 8190)
         self.assertRaises(UnexpectedInput, l.parse, u'A' * 8192)
 
+    def test_term_combine(self):
+        # Issue #1414
+        g = """
+        start: START
+        START: A B C
+        A: "a"
+        B: "b"
+        C: /c|d/
+        """
+        l = Lark(g, parser='lalr')
+        self.assertEqual(l.parse('abc'), Tree('start', ['abc']))
+        self.assertEqual(l.parse('abd'), Tree('start', ['abd']))
+
     def test_large_terminal(self):
         g = "start: NUMBERS\n"
         g += "NUMBERS: " + '|'.join('"%s"' % i for i in range(0, 1000))


### PR DESCRIPTION
Fix #1414

The core issue is that `A B` got turned into `/{A}{B}/` instead of `/(?:{A})(?:{B})/`. Most of the time, this doesn't matter, however if `B` is a manually defined regex, for example `/c|d/`, the overall regex ended up being `/ac|d/`, which ofcourse means something else than the BNF was supposed to express.

This is technically a breaking change if people were relying on this buggy behavior.