### PR TITLE
better error messages for shift/reduct conflicts

### DIFF
--- a/lark/parsers/lalr_analysis.py
+++ b/lark/parsers/lalr_analysis.py
@@ -286,7 +286,7 @@ class LALR_Analyzer(GrammarAnalyzer):
                 if la in actions:
                     if self.strict:
                         msg = f'Shift/Reduce conflict for terminal {la.name}. [strict-mode]\n' \
-                               ' * {rule}\n'
+                              f' * {rule}\n'
                         raise GrammarError(msg)
                     elif self.debug:
                         logger.warning('Shift/Reduce conflict for terminal %s: (resolving as shift)', la.name)

--- a/lark/parsers/lalr_analysis.py
+++ b/lark/parsers/lalr_analysis.py
@@ -285,7 +285,9 @@ class LALR_Analyzer(GrammarAnalyzer):
                 rule ,= rules
                 if la in actions:
                     if self.strict:
-                        raise GrammarError(f"Shift/Reduce conflict for terminal {la.name}. [strict-mode]\n ")
+                        msg = f'Shift/Reduce conflict for terminal {la.name}. [strict-mode]\n' \
+                               ' * {rule}\n'
+                        raise GrammarError(msg)
                     elif self.debug:
                         logger.warning('Shift/Reduce conflict for terminal %s: (resolving as shift)', la.name)
                         logger.warning(' * %s', rule)


### PR DESCRIPTION
In case of strict=True, include the offending rule for shift/reduce conflicts