### PR TITLE
Miscellaneous improvements to the behavior and documentation of Visitor, Transformer, Interpreter, and friends

### DIFF
--- a/docs/visitors.rst
+++ b/docs/visitors.rst
@@ -4,7 +4,7 @@ Transformers & Visitors
 Transformers & Visitors provide a convenient interface to process the
 parse-trees that Lark returns.
 
-They are used by inheriting from the correct class (visitor or transformer),
+They are used by inheriting from one of the classes described here,
 and implementing methods corresponding to the rule you wish to process. Each
 method accepts the children as an argument. That can be modified using the
 ``v_args`` decorator, which allows one to inline the arguments (akin to ``*args``),
@@ -17,9 +17,8 @@ See: `visitors.py`_
 Visitor
 -------
 
-Visitors visit each node of the tree, and run the appropriate method on it according to the node's data.
-
-They work bottom-up, starting with the leaves and ending at the root of the tree.
+Visitors visit each node of the tree and run the appropriate method on it according to the node's data.
+They can work top-down or bottom-up, depending on what method you use.
 
 There are two classes that implement the visitor interface:
 
@@ -45,11 +44,11 @@ Example:
 Interpreter
 -----------
 
-.. autoclass:: lark.visitors.Interpreter
-
-
 Example:
     ::
+
+        from lark.visitors import Interpreter
+
 
         class IncreaseSomeOfTheNumbers(Interpreter):
             def number(self, tree):
@@ -59,7 +58,12 @@ Example:
                 # skip this subtree. don't change any number node inside it.
                 pass
 
-            IncreaseSomeOfTheNumbers().visit(parse_tree)
+
+        IncreaseSomeOfTheNumbers().visit(parse_tree)
+
+
+.. autoclass:: lark.visitors.Interpreter
+    :members: visit, visit_children, __default__
 
 Transformer
 -----------
@@ -98,14 +102,11 @@ Example:
 
 .. autoclass:: lark.visitors.Transformer_InPlaceRecursive
 
-v_args
-------
+Useful Utilities
+----------------
 
 .. autofunction:: lark.visitors.v_args
-
-merge_transformers
-------------------
-
+.. autofunction:: lark.visitors.visit_children_decor
 .. autofunction:: lark.visitors.merge_transformers
 
 Discard

--- a/docs/visitors.rst
+++ b/docs/visitors.rst
@@ -18,7 +18,7 @@ Visitor
 -------
 
 Visitors visit each node of the tree and run the appropriate method on it according to the node's data.
-They can work top-down or bottom-up, depending on what method you use.
+They can traverse top-down or bottom-up, depending on the class and method.
 
 There are two classes that implement the visitor interface:
 

--- a/lark/visitors.py
+++ b/lark/visitors.py
@@ -423,10 +423,6 @@ class Interpreter(_Decoratable, ABC, Generic[_Leaf_T, _Return_T]):
         # visiting child trees.
         return self._visit_tree(tree)
 
-    def visit_topdown(self, tree: Tree[_Leaf_T]):
-        "Interpreters only work top-down. This method is identical to `visit()`."
-        return self.visit(tree)
-
     def _visit_tree(self, tree: Tree[_Leaf_T]):
         f = getattr(self, tree.data)
         wrapper = getattr(f, 'visit_wrapper', None)

--- a/lark/visitors.py
+++ b/lark/visitors.py
@@ -592,18 +592,6 @@ def v_args(inline: bool = False, meta: bool = False, tree: bool = False, wrapper
         func = wrapper
 
     def _visitor_args_dec(obj):
-        from inspect import isclass
-        if isclass(obj) and issubclass(obj, Visitor):
-            raise TypeError("v_args cannot be applied to Visitor classes.")
-        if callable(obj) and not isclass(obj):
-            @wraps(obj)
-            def method_wrapper(*args, **kwargs):
-                if args:
-                    self_instance = args[0]
-                    if isinstance(self_instance, Visitor):
-                        raise TypeError("v_args cannot be applied to Visitor methods.")
-                return obj(*args, **kwargs)
-            return _apply_v_args(method_wrapper, func)
         return _apply_v_args(obj, func)
     return _visitor_args_dec
 

--- a/tests/test_trees.py
+++ b/tests/test_trees.py
@@ -131,6 +131,10 @@ class TestTrees(TestCase):
                 return 'C'
 
         self.assertEqual(Interp3().visit(t), list('BCd'))
+        self.assertEqual(
+            Interp3().visit(t),
+            Interp3().visit_topdown(t),
+        )
 
     def test_transformer(self):
         t = Tree('add', [Tree('sub', [Tree('i', ['3']), Tree('f', ['1.1'])]), Tree('i', ['1'])])
@@ -471,6 +475,30 @@ class TestTrees(TestCase):
 
         assert MyTransformer().transform(t) is None
 
+    def test_incorrect_use_of_decorators(self):
+        class TestVisitor1(Visitor):
+            @visit_children_decor
+            def a(self, tree):
+                pass
+
+            @v_args(inline=True)
+            def b(self, tree):
+                pass
+
+        with self.assertRaises(TypeError) as e:
+            TestVisitor1().visit_topdown(self.tree1)
+        self.assertIn("visit_children_decor", str(e.exception))
+        self.assertIn("Interpreter", str(e.exception))
+        with self.assertRaises(TypeError) as e:
+            TestVisitor1().visit(self.tree1)
+        self.assertIn("v_args", str(e.exception))
+
+        with self.assertRaises(TypeError) as e:
+            @v_args(inline=True)
+            class TestVisitor2(Visitor):
+                def a(self, tree):
+                    pass
+        self.assertIn("v_args", str(e.exception))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_trees.py
+++ b/tests/test_trees.py
@@ -491,14 +491,6 @@ class TestTrees(TestCase):
         self.assertIn("Interpreter", str(e.exception))
         with self.assertRaises(TypeError) as e:
             TestVisitor1().visit(self.tree1)
-        self.assertIn("v_args", str(e.exception))
-
-        with self.assertRaises(TypeError) as e:
-            @v_args(inline=True)
-            class TestVisitor2(Visitor):
-                def a(self, tree):
-                    pass
-        self.assertIn("v_args", str(e.exception))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_trees.py
+++ b/tests/test_trees.py
@@ -131,10 +131,6 @@ class TestTrees(TestCase):
                 return 'C'
 
         self.assertEqual(Interp3().visit(t), list('BCd'))
-        self.assertEqual(
-            Interp3().visit(t),
-            Interp3().visit_topdown(t),
-        )
 
     def test_transformer(self):
         t = Tree('add', [Tree('sub', [Tree('i', ['3']), Tree('f', ['1.1'])]), Tree('i', ['1'])])
@@ -481,16 +477,14 @@ class TestTrees(TestCase):
             def a(self, tree):
                 pass
 
-            @v_args(inline=True)
-            def b(self, tree):
-                pass
-
         with self.assertRaises(TypeError) as e:
             TestVisitor1().visit_topdown(self.tree1)
         self.assertIn("visit_children_decor", str(e.exception))
         self.assertIn("Interpreter", str(e.exception))
         with self.assertRaises(TypeError) as e:
             TestVisitor1().visit(self.tree1)
+        self.assertIn("visit_children_decor", str(e.exception))
+        self.assertIn("Interpreter", str(e.exception))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_trees.py
+++ b/tests/test_trees.py
@@ -477,14 +477,14 @@ class TestTrees(TestCase):
             def a(self, tree):
                 pass
 
-        with self.assertRaises(TypeError) as e:
-            TestVisitor1().visit_topdown(self.tree1)
-        self.assertIn("visit_children_decor", str(e.exception))
-        self.assertIn("Interpreter", str(e.exception))
-        with self.assertRaises(TypeError) as e:
-            TestVisitor1().visit(self.tree1)
-        self.assertIn("visit_children_decor", str(e.exception))
-        self.assertIn("Interpreter", str(e.exception))
+        for visit_method in [
+            TestVisitor1().visit,
+            TestVisitor1().visit_topdown,
+        ]:
+            with self.assertRaises(TypeError) as e:
+                visit_method(self.tree1)
+            self.assertIn("visit_children_decor", str(e.exception))
+            self.assertIn("Interpreter", str(e.exception))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR makes the following improvements.

Documentation:
- Add docstrings for `visit_children_decor` and various methods of `Interpreter`.
- Correct the top-level docs for `Visitor` to clarify that it can traverse the tree in either direction.
- Move utilities into their own section and add documentation for `visit_children_decor`, which was previously not visible.

Behavior:
- Have `visit_children_decor` raise a `TypeError` if applied to a method of any class other than `Interpreter`.