### PR TITLE
Rethinking the import system

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.py]
+indent_style = space
+indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ tags
 docs/_build
 docs/examples
 docs/sg_execution_times.rst
+/venv

--- a/lark/lark.py
+++ b/lark/lark.py
@@ -71,6 +71,7 @@ class LarkOptions(Serialize):
     edit_terminals: Optional[Callable[[TerminalDef], TerminalDef]]
     import_paths: 'List[Union[str, Callable[[Union[None, str, PackageResource], str], Tuple[str, str]]]]'
     source_path: Optional[str]
+    legacy_import: bool
 
     OPTIONS_DOC = r"""
     **===  General Options  ===**
@@ -107,6 +108,8 @@ class LarkOptions(Serialize):
             Prevent the tree builder from automagically removing "punctuation" tokens (Default: ``False``)
     tree_class
             Lark will produce trees comprised of instances of this class instead of the default ``lark.Tree``.
+    legacy_import
+            Lark will use the old import system where imported rules are not namespaced.
 
     **=== Algorithm Options ===**
 
@@ -183,6 +186,7 @@ class LarkOptions(Serialize):
         'import_paths': [],
         'source_path': None,
         '_plugins': {},
+        'legacy_import': True,
     }
 
     def __init__(self, options_dict: Dict[str, Any]) -> None:
@@ -354,7 +358,13 @@ class Lark(Serialize):
 
 
             # Parse the grammar file and compose the grammars
-            self.grammar, used_files = load_grammar(grammar, self.source_path, self.options.import_paths, self.options.keep_all_tokens)
+            self.grammar, used_files = load_grammar(
+                grammar,
+                self.source_path,
+                self.options.import_paths,
+                self.options.keep_all_tokens,
+                legacy_import=self.options.legacy_import
+            )
         else:
             assert isinstance(grammar, Grammar)
             self.grammar = grammar

--- a/lark/load_grammar.py
+++ b/lark/load_grammar.py
@@ -1230,7 +1230,7 @@ class GrammarBuilder:
         else:  # Relative import
             if grammar_name == '<string>':  # Import relative to script file path if grammar is coded in script
                 try:
-                    base_file = os.path.abspath(sys.modules['__main__'].__file__)
+                    base_file = os.path.abspath(cast(str, sys.modules['__main__'].__file__))
                 except AttributeError:
                     base_file = None
             else:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,4 @@
+# Workaround to force unittest to print out all diffs without truncation
+# https://stackoverflow.com/a/61345284
+import unittest
+__import__('sys').modules['unittest.util']._MAX_LENGTH = 999999999

--- a/tests/configurations.py
+++ b/tests/configurations.py
@@ -1,0 +1,13 @@
+def configurations(cases):
+    def decorator(f):
+        def inner(self):
+            for case in cases:
+                f.__name__ += f".case({case})"
+                f.__qualname__ += f".case({case})"
+                f(self, case)
+        inner.__name__ = f.__name__
+        inner.__qualname__ = f.__qualname__
+        return inner
+    return decorator
+
+import_test = configurations(("new", "legacy"))


### PR DESCRIPTION
Hello Lark developers!

I've tried using this library in a personal project, and really liked it, thank you for it!

## The problem

...except one thing, which was grammar composition. Lark docs make you think it has a nice module system where you can just import rules and terminals and everything magically works... but for some reason it doesn't.

Rules don't compose well since when you `%import` them, the grammar module that imported the rule is now responsible for parsing it since the rule has namespace of the current grammar module assigned to it, and funnily enough, every rule that it depends on still gets the imported grammar module prefix.

So if you had a layout like this:
```
# lib.lark

b: "b"
a: b
```

```
# main.lark
%import lib.a

start: a
```

Parse tree for "b" would look like:
```
start
	a
		lib__b
```

which makes approximately 0 sense to me :smile: ([this has been discussed before in lark](https://github.com/lark-parser/lark/pull/973#issuecomment-907287565), and in my opinion the ["official solution"](https://github.com/lark-parser/lark/blob/master/examples/composition/storage.lark) came out looking as more of a workaround than something to be used and recommended to others)

Main grammar is supposed to parse imported terminal, but none of its children. Which is a very odd way of making the import system work. For example, if multiple grammar modules import the same terminal, they would all be responsible for parsing it, but not its children, which in transformer implementation terms means that importing transformers would have to inherit the implementation for parsing the imported terminal, **and then on top of that** get `merge_transformers`'d with the `lib` transformer (which also wouldn't be responsible for parsing one of its own rules?).

All of this makes working with multiple grammars very inconvenient.

## The solution

`%use` directive.

More is explained in added docs, but here is a quick excerpt:
> Imports terminals and rules just as `%import` does, but also puts the imported rule itself in its namespace and automatically aliases it.
>
> Useful for importing rules that this chunk of grammar uses, but does not define a transformer for (isn't responsible for parsing it).

Changing `%import` to `%use` in the example above, and parsing same "b" will now result in:
```
start
	lib__a
		lib__b
```

This allows to simply compose transformers with `merge_transformers` and not worry about inheritance, mixins, or anything else for such a simple example!

### Compatibility with `%import`

`%use` is currently incompatible with `%import`, i. e. you cannot do this:
```
# mixing both not allowed
%import a.b
%use a.c
```
or in the other direction, but you can import/use on different modules:
```
# this is ok!
%import a.b
%use b.c
```

## The implementation

I am not going to lie, the implementation could use some design work, but right now it works as is.

Any comments or ideas on how to make it more robust will be appreciated as I am new to this codebase.

Currently it creates new group of aliases called `use_aliases` and uses that to rewrite all `_define`s, and that's about it. I am a bit worried it has some hidden bugs I haven't considered, but I hope for them to get ironed out during the code review :)

## Other concerns

Of course, all of these issues could be solved with
> ...using inheritance? Or mixins? Python already has a few mechanisms (and libraries) for that sort of composition.<sup>[^1]</sup>

But in my opinion, lark shouldn't impose a hell of mixins, inheritance, and a ton of other OOP boilerplate on its users just to do such a simple thing as basic grammar composition, especially when it can be "just fixed" in a hundred lines or so in lark itself, for basically no cost.

Another option would be to enforce manually prefixing imported rules, which doesn't scale. Like at all.

And I guess you could always just string together all files and implement all rules and terminals in one transformer, but then you would have to manually namespace all rules and terminals, and their uses, not just `%import`s.

## Lastly...

This isn't supposed to be final, I'm open to comments and suggestions! The tests aren't supposed to be final either, I can write some more, the only one I added is just supposed to show how it all works :)

P.S.: I've also added minimal `.editorconfig` to the repository since my editor always wanted to convert everything to tabs, maybe it will also help other contributors

[^1]: https://github.com/lark-parser/lark/issues/531#issuecomment-593422234