### PR TITLE
Rephrase v_args() documentation to underline it is related to Transformer classes only

### DIFF
--- a/lark/visitors.py
+++ b/lark/visitors.py
@@ -511,12 +511,12 @@ def _vargs_tree(f, data, children, meta):
 
 
 def v_args(inline: bool = False, meta: bool = False, tree: bool = False, wrapper: Optional[Callable] = None) -> Callable[[_DECORATED], _DECORATED]:
-    """A convenience decorator factory for modifying the behavior of user-supplied visitor methods.
+    """A convenience decorator factory for modifying the behavior of user-supplied visitor methods of ``Transformer`` classes.
 
-    By default, callback methods of transformers/visitors accept one argument - a list of the node's children.
+    By default, visitor callback methods accept one argument - a list of the node's children.
 
-    ``v_args`` can modify this behavior. When used on a transformer/visitor class definition,
-    it applies to all the callback methods inside it.
+    ``v_args`` can modify this behavior. When used on a ``Transformer`` class definition, it applies to
+    all the callback methods inside it.
 
     ``v_args`` can be applied to a single method, or to an entire class. When applied to both,
     the options given to the method take precedence.


### PR DESCRIPTION
Related to issue #1457, rewording the documentation of `v_args()` to specify it is only applicable to `Transformer` classes.