### PR TITLE
lexer: Always init line_ctr,  for a more predictable interface, even if not needed

### DIFF
--- a/lark/lexer.py
+++ b/lark/lexer.py
@@ -429,6 +429,8 @@ class LexerState:
 
             if not (text.start <= line_ctr.char_pos <= text.end):
                 raise ValueError("LineCounter.char_pos is out of bounds")
+        else:
+            line_ctr = line_ctr or LineCounter('\n')
 
         self.text = text
         self.line_ctr = line_ctr


### PR DESCRIPTION
Attempts to solve issue #1565 