### PR TITLE
Bugfix Earley: handle ambiguity from ignored tokens

### DIFF
--- a/lark/parsers/xearley.py
+++ b/lark/parsers/xearley.py
@@ -22,6 +22,7 @@ from ..exceptions import UnexpectedCharacters
 from ..lexer import Token
 from ..grammar import Terminal
 from .earley import Parser as BaseParser
+from .earley_common import Item
 from .earley_forest import TokenNode
 
 if TYPE_CHECKING:
@@ -108,6 +109,14 @@ class Parser(BaseParser):
                     token_node = TokenNode(token, terminals[token.type])
                     new_item.node = node_cache[label] if label in node_cache else node_cache.setdefault(label, self.SymbolNode(*label))
                     new_item.node.add_family(new_item.s, item.rule, new_item.start, item.node, token_node)
+                elif item.is_complete and item.s == start_symbol:
+                    # Handle completed start symbols
+                    new_item = Item(item.rule, item.ptr, item.start)
+                    label = (new_item.s, new_item.start, i + 1)
+                    new_item.node = node_cache[label] if label in node_cache else node_cache.setdefault(label, self.SymbolNode(*label))
+                    # new_item.node and item.node both represent the start symbol, so merge their children
+                    for child in item.node.children:
+                        new_item.node.add_family(new_item.s, child.rule, new_item.start, child.left, child.right)
                 else:
                     new_item = item
 

--- a/lark/parsers/xearley.py
+++ b/lark/parsers/xearley.py
@@ -109,16 +109,15 @@ class Parser(BaseParser):
                     token_node = TokenNode(token, terminals[token.type])
                     new_item.node = node_cache[label] if label in node_cache else node_cache.setdefault(label, self.SymbolNode(*label))
                     new_item.node.add_family(new_item.s, item.rule, new_item.start, item.node, token_node)
-                elif item.is_complete and item.s == start_symbol:
-                    # Handle completed start symbols
+                else:
+                    # Handle items carried over due to ignores
                     new_item = Item(item.rule, item.ptr, item.start)
                     label = (new_item.s, new_item.start, i + 1)
                     new_item.node = node_cache[label] if label in node_cache else node_cache.setdefault(label, self.SymbolNode(*label))
-                    # new_item.node and item.node both represent the start symbol, so merge their children
-                    for child in item.node.children:
-                        new_item.node.add_family(new_item.s, child.rule, new_item.start, child.left, child.right)
-                else:
-                    new_item = item
+                    if item.node:
+                        # new_item.node and item.node both represent the same symbol, so merge their children
+                        for child in item.node.children:
+                            new_item.node.add_family(new_item.s, child.rule, new_item.start, child.left, child.right)
 
                 if new_item.expect in self.TERMINALS:
                     # add (B ::= Aai+1.B, h, y) to Q'

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -876,6 +876,26 @@ def _make_full_earley_test(LEXER):
             tree = l.parse('x')
             assert tree == Tree('start', [Tree('a', ['x'])])
 
+        @unittest.skipIf(LEXER=='basic', 'This scenario only occurs with the dynamic lexers')
+        def test_multiple_start_solutions2(self):
+            grammar = r"""
+                !start: "foo1" | "foo" | "foo12"
+                %ignore "1"
+                %ignore "2"
+            """
+            l = Lark(grammar, ambiguity='explicit', lexer=LEXER)
+            tree = l.parse('foo12')
+
+            expected = Tree('_ambig', [
+                Tree('start', ['foo1']),
+                Tree('start', ['foo']),
+                Tree('start', ['foo12']),
+            ])
+            self.assertEqual(tree, expected)
+
+            l = Lark(grammar, ambiguity='resolve', lexer=LEXER)
+            tree = l.parse('foo12')
+            self.assertEqual(tree, Tree('start', ['foo1']))
 
         def test_cycle(self):
             grammar = """

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -784,6 +784,24 @@ def _make_full_earley_test(LEXER):
             self.assertEqual(ambig_tree.data, '_ambig')
             self.assertEqual(set(ambig_tree.children), expected)
 
+        @unittest.skipIf(LEXER=='basic', 'This ambiguity only occurs with the dynamic lexers')
+        def test_ambiguous_ignores(self):
+            grammar = """
+            !start: a "b"
+            !a: "a" | "a1" | "a12"
+            %ignore "1"
+            %ignore "2"
+            """
+
+            l = Lark(grammar, ambiguity='explicit', lexer=LEXER)
+            tree = l.parse('a12b')
+
+            expected = Tree('_ambig', [
+                Tree('start', [Tree('a', ['a']), 'b']),
+                Tree('start', [Tree('a', ['a1']), 'b']),
+                Tree('start', [Tree('a', ['a12']), 'b']),
+            ])
+            self.assertEqual(tree, expected)
 
         @unittest.skipIf(LEXER=='basic', "Requires dynamic lexer")
         def test_fruitflies_ambig(self):


### PR DESCRIPTION
Fixes #1576: an edge case in which start symbol nodes were not shared between start symbol items that completed at different parts of the string due to ignores.

Thanks @kwilinsi for the great MCVE!