### PR TITLE
Support match on tree

### DIFF
--- a/lark/tree.py
+++ b/lark/tree.py
@@ -69,6 +69,8 @@ class Tree(Generic[_Leaf_T]):
 
     def __repr__(self):
         return 'Tree(%r, %r)' % (self.data, self.children)
+    
+    __match_args__ = ("data", "children")
 
     def _pretty_label(self):
         return self.data

--- a/lark/tree.py
+++ b/lark/tree.py
@@ -69,7 +69,7 @@ class Tree(Generic[_Leaf_T]):
 
     def __repr__(self):
         return 'Tree(%r, %r)' % (self.data, self.children)
-    
+
     __match_args__ = ("data", "children")
 
     def _pretty_label(self):

--- a/tests/test_pattern_matching.py
+++ b/tests/test_pattern_matching.py
@@ -1,6 +1,6 @@
 from unittest import TestCase, main
 
-from lark import Token
+from lark import Token, Tree
 
 
 class TestPatternMatching(TestCase):
@@ -45,6 +45,51 @@ class TestPatternMatching(TestCase):
                 assert False
             case _:
                 pass
+
+    def test_match_on_tree(self):
+        tree1 = Tree('a', [Tree(x, y) for x, y in zip('bcd', 'xyz')])
+        tree2 = Tree('a', [
+            Tree('b', [Token('T', 'x')]),
+            Tree('c', [Token('T', 'y')]),
+            Tree('d', [Tree('z', [Token('T', 'zz'), Tree('zzz', 'zzz')])]),
+        ])
+
+        match tree1:
+            case Tree('X', []):
+                assert False
+            case Tree('a', []):
+                assert False
+            case Tree(_, 'b'):
+                assert False
+            case Tree('X', _):
+                assert False
+        tree = Tree('q', [Token('T', 'x')])
+        match tree:
+            case Tree('q', [Token('T', 'x')]):
+                pass
+            case _:
+                assert False
+        tr = Tree('a', [Tree('b', [Token('T', 'a')])])
+        match tr:
+            case Tree('a', [Tree('b', [Token('T', 'a')])]):
+                pass
+            case _:
+                assert False
+        # test nested trees
+        match tree2:
+            case Tree('a', [
+                    Tree('b', [Token('T', 'x')]),
+                    Tree('c', [Token('T', 'y')]),
+                    Tree('d', [
+                        Tree('z', [
+                            Token('T', 'zz'),
+                            Tree('zzz', 'zzz')
+                        ])
+                    ])
+            ]):
+                pass
+            case _:
+                assert False
 
 
 

--- a/tests/test_trees.py
+++ b/tests/test_trees.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import sys
 import unittest
 from functools import partial, reduce, partialmethod
 from operator import add, mul

--- a/tests/test_trees.py
+++ b/tests/test_trees.py
@@ -472,48 +472,6 @@ class TestTrees(TestCase):
 
         assert MyTransformer().transform(t) is None
 
-    def test_pattern_match(self):
-        # match statements are only available in Python 3.10+
-        major, minor, _, _, _ = sys.version_info
-        if major < 3 or minor < 10:
-            return
-
-        match self.tree1:
-            case Tree('X', []):
-                self.fail()
-            case Tree('a', []):
-                self.fail()
-            case Tree(_, 'b'):
-                self.fail()
-            case Tree('X', _):
-                self.fail()
-        tree = Tree('q', [Token('T', 'x')])
-        match tree:
-            case Tree('q', [Token('T', 'x')]):
-                pass
-            case _:
-                self.fail()
-        tr = Tree('a', [Tree('b', [Token('T', 'a')])])
-        match tr:
-            case Tree('a', [Tree('b', [Token('T', 'a')])]):
-                pass
-            case _:
-                self.fail()
-        # test nested trees
-        match self.tree2:
-            case Tree('a', [
-                    Tree('b', [Token('T', 'x')]),
-                    Tree('c', [Token('T', 'y')]),
-                    Tree('d', [
-                        Tree('z', [
-                            Token('T', 'zz'),
-                            Tree('zzz', 'zzz')
-                        ])
-                    ])
-            ]):
-                pass
-            case _:
-                self.fail()
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_trees.py
+++ b/tests/test_trees.py
@@ -474,7 +474,8 @@ class TestTrees(TestCase):
 
     def test_pattern_match(self):
         # match statements are only available in Python 3.10+
-        if sys.version < "3.10":
+        major, minor, _, _, _ = sys.version_info
+        if major < 3 or minor < 10:
             return
 
         match self.tree1:

--- a/tests/test_trees.py
+++ b/tests/test_trees.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import sys
 import unittest
 from functools import partial, reduce, partialmethod
 from operator import add, mul
@@ -471,6 +472,47 @@ class TestTrees(TestCase):
 
         assert MyTransformer().transform(t) is None
 
+    def test_pattern_match(self):
+        # match statements are only available in Python 3.10+
+        if sys.version < "3.10":
+            return
+
+        match self.tree1:
+            case Tree('X', []):
+                self.fail()
+            case Tree('a', []):
+                self.fail()
+            case Tree(_, 'b'):
+                self.fail()
+            case Tree('X', _):
+                self.fail()
+        tree = Tree('q', [Token('T', 'x')])
+        match tree:
+            case Tree('q', [Token('T', 'x')]):
+                pass
+            case _:
+                self.fail()
+        tr = Tree('a', [Tree('b', [Token('T', 'a')])])
+        match tr:
+            case Tree('a', [Tree('b', [Token('T', 'a')])]):
+                pass
+            case _:
+                self.fail()
+        # test nested trees
+        match self.tree2:
+            case Tree('a', [
+                    Tree('b', [Token('T', 'x')]),
+                    Tree('c', [Token('T', 'y')]),
+                    Tree('d', [
+                        Tree('z', [
+                            Token('T', 'zz'),
+                            Tree('zzz', 'zzz')
+                        ])
+                    ])
+            ]):
+                pass
+            case _:
+                self.fail()
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This adds support for pattern matching `Tree` objects in Python 3.10+ (#1487).

This is my first PR to the project. If I'm missing something, please let me know and I'll address it 