### PR TITLE
Longest match lexer option to mimic the Unix tool Lex

### DIFF
--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -135,6 +135,8 @@ When using a lexer (basic or contextual), it is the grammar-author's responsibil
 3. Length of literal / pattern definition
 4. Name
 
+When using the longest_match lexer, for matches that have the same length the literal that is defined first is used.
+
 **Examples:**
 ```perl
 IF: "if"

--- a/docs/how_to_use.md
+++ b/docs/how_to_use.md
@@ -44,7 +44,7 @@ But if it doesn't, feel free to ask us on gitter, or even open an issue. Post a 
 
 ### Regex collisions
 
-A likely source of bugs occurs when two regexes in a grammar can match the same input. If both terminals have the same priority, most lexers would arbitrarily choose the first one that matches, which isn't always the desired one. (a notable exception is the `dynamic_complete` lexer, which always tries all variations. But its users pay for that with performance.)
+A likely source of bugs occurs when two regexes in a grammar can match the same input. If both terminals have the same priority, most lexers would arbitrarily choose the first one that matches, which isn't always the desired one. (a notable exception is the `dynamic_complete` lexer, which always tries all variations. But its users pay for that with performance.) The `longest_match` lexer chooses the terminal with the longest matched length, similiar to the Unix tool "Lex".
 
 These collisions can be hard to notice, and their effects can be difficult to debug, as they are subtle and sometimes hard to reproduce.
 

--- a/lark/lexer.py
+++ b/lark/lexer.py
@@ -391,6 +391,31 @@ class Scanner:
                 return m.group(0), m.lastgroup
 
 
+class LongestMatchScanner:
+    def __init__(self, terminals, g_regex_flags, re_, use_bytes):
+        self.terminals = terminals
+        self.g_regex_flags = g_regex_flags
+        self.use_bytes = use_bytes
+
+        self.name_regex = {}
+        for t in self.terminals:
+            pattern = t.pattern.to_regexp()
+            if self.use_bytes:
+                pattern = pattern.encode('latin-1')
+            self.name_regex[t.name] = re_.compile(pattern, self.g_regex_flags)
+
+    def match(self, text, pos):
+        longestMatchLen = -1
+        longestMatch = None
+        for name, regex in self.name_regex.items():
+            m = regex.match(text, pos)
+            if m and longestMatchLen < len(m.group()):
+                longestMatchLen = len(m.group())
+                longestMatch = (m.group(0), name)
+
+        return longestMatch
+
+
 def _regexp_has_newline(r: str):
     r"""Expressions that may indicate newlines in a regexp:
         - newlines (\n)
@@ -620,6 +645,25 @@ class BasicLexer(AbstractBasicLexer):
 
         # EOF
         raise EOFError(self)
+
+
+class LongestMatchLexer(BasicLexer):
+    def __init__(self, conf: 'LexerConf', comparator=None) -> None:
+        super().__init__(conf, comparator)
+        self.terminals = list(conf.terminals)
+
+    def _build_scanner(self):
+        terminals, self.callback = _create_unless(self.terminals, self.g_regex_flags, self.re, self.use_bytes)
+        assert all(self.callback.values())
+
+        for type_, f in self.user_callbacks.items():
+            if type_ in self.callback:
+                # Already a callback there, probably UnlessCallback
+                self.callback[type_] = CallChain(self.callback[type_], f, lambda t: t.type == type_)
+            else:
+                self.callback[type_] = f
+
+        self._scanner = LongestMatchScanner(terminals, self.g_regex_flags, self.re, self.use_bytes)
 
 
 class ContextualLexer(Lexer):

--- a/lark/lexer.py
+++ b/lark/lexer.py
@@ -396,6 +396,7 @@ class LongestMatchScanner:
         self.terminals = terminals
         self.g_regex_flags = g_regex_flags
         self.use_bytes = use_bytes
+        self.allowed_types = {t.name for t in self.terminals}
 
         self.name_regex = {}
         for t in self.terminals:


### PR DESCRIPTION
Hi. I added a lexer for the lalr parser as a complement, which mimics the behavior of the Unix tool [Lex](https://man7.org/linux/man-pages/man1/lex.1p.html) and libraries such as [flex](https://westes.github.io/flex/manual/Matching.html#Matching). The behavior in question is to: match with the longest match found; if there are multiple longest matches the precedence of the terminals is in the order that they are defined.

This also means that the terminals are **not** sorted according to the priority rules defined in grammar.md:
1. Highest priority first (priority is specified as: TERM.number: ...)
2. Length of match (for regexps, the longest _theoretical_ match is used)
3. Length of literal / pattern definition
4. Name

By not relying on the above rules for precedence, it is possible to use grammars defined for Lex and its derivations in Lark.

Below follows an example using `longest_match`:

```
from lark import Lark

parser = Lark(r"""
        start: AB -> ab
          | AC -> ac
        
        AB: /a(b)*/
        AC: /a(c)*/
        
        """, parser='lalr', lexer='longest_match')

data = 'ac'
tree = parser.parse(data)
print(tree)
```
This is a grammar that neither the basic nor contextual lexer can deal with. Both will use AB, and the contextual will not try AC as AB is a possible token to parse from start. It's not possible for the programmer to set the precedence in this scenario to tokenize "ab" or "ac" correctly. Using basic yields:
```
lark.exceptions.UnexpectedCharacters: No terminal matches 'c' in the current parser context, at line 1 col 2

ac
 ^
Expected one of: 
	* AB
	* AC
```
Using contextual yields:
```
lark.exceptions.UnexpectedCharacters: No terminal matches 'c' in the current parser context, at line 1 col 2

ac
 ^
Expected one of: 
	* <END-OF-FILE>

Previous tokens: Token('AB', 'a')
```
Regarding the implementation it consists of a new lexer and a new scanner: LongestMatchLexer, which inherits from BasicLexer; LongestMatchScanner, which attempts to match against every terminal, yielding the longest match. (Not optimal - but it's an option.)

It seems some other users have attempted to use longest matches (as I tried when I used lark first):
https://github.com/lark-parser/lark/issues/370
https://github.com/lark-parser/lark/issues/1463

Edit:
An issue with using **earley** instead, is that it may not yield the desired result for ambiguous grammars such as in the example below (which is a simplification of a grammar that worked for a lex derivation):
```
from lark import Lark

grammar = r"""
  start: INTEGER "." INTEGER -> eproj
    | DOUBLE -> double

    INTEGER: /\d+/
    DOUBLE: /\d+\.\d+/
"""

parser = Lark(grammar, start='start', parser='earley')
result = parser.parse("1.2")
print(result)
```
Which yields:
```
Tree('eproj', [Token('INTEGER', '1'), Token('INTEGER', '2')])
```