### PR TITLE
Make Lark generic on transformer return type

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -28,7 +28,7 @@ jobs:
         pip install pytest-cov
         pytest --cov=./ --cov-report=xml
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./coverage.xml
@@ -36,5 +36,4 @@ jobs:
         env_vars: OS,PYTHON
         name: codecov-umbrella
         fail_ci_if_error: false
-        path_to_write_report: ./coverage/codecov_report.txt
         verbose: true

--- a/lark/lark.py
+++ b/lark/lark.py
@@ -6,7 +6,7 @@ import types
 import re
 from typing import (
     TypeVar, Type, List, Dict, Iterator, Callable, Union, Optional, Sequence,
-    Tuple, Iterable, IO, Any, TYPE_CHECKING, Collection
+    Tuple, Iterable, IO, Any, TYPE_CHECKING, Collection, Generic, overload,
 )
 if TYPE_CHECKING:
     from .parsers.lalr_interactive_parser import InteractiveParser
@@ -18,10 +18,12 @@ if TYPE_CHECKING:
 from .exceptions import ConfigurationError, assert_config, UnexpectedInput
 from .utils import Serialize, SerializeMemoizer, FS, logger, TextOrSlice, LarkInput
 from .load_grammar import load_grammar, FromPackageLoader, Grammar, verify_used_files, PackageResource, sha256_digest
+
 from .tree import Tree
 from .common import LexerConf, ParserConf, _ParserArgType, _LexerArgType
 
 from .lexer import Lexer, BasicLexer, TerminalDef, LexerThread, Token
+from .visitors import _Return_T
 from .parse_tree_builder import ParseTreeBuilder
 from .parser_frontends import _validate_frontend_args, _get_lexer_callbacks, _deserialize_parsing_frontend, _construct_parsing_frontend
 from .grammar import Rule
@@ -250,8 +252,9 @@ _VALID_AMBIGUITY_OPTIONS = ('auto', 'resolve', 'explicit', 'forest')
 
 
 _T = TypeVar('_T', bound="Lark")
+_InitReturn_T = TypeVar('_InitReturn_T') # __init__ self annotations must use a new type-var
 
-class Lark(Serialize):
+class Lark(Serialize, Generic[_Return_T]):
     """Main interface for the library.
 
     It's mostly a thin wrapper for the many different parsers, and for the tree constructor.
@@ -274,6 +277,22 @@ class Lark(Serialize):
     terminals: Collection[TerminalDef]
 
     __serialize_fields__ = ['parser', 'rules', 'options']
+
+    @overload
+    def __init__(
+        self: 'Lark[_InitReturn_T]',
+        grammar: 'Union[Grammar, str, IO[str]]',
+        *,
+        transformer: 'Transformer[Token, _InitReturn_T]',
+        **options: Any,
+    ) -> None: ...
+
+    @overload
+    def __init__(
+        self: 'Lark[ParseTree]',
+        grammar: 'Union[Grammar, str, IO[str]]',
+        **options: Any,
+    ) -> None: ...
 
     def __init__(self, grammar: 'Union[Grammar, str, IO[str]]', **options) -> None:
         self.options = LarkOptions(options)
@@ -575,8 +594,28 @@ class Lark(Serialize):
         inst = cls.__new__(cls)
         return inst._load({'data': data, 'memo': memo}, **kwargs)
 
+    @overload
     @classmethod
-    def open(cls: Type[_T], grammar_filename: str, rel_to: Optional[str]=None, **options) -> _T:
+    def open(
+        cls,
+        grammar_filename: str,
+        rel_to: Optional[str] = None,
+        *,
+        transformer: 'Transformer[Token, _Return_T]',
+        **options: Any,
+    ) -> 'Lark[_Return_T]': ...
+
+    @overload
+    @classmethod
+    def open(
+        cls,
+        grammar_filename: str,
+        rel_to: Optional[str] = None,
+        **options: Any,
+    ) -> 'Lark[ParseTree]': ...
+
+    @classmethod
+    def open(cls, grammar_filename: str, rel_to: Optional[str]=None, **options) -> 'Lark':
         """Create an instance of Lark with the grammar given by its filename
 
         If ``rel_to`` is provided, the function will find the grammar filename in relation to it.
@@ -585,7 +624,6 @@ class Lark(Serialize):
 
             >>> Lark.open("grammar_file.lark", rel_to=__file__, parser="lalr")
             Lark(...)
-
         """
         if rel_to:
             basepath = os.path.dirname(rel_to)
@@ -593,12 +631,34 @@ class Lark(Serialize):
         with open(grammar_filename, encoding='utf8') as f:
             return cls(f, **options)
 
+    @overload
     @classmethod
-    def open_from_package(cls: Type[_T], package: str, grammar_path: str, search_paths: 'Sequence[str]'=[""], **options) -> _T:
-        """Create an instance of Lark with the grammar loaded from within the package `package`.
+    def open_from_package(
+        cls,
+        package: str,
+        grammar_path: str,
+        search_paths: 'Sequence[str]' = ...,
+        *,
+        transformer: 'Transformer[Token, _Return_T]',
+        **options: Any,
+    ) -> 'Lark[_Return_T]': ...
+
+    @overload
+    @classmethod
+    def open_from_package(
+        cls,
+        package: str,
+        grammar_path: str,
+        search_paths: 'Sequence[str]' = ...,
+        **options: Any,
+    ) -> 'Lark[ParseTree]': ...
+
+    @classmethod
+    def open_from_package(cls, package: str, grammar_path: str, search_paths: 'Sequence[str]'=[""], **options) -> 'Lark':
+        """Create an instance of Lark with the grammar loaded from within the package ``package``.
         This allows grammar loading from zipapps.
 
-        Imports in the grammar will use the `package` and `search_paths` provided, through `FromPackageLoader`
+        Imports in the grammar will use the ``package`` and ``search_paths`` provided, through ``FromPackageLoader``
 
         Example:
 
@@ -651,7 +711,7 @@ class Lark(Serialize):
         """
         return self.parser.parse_interactive(text, start=start)
 
