### PR TITLE
Improve lark-cython compatibility

### DIFF
--- a/examples/advanced/tree_forest_transformer.py
+++ b/examples/advanced/tree_forest_transformer.py
@@ -23,7 +23,7 @@ class CustomTransformer(TreeForestTransformer):
         return Discard
 
     def __default_token__(self, token):
-        return token.capitalize()
+        return token.value.capitalize()
 
 grammar = """
     sentence: noun verb noun        -> simple

--- a/lark/indenter.py
+++ b/lark/indenter.py
@@ -40,7 +40,7 @@ class Indenter(PostLex, ABC):
 
         yield token
 
-        indent_str = token.rsplit('\n', 1)[1] # Tabs and spaces
+        indent_str = token.value.rsplit('\n', 1)[1] # Tabs and spaces
         indent = indent_str.count(' ') + indent_str.count('\t') * self.tab_len
 
         if indent > self.indent_level[-1]:

--- a/lark/parser_frontends.py
+++ b/lark/parser_frontends.py
@@ -2,7 +2,7 @@ from typing import Any, Callable, Dict, Optional, Collection, Union, TYPE_CHECKI
 
 from .exceptions import ConfigurationError, GrammarError, assert_config
 from .utils import get_regexp_width, Serialize, TextOrSlice, TextSlice
-from .lexer import LexerThread, BasicLexer, ContextualLexer, Lexer
+from .lexer import LexerThread, BasicLexer, ContextualLexer, Lexer, PostLexThread
 from .parsers import earley, xearley, cyk
 from .parsers.lalr_parser import LALR_Parser
 from .tree import Tree
@@ -95,8 +95,7 @@ class ParsingFrontend(Serialize):
         else:
             raise TypeError("Bad value for lexer_type: {lexer_type}")
 
-        if lexer_conf.postlex:
-            self.lexer = PostLexConnector(self.lexer, lexer_conf.postlex)
+        self.postlex: PostLex | None = lexer_conf.postlex  # Store the postlex separately
 
     def _verify_start(self, start=None):
         if start is None:
@@ -109,8 +108,18 @@ class ParsingFrontend(Serialize):
         return start
 
     def _make_lexer_thread(self, text: Optional[TextOrSlice]) -> Union[TextOrSlice, LexerThread, None]:
+        if self.skip_lexer:
+            return text
+
         cls = (self.options and self.options._plugins.get('LexerThread')) or LexerThread
-        return text if self.skip_lexer else cls(self.lexer, None) if text is None else cls.from_text(self.lexer, text)
+        
+        thread = cls(self.lexer, text) if text is None else cls.from_text(self.lexer, text)
+
+        # If we have a postlex, wrap the thread
+        if self.postlex is not None:
+            return PostLexThread(self.lexer, thread.state, self.postlex)
+
+        return thread
 
     def parse(self, text: Optional[TextOrSlice], start=None, on_error=None):
         if self.lexer_conf.lexer_type in ("dynamic", "dynamic_complete"):
@@ -150,15 +159,6 @@ def _get_lexer_callbacks(transformer, terminals):
         if callback is not None:
             result[terminal.name] = callback
     return result
-
-class PostLexConnector:
-    def __init__(self, lexer, postlexer):
-        self.lexer = lexer
-        self.postlexer = postlexer
-
-    def lex(self, lexer_state, parser_state):
-        i = self.lexer.lex(lexer_state, parser_state)
-        return self.postlexer.process(i)
 
 
 


### PR DESCRIPTION
This PR addresses two significant compatibility issues when using lark-cython:

# 1. Fix Token handling for lark-cython
In the standard lark implementation, Token inherits from str, allowing string methods to be called directly on Token objects. However, lark-cython implements Token differently - it doesn't inherit from str, which means string methods like rsplit() won't work on token objects.

Changes:
- Replaced direct string method calls on Token instances with calls on token.value instead

# 2. Refactor postlexer handling architecture
The original implementation used a PostLexConnector class that acted as a wrapper around a lexer but only implemented part of the Lexer interface (the lex() method but not next_token()). This partial implementation worked in standard lark through duck typing but caused errors in lark-cython's more strict implementation.

Changes:
- Removed the use of PostLexConnector class
- Added a self.postlex attribute to store the postlexer separately
- Preserves the stream-based design of PostLex while ensuring proper interface implementation

This approach is more consistent with the architectural intent of postlexers as stream processors, while avoiding type compatibility issues in lark-cython.