### PR TITLE
Better error in Lark.parse when using on_error when parser!=lalr (issue #1311)

### DIFF
--- a/lark/lark.py
+++ b/lark/lark.py
@@ -652,6 +652,8 @@ class Lark(Serialize):
                 For convenience, these sub-exceptions also inherit from ``ParserError`` and ``LexerError``.
 
         """
+        if on_error is not None and self.options.parser != 'lalr':
+            raise NotImplementedError("The on_error option is only implemented for the LALR(1) parser.")
         return self.parser.parse(text, start=start, on_error=on_error)
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2584,6 +2584,11 @@ def _make_parser_test(LEXER, PARSER):
             s = "[0 1, 2,@, 3,,, 4, 5 6 ]$"
             tree = g.parse(s, on_error=ignore_errors)
 
+        @unittest.skipIf(PARSER == 'lalr', "test on_error only works with lalr")
+        def test_on_error_without_lalr(self):
+            p = _Lark(r"""start: "A" """)
+            self.assertRaises(NotImplementedError, p.parse, "", on_error=print)
+
         @unittest.skipIf(PARSER != 'lalr', "interactive_parser error handling only works with LALR for now")
         def test_iter_parse(self):
             ab_grammar = '!start: "a"* "b"*'


### PR DESCRIPTION
Not much to review, but I'll still leave it up for comments for a while