-    def parse(self, text: LarkInput, start: Optional[str]=None, on_error: 'Optional[Callable[[UnexpectedInput], bool]]'=None) -> 'ParseTree':
+    def parse(self, text: LarkInput, start: Optional[str]=None, on_error: 'Optional[Callable[[UnexpectedInput], bool]]'=None) -> _Return_T:
         """Parse the given text, according to the options provided.
 
         Parameters:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ lark = ["py.typed"]
 version = {attr = "lark.__version__"}
 
 [tool.mypy]
-files = "lark"
+files = ["lark", "tests/test_typing.py"]
 python_version = "3.8"
 show_error_codes = true
 enable_error_code = ["ignore-without-code", "unused-ignore"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,9 @@ exclude = [
 module = [ "js2py" ]
 ignore_missing_imports = true
 
+[tool.coverage.run]
+omit = ["tests/test_typing.py"]
+
 [tool.coverage.report]
 exclude_lines = [
     "pragma: no cover",

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -35,6 +35,17 @@ from lark.indenter import Indenter
 __all__ = ['TestParsers']
 
 
+class SerializeTestT(Transformer[Token, int]):
+    def __init__(self):
+        self.count = iter(range(2))
+
+    def NUMBER(self, token):
+        return next(self.count)
+
+    def start(self, children):
+        return children[0]
+
+
 class TestParsers(unittest.TestCase):
     def test_big_list(self):
         Lark(r"""
@@ -2502,6 +2513,20 @@ def _make_parser_test(LEXER, PARSER):
             s.seek(0)
             parser2 = Lark.load(s)
             self.assertEqual(parser2.parse('ABC'), Tree('start', [Tree('b', [])]) )
+
+        @unittest.skipIf(PARSER!='lalr' or LEXER == 'custom_old0', "Serialize currently only works for LALR parsers without custom lexers (though it should be easy to extend)")
+        def test_serialize_with_transformer(self):
+            grammar = r"""
+                start: NUMBER
+                NUMBER: /\d+/
+            """
+            parser = _Lark(grammar, transformer=SerializeTestT())
+            self.assertEqual(parser.parse('123'), 0)
+            s = BytesIO()
+            parser.save(s)
+            s.seek(0)
+            parser2 = Lark.load(s)
+            self.assertEqual(parser2.parse('123'), 1)
 
         def test_multi_start(self):
             parser = _Lark('''

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -1,0 +1,41 @@
+"""Static type checks for Lark's generic parse() return type.
+
+This file is never executed — it is checked by mypy only.
+Wrong type annotations here will cause a mypy error.
+"""
+from lark import Lark, Token, ParseTree, Transformer
+
+
+class _ToInt(Transformer[Token, int]):
+    def start(self, children): ...
+
+class _Untyped(Transformer):
+    def start(self, children): ...
+
+
+# __init__ without transformer -> Lark[ParseTree]
+_p1: Lark[ParseTree] = Lark(r'start: /\d+/')
+_r1: ParseTree = _p1.parse("42")
+
+# __init__ with transformer -> Lark[int]
+_p2: Lark[int] = Lark(r'start: /\d+/', parser='lalr', transformer=_ToInt())
+_r2: int = _p2.parse("42")
+
+# open() without transformer -> Lark[ParseTree]
+_p3: Lark[ParseTree] = Lark.open('grammar.lark')
+_r3: ParseTree = _p3.parse("42")
+
+# open() with transformer -> Lark[int]
+_p4: Lark[int] = Lark.open('grammar.lark', parser='lalr', transformer=_ToInt())
+_r4: int = _p4.parse("42")
+
+# open_from_package() without transformer -> Lark[ParseTree]
+_p5: Lark[ParseTree] = Lark.open_from_package(__name__, 'grammar.lark')
+_r5: ParseTree = _p5.parse("42")
+
+# open_from_package() with transformer -> Lark[int]
+_p6: Lark[int] = Lark.open_from_package(__name__, 'grammar.lark', parser='lalr', transformer=_ToInt())
+_r6: int = _p6.parse("42")
+
+# untyped transformer
+_p7: Lark[int] = Lark(r'start: /\d+/', parser='lalr', transformer=_Untyped())

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ description = run type check on code base
 skip_install = true
 recreate = false
 deps =
-    mypy==1.10
+    mypy==1.12
     interegular>=0.3.1,<0.4.0
     types-atomicwrites
     types-regex


### PR DESCRIPTION
Fixes #1186

One regression: subclasses of Lark using open() etc. will see a regression. But arguably it is pretty unusual, and we're fixing the much more common use-case.