### PR TITLE
Support Python regex a and L flags

### DIFF
--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -69,7 +69,7 @@ Literals can be one of:
 * `"string"`
 * `/regular expression+/`
 * `"case-insensitive string"i`
-* `/re with flags/imulx`
+* `/re with flags/imulxaL`
 * Literal range: `"a".."z"`, `"1".."9"`, etc.
 
 Terminals also support grammar operators, such as `|`, `+`, `*` and `?`.
@@ -122,7 +122,7 @@ SIGNED_INTEGER: /
  /x
 ```
 
-Supported flags are one of: `imslux`. See Python's regex documentation for more details on each one.
+Supported flags are one of: `imsluxaL`. See Python's regex documentation for more details on each one. Note that Python's `L` locale flag is only valid for bytes patterns, and can therefore only be used with `use_bytes=True`.
 
 Regexps/strings of different flags can only be concatenated in Python 3.6+
 

--- a/examples/advanced/template_lark.lark
+++ b/examples/advanced/template_lark.lark
@@ -43,7 +43,7 @@ OP: /[+*]|[?](?![a-z])/
 RULE: /!?[_?]?[a-z][_a-z0-9]*/
 TOKEN: /_?[A-Z][_A-Z0-9]*/
 STRING: _STRING "i"?
-REGEXP: /\/(?!\/)(\\\/|\\\\|[^\/\n])*?\/[imslux]*/
+REGEXP: /\/(?!\/)(\\\/|\\\\|[^\/\n])*?\/[imsluxaL]*/
 _NL: /(\r?\n)+\s*/
 
 %import common.ESCAPED_STRING -> _STRING

--- a/lark/grammars/lark.lark
+++ b/lark/grammars/lark.lark
@@ -49,7 +49,7 @@ OP: /[+*]|[?](?![a-z])/
 RULE: /!?[_?]?[a-z][_a-z0-9]*/
 TOKEN: /_?[A-Z][_A-Z0-9]*/
 STRING: _STRING "i"?
-REGEXP: /\/(?!\/)(\\\/|\\\\|[^\/])*?\/[imslux]*/
+REGEXP: /\/(?!\/)(\\\/|\\\\|[^\/])*?\/[imsluxaL]*/
 _NL: /(\r?\n)+\s*/
 
 %import common.ESCAPED_STRING -> _STRING

--- a/lark/lexer.py
+++ b/lark/lexer.py
@@ -558,8 +558,9 @@ class BasicLexer(AbstractBasicLexer):
             terminal_to_regexp = {}
             for t in terminals:
                 regexp = t.pattern.to_regexp()
+                regexp_for_validation = regexp.encode('latin-1') if conf.use_bytes else regexp
                 try:
-                    self.re.compile(regexp, conf.g_regex_flags)
+                    self.re.compile(regexp_for_validation, conf.g_regex_flags)
                 except self.re.error:
                     raise LexError("Cannot compile token %s: %s" % (t.name, t.pattern))
 

--- a/lark/load_grammar.py
+++ b/lark/load_grammar.py
@@ -29,7 +29,7 @@ IMPORT_PATHS = ['grammars']
 
 EXT = '.lark'
 
-_RE_FLAGS = 'imslux'
+_RE_FLAGS = 'imsluxaL'
 
 _EMPTY = Symbol('__empty__')
 

--- a/lark/utils.py
+++ b/lark/utils.py
@@ -130,8 +130,20 @@ else:
     import sre_constants
 
 categ_pattern = re.compile(r'\\p{[A-Za-z_]+}')
+locale_flag_pattern = re.compile(r'\(\?([aiLmsux]+)(:|\))')
+
+def _strip_width_only_locale_flags(expr: str) -> str:
+    def _replace(match):
+        flags = match.group(1).replace('L', '')
+        suffix = match.group(2)
+        if flags:
+            return '(?%s%s' % (flags, suffix)
+        return '(?:' if suffix == ':' else ''
+
+    return re.sub(locale_flag_pattern, _replace, expr)
 
 def get_regexp_width(expr: str) -> Union[Tuple[int, int], List[int]]:
+    expr = _strip_width_only_locale_flags(expr)
     if _has_regex:
         # Since `sre_parse` cannot deal with Unicode categories of the form `\p{Mn}`, we replace these with
         # a simple letter, which makes no difference as we are only trying to get the possible lengths of the regex

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1782,6 +1782,19 @@ def _make_parser_test(LEXER, PARSER):
             x = g.parse('abcdef')
             self.assertEqual(x.children, ['abcdef'])
 
+        def test_token_flags_ascii(self):
+            g = _Lark(r"""start: ASCII_WORD
+                          ASCII_WORD: /\w+/a
+                      """)
+            self.assertEqual(g.parse('abc').children, ['abc'])
+            self.assertRaises(UnexpectedCharacters, g.parse, 'é')
+
+        def test_token_flags_locale_bytes(self):
+            g = _Lark(r"""start: WORD
+                          WORD: /\w+/L
+                      """, use_bytes=True)
+            self.assertEqual(g.parse(b'abc').children[0].value, b'abc')
+
         @unittest.skipIf(PARSER == 'cyk', "No empty rules")
         def test_twice_empty(self):
             g = """!start: ("A"?)?


### PR DESCRIPTION
Added grammar-level support for Python's a and L regular expression flags, closing the gap between Lark's supported regex suffix syntax and Python's re flags. Fixes #1527