### PR TITLE
Skip UTF-8 BOM before parsing

### DIFF
--- a/lark/lark.py
+++ b/lark/lark.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from .parser_frontends import ParsingFrontend
 
 from .exceptions import ConfigurationError, assert_config, UnexpectedInput
-from .utils import Serialize, SerializeMemoizer, FS, logger, TextOrSlice, LarkInput
+from .utils import Serialize, SerializeMemoizer, FS, logger, TextOrSlice, TextSlice, LarkInput
 from .load_grammar import load_grammar, FromPackageLoader, Grammar, verify_used_files, PackageResource, sha256_digest
 from .tree import Tree
 from .common import LexerConf, ParserConf, _ParserArgType, _LexerArgType
@@ -43,6 +43,23 @@ class PostLex(ABC):
         return stream
 
     always_accept: Iterable[str] = ()
+
+
+_UTF8_BOM = '\ufeff'
+_UTF8_BOM_BYTES = b'\xef\xbb\xbf'
+
+
+def _strip_bom(text: LarkInput) -> LarkInput:
+    if isinstance(text, str) and text.startswith(_UTF8_BOM):
+        return text[1:]
+    if isinstance(text, bytes) and text.startswith(_UTF8_BOM_BYTES):
+        return text[len(_UTF8_BOM_BYTES):]
+    if isinstance(text, TextSlice):
+        bom = _UTF8_BOM_BYTES if isinstance(text.text, bytes) else _UTF8_BOM
+        if text.text.startswith(bom, text.start, text.end):
+            return TextSlice(text.text, text.start + len(bom), text.end)
+    return text
+
 
 class LarkOptions(Serialize):
     """Specifies the options for Lark
@@ -309,6 +326,9 @@ class Lark(Serialize):
             pass
         else:
             grammar = read()
+
+        if isinstance(grammar, str):
+            grammar = _strip_bom(grammar)
 
         cache_fn = None
         cache_sha256 = None
@@ -674,6 +694,7 @@ class Lark(Serialize):
         """
         if on_error is not None and self.options.parser != 'lalr':
             raise NotImplementedError("The on_error option is only implemented for the LALR(1) parser.")
+        text = _strip_bom(text)
         return self.parser.parse(text, start=start, on_error=on_error)
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1311,6 +1311,33 @@ def _make_parser_test(LEXER, PARSER):
                 s = j.encode(enc)
                 self.assertRaises(UnexpectedCharacters, g.parse, s)
 
+        def test_utf8_bom_is_skipped(self):
+            g = _Lark(r"""!start: "hello" """)
+            self.assertEqual(g.parse('\ufeffhello').children, ['hello'])
+
+        def test_utf8_bom_bytes_is_skipped(self):
+            g = _Lark(r"""!start: "hello" """, use_bytes=True)
+            self.assertEqual(g.parse(b'\xef\xbb\xbfhello').children[0].value, b'hello')
+
+        @unittest.skipIf(LEXER not in ('basic', 'contextual'), "TextSlice only supports basic and contextual lexers")
+        def test_utf8_bom_textslice_is_skipped(self):
+            g = _Lark(r"""!start: "hello" """)
+            self.assertEqual(g.parse(TextSlice('x\ufeffhello', 1, None)).children, ['hello'])
+
+        def test_utf8_bom_grammar_file_is_skipped(self):
+            import tempfile
+
+            grammar = '\ufeff!start: "hello"'
+            with tempfile.NamedTemporaryFile('w', encoding='utf8', suffix='.lark', delete=False) as f:
+                f.write(grammar)
+                grammar_path = f.name
+
+            try:
+                g = _Lark_open(grammar_path)
+                self.assertEqual(g.parse('hello').children, ['hello'])
+            finally:
+                os.unlink(grammar_path)
+
         @unittest.skipIf(PARSER == 'cyk', "Takes forever")
         def test_stack_for_ebnf(self):
             """Verify that stack depth isn't an issue for EBNF grammars"""


### PR DESCRIPTION
skip initial UTF-8 BOM before parsing text input and grammar files. Fixes #407
