### PR TITLE
Bugfix: Earley now respects ambiguity='resolve' again. Bug was introd…

### DIFF
--- a/lark/parsers/earley.py
+++ b/lark/parsers/earley.py
@@ -306,7 +306,7 @@ class Parser:
             transformer = ForestToParseTree(self.Tree, self.callbacks, self.forest_sum_visitor and self.forest_sum_visitor(), self.resolve_ambiguity, use_cache)
             solutions = [transformer.transform(s) for s in solutions]
 
-            if len(solutions) > 1:
+            if len(solutions) > 1 and not self.resolve_ambiguity:
                 t: Tree = self.Tree('_ambig', solutions)
                 t.expand_kids_by_data('_ambig')     # solutions may themselves be _ambig nodes
                 return t

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -841,6 +841,11 @@ def _make_full_earley_test(LEXER):
             )
             self.assertEqual(tree, expected)
 
+            l = Lark(grammar, ambiguity='resolve', lexer=LEXER)
+            tree = l.parse('x')
+            assert tree == Tree('start', ['x'])
+
+
         def test_cycle(self):
             grammar = """
             start: start?


### PR DESCRIPTION
Reported in #1443 

The bug was introduced in a previous bugfix.