### PR TITLE
docs: migrate SPPF page from Bootstrap 4 to Bootstrap 5

### DIFF
--- a/docs/_static/sppf/sppf.html
+++ b/docs/_static/sppf/sppf.html
@@ -3,7 +3,7 @@
 <html lang="en-us">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-<link rel="stylesheet" type="text/css" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
+<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
 
 <body>
 
@@ -193,7 +193,7 @@ $ E ::= E + E \mid 1 $.</p>
       Powered by the <a href="https://web.archive.org/web/20200128172318/https://github.com/gcushen/hugo-academic" target="_blank">Academic
       theme</a> for <a href="https://web.archive.org/web/20200128172318/http://gohugo.io/" target="_blank">Hugo</a>.
 
-      <span class="pull-right" aria-hidden="true">
+      <span class="float-end" aria-hidden="true">
         <a href="#" id="back_to_top">
           <span class="button_icon">
             <i class="fa fa-chevron-up fa-2x"></i>


### PR DESCRIPTION
## Summary

Fixes #1494.

Migrates \`docs/_static/sppf/sppf.html\` off of Bootstrap 4 (EOL since 2023-01-01) onto Bootstrap 5.

## Changes

- **CDN:** \`stackpath.bootstrapcdn.com/bootstrap/4.3.1\` → \`cdn.jsdelivr.net/npm/bootstrap@5.3.3\`. stackpath.bootstrapcdn.com never mirrored Bootstrap 5, so a switch of host is required. Added an SRI \`integrity\` hash computed locally against the jsDelivr asset.
- **Utility class:** the only Bootstrap utility on the page was \`pull-right\` (legacy Bootstrap 3 name that survived through v4). Renamed to \`float-end\` per the v5 migration guide.

Nothing else on the page uses Bootstrap classes, \`data-toggle\` attributes, or jQuery, so no further changes were needed.

## Test plan

- [x] HTML diff is two character-level changes; behavior on the SPPF page is unchanged (the back-to-top link stays right-aligned via \`float-end\`).
- [x] SRI hash regenerated from the upstream jsDelivr asset to match 5.3.3.