### PR TITLE
Fix `Symbol.__eq__` to return false when comparing with None

### DIFF
--- a/lark/grammar.py
+++ b/lark/grammar.py
@@ -16,8 +16,12 @@ class Symbol(Serialize):
         self.name = name
 
     def __eq__(self, other):
-        if not isinstance(other, Symbol):
+        if other is None:
             return False
+        if not isinstance(other, Symbol):
+            raise NotImplementedError(
+                f"Comparing a Symbol with type {type(other).__name__} is not implemented"
+            )
         return self.is_term == other.is_term and self.name == other.name
 
     def __ne__(self, other):

--- a/lark/grammar.py
+++ b/lark/grammar.py
@@ -16,12 +16,8 @@ class Symbol(Serialize):
         self.name = name
 
     def __eq__(self, other):
-        if other is None:
-            return False
         if not isinstance(other, Symbol):
-            raise NotImplementedError(
-                f"Comparing a Symbol with type {type(other).__name__} is not implemented"
-            )
+            return NotImplemented
         return self.is_term == other.is_term and self.name == other.name
 
     def __ne__(self, other):

--- a/lark/grammar.py
+++ b/lark/grammar.py
@@ -16,7 +16,8 @@ class Symbol(Serialize):
         self.name = name
 
     def __eq__(self, other):
-        assert isinstance(other, Symbol), other
+        if not isinstance(other, Symbol):
+            return False
         return self.is_term == other.is_term and self.name == other.name
 
     def __ne__(self, other):

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -302,6 +302,14 @@ class TestGrammar(TestCase):
 
         self.assertNotEqual(a, b)
 
+        a = dict()
+
+        self.assertRaisesRegex(
+            NotImplementedError,
+            r"Comparing a Symbol with type dict is not implemented",
+            lambda: a == b,
+        )
+
 
 if __name__ == '__main__':
     main()

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -6,7 +6,7 @@ from unittest import TestCase, main
 from lark import Lark, Token, Tree, ParseError, UnexpectedInput
 from lark.load_grammar import GrammarError, GRAMMAR_ERRORS, find_grammar_errors, list_grammar_imports
 from lark.load_grammar import FromPackageLoader
-
+from lark.grammar import Symbol
 
 class TestGrammar(TestCase):
     def setUp(self):
@@ -296,8 +296,11 @@ class TestGrammar(TestCase):
         p.parse('ab')
 
 
+    def test_symbol_eq(self):
+        a = None
+        b = Symbol("abc")
 
-
+        self.assertNotEqual(a, b)
 
 
 if __name__ == '__main__':

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -302,14 +302,6 @@ class TestGrammar(TestCase):
 
         self.assertNotEqual(a, b)
 
-        a = dict()
-
-        self.assertRaisesRegex(
-            NotImplementedError,
-            r"Comparing a Symbol with type dict is not implemented",
-            lambda: a == b,
-        )
-
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Fixes #1476. `Symbol.__eq__` now returns False when comparing with an object that is not an instance of the Symbol class.