### PR TITLE
Mention internal/external transformers in the documentation

### DIFF
--- a/lark/parse_tree_builder.py
+++ b/lark/parse_tree_builder.py
@@ -320,7 +320,7 @@ def inplace_transformer(func):
 
 def apply_visit_wrapper(func, name, wrapper):
     if wrapper is _vargs_meta or wrapper is _vargs_meta_inline:
-        raise NotImplementedError("Meta args not supported for internal transformer")
+        raise NotImplementedError("Meta args not supported for internal transformer; use YourTransformer().transform(parser.parse()) instead")
 
     @wraps(func)
     def f(children):

--- a/lark/visitors.py
+++ b/lark/visitors.py
@@ -523,7 +523,7 @@ def v_args(inline: bool = False, meta: bool = False, tree: bool = False, wrapper
 
     Parameters:
         inline (bool, optional): Children are provided as ``*args`` instead of a list argument (not recommended for very long lists).
-        meta (bool, optional): Provides two arguments: ``meta`` and ``children`` (instead of just the latter); ``meta`` is only available for external transformers (i.e., those not supplied as ``Lark``'s ``transformer`` parameter).
+        meta (bool, optional): Provides two arguments: ``meta`` and ``children`` (instead of just the latter); ``meta`` isn't available for transformers supplied to Lark using the ``transformer`` parameter (aka internal transformers).
         tree (bool, optional): Provides the entire tree as the argument, instead of the children.
         wrapper (function, optional): Provide a function to decorate all methods.
 

--- a/lark/visitors.py
+++ b/lark/visitors.py
@@ -523,7 +523,7 @@ def v_args(inline: bool = False, meta: bool = False, tree: bool = False, wrapper
 
     Parameters:
         inline (bool, optional): Children are provided as ``*args`` instead of a list argument (not recommended for very long lists).
-        meta (bool, optional): Provides two arguments: ``meta`` and ``children`` (instead of just the latter)
+        meta (bool, optional): Provides two arguments: ``meta`` and ``children`` (instead of just the latter); ``meta`` is only available for external transformers (i.e., those not supplied as ``Lark``'s ``transformer`` parameter).
         tree (bool, optional): Provides the entire tree as the argument, instead of the children.
         wrapper (function, optional): Provide a function to decorate all methods.
 


### PR DESCRIPTION
Helps users not fall into a problem similar to #408 — which I recently did.

I'm sure the actual text could be improved; feel free to modify it to taste, but I do think it would be helpful to have this or something similar in the docs. Thanks for the library!