### PR TITLE
Fix type hint of @v_args() decorator

### DIFF
--- a/lark/visitors.py
+++ b/lark/visitors.py
@@ -15,8 +15,8 @@ _Return_V = TypeVar('_Return_V')
 _Leaf_T = TypeVar('_Leaf_T')
 _Leaf_U = TypeVar('_Leaf_U')
 _R = TypeVar('_R')
-_FUNC = Callable[..., _Return_T]
-_DECORATED = Union[_FUNC, type]
+_DECORATED = Union[Callable[..., _Return_T], Type[_Return_T]]
+_DECORATOR = Callable[[_DECORATED[_Return_T]], _DECORATED[_Return_T]]
 
 class _DiscardType:
     """When the Discard value is returned from a transformer callback,
@@ -510,7 +510,7 @@ def _vargs_tree(f, data, children, meta):
     return f(Tree(data, children, meta))
 
 
-def v_args(inline: bool = False, meta: bool = False, tree: bool = False, wrapper: Optional[Callable] = None) -> Callable[[_DECORATED], _DECORATED]:
+def v_args(inline: bool = False, meta: bool = False, tree: bool = False, wrapper: Optional[Callable] = None) -> _DECORATOR:
     """A convenience decorator factory for modifying the behavior of user-supplied callback methods of ``Transformer`` classes.
 
     By default, transformer callback methods accept one argument - a list of the node's children.


### PR DESCRIPTION
Before, the test script below fails Pyright's type-checking:

```
error: "assert_type" mismatch: expected "str" but received "Any | Unknown" (reportAssertTypeFailure)
```

(VSCode's python extension, Pylance, uses Pyright internally)

Test script:

```python
import sys

from lark import Transformer, Token, Tree, v_args

if sys.version_info < (3, 11):
    from typing_extensions import assert_type, reveal_type
else:
    from typing import assert_type, reveal_type

@v_args()
class Foo(Transformer[Token, str]):
    def __init__(self):
        super().__init__()

    def foo(self, meta, args):
        return 'baz'

bar = Foo().transform(Tree('foo', []))

assert_type(bar, str)
```

I've not added this test because it would require adding pyright as a second typechecker dependency when the project already uses mypy

fix: #1579