### PR TITLE
Tree.data typing - extend type with Token class

### DIFF
--- a/lark/tree.py
+++ b/lark/tree.py
@@ -51,10 +51,10 @@ class Tree(Generic[_Leaf_T]):
             contain 'a' will consider it in full, including _A and _C for all attributes.
     """
 
-    data: str
+    data: Union[str, "Token"]
     children: 'List[Branch[_Leaf_T]]'
 
-    def __init__(self, data: str, children: 'List[Branch[_Leaf_T]]', meta: Optional[Meta]=None) -> None:
+    def __init__(self, data: Union[str, "Token"], children: 'List[Branch[_Leaf_T]]', meta: Optional[Meta]=None) -> None:
         self.data = data
         self.children = children
         self._meta = meta


### PR DESCRIPTION
Because it tends to be `Token` also.

See example below:
```python
from lark import Lark, Tree

grammar = """
    start: entity+
    entity: "entity"
"""

parser = Lark(grammar)
tree = parser.parse("entityentityentity")

for subtree in tree.iter_subtrees_topdown():
    # start RULE <class 'lark.lexer.Token'>
    # entity RULE <class 'lark.lexer.Token'>
    # entity RULE <class 'lark.lexer.Token'>
    # entity RULE <class 'lark.lexer.Token'>
    print(subtree.data, subtree.data.type, type(subtree.data))
```