### PR TITLE
Keep sdist in sync with git (include all files in source build, including docs, tests and examples)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
-include README.md LICENSE docs/* examples/*.py examples/*.png examples/*.lark tests/*.py tests/*.lark tests/grammars/* tests/test_nearley/*.py tests/test_nearley/grammars/*
+recursive-exclude .github *
+recursive-include tests/test_nearley/nearley *.ne

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,10 @@
+# By default, all files tracked by git are included in the sdist via setuptools-scm
+# This manifest is used to exclude certain files and include files from git submodules
 recursive-exclude .github *
+recursive-exclude docs/ide *
+exclude .gitignore .gitmodules .pre-commit-config.yaml
+
+# Include nearley grammars from the nearley submodule
+# Many of them are used by tests/test_nearley/test_nearley.py
 recursive-include tests/test_nearley/nearley *.ne
+include tests/test_nearley/nearley/LICENSE.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.2.0"]
+requires = ["setuptools>=80", "setuptools-scm>=9.2.2"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
This PR adopts [setuptools-scm](https://setuptools-scm.readthedocs.io/en/latest/)'s file finder functionality to automatically include files tracked by git in the sdist. The version-extraction functionality is not enabled.

Resolves #1559.

Result of [check-sdist](https://github.com/henryiii/check-sdist) without nearley submodule before:

```
SDist does not match git

SDist only:


Git only:
  .gitignore
  .gitmodules
  CHANGELOG.md
  docs/_static/comparison_memory.png
  docs/_static/comparison_runtime.png
  docs/_static/lark_cheatsheet.pdf
  docs/_static/sppf/sppf.html
  docs/_static/sppf/sppf_111.svg
  docs/_static/sppf/sppf_abcd.svg
  docs/_static/sppf/sppf_abcd_noint.svg
  docs/_static/sppf/sppf_cycle.svg
  docs/ide/app.html
  docs/ide/app.js
  docs/ide/app/app.py
  docs/ide/app/core.py
  docs/ide/app/examples.py
  docs/ide/app/ext.py
  docs/ide/app/files.json
  docs/ide/app/html5.py
  docs/ide/app/ignite.py
  docs/ide/app/utils.py
  docs/ide/is-loading.gif
  docs/ide/lark-logo.png
  examples/README.rst
  examples/advanced/README.rst
  examples/advanced/_json_parser.py
  examples/advanced/conf_earley.py
  examples/advanced/conf_lalr.py
  examples/advanced/create_ast.py
  examples/advanced/custom_lexer.py
  examples/advanced/dynamic_complete.py
  examples/advanced/error_handling.py
  examples/advanced/error_reporting_earley.py
  examples/advanced/error_reporting_lalr.py
  examples/advanced/prioritizer.py
  examples/advanced/py3to2.py
  examples/advanced/python2.lark
  examples/advanced/python_parser.py
  examples/advanced/qscintilla_json.py
  examples/advanced/reconstruct_json.py
  examples/advanced/reconstruct_python.py
  examples/advanced/template_lark.lark
  examples/advanced/templates.py
  examples/advanced/tree_forest_transformer.py
  examples/composition/README.rst
  examples/composition/combined_csv_and_json.txt
  examples/composition/csv.lark
  examples/composition/eval_csv.py
  examples/composition/eval_json.py
  examples/composition/json.lark
  examples/composition/main.py
  examples/composition/storage.lark
  examples/grammars/README.rst
  examples/grammars/verilog.lark
  examples/relative-imports/multiple2.lark
  examples/relative-imports/multiple3.lark
  examples/relative-imports/multiples.lark
  examples/relative-imports/multiples.py
  examples/standalone/README.rst
  examples/standalone/create_standalone.sh
  examples/standalone/json.lark
  examples/standalone/json_parser_main.py
  examples/tests/negative_priority.lark
  examples/tests/no_newline_at_end.lark
  readthedocs.yml
  test-requirements.txt
  tests/test_nearley/nearley
  tox.ini
```

After:

```
SDist does not match git

SDist only:


Git only:
  tests/test_nearley/nearley
```