### PR TITLE
exceptions.py: sort set of expected things to get deterministic result

### DIFF
--- a/lark/exceptions.py
+++ b/lark/exceptions.py
@@ -137,6 +137,7 @@ class UnexpectedInput(LarkError):
         return candidate[0]
 
     def _format_expected(self, expected):
+        expected = sorted(expected)
         if self._terminals_by_name:
             d = self._terminals_by_name
             expected = [d[t_name].user_repr() if t_name in d else t_name for t_name in expected]


### PR DESCRIPTION
Currently expected tokens are stored in a set, and because of that the order they appear in error message is unstable - different runs may produce different orderings.

Here I sort the set of expected tokens, so that the order is guaranteed to be stable between runs.