### PR TITLE
Add Lark.scan() for finding grammar matches in text, and parsing them.

### DIFF
--- a/docs/classes.rst
+++ b/docs/classes.rst
@@ -107,4 +107,4 @@ ScanMatch
 
 A single match yielded by :meth:`Lark.scan`.
 
-.. autoclass:: lark.parser_frontends.ScanMatch
+.. autoclass:: lark.ScanMatch

--- a/docs/classes.rst
+++ b/docs/classes.rst
@@ -5,7 +5,7 @@ Lark
 ----
 
 .. autoclass:: lark.Lark
-    :members: open, parse, parse_interactive, lex, save, load, get_terminal, open_from_package
+    :members: open, parse, parse_interactive, scan, lex, save, load, get_terminal, open_from_package
 
 
 Using Unicode character classes with ``regex``
@@ -101,3 +101,10 @@ TextSlice
 ---------
 
 .. autoclass:: lark.utils.TextSlice
+
+ScanMatch
+---------
+
+A single match yielded by :meth:`Lark.scan`.
+
+.. autoclass:: lark.parser_frontends.ScanMatch

--- a/docs/features.md
+++ b/docs/features.md
@@ -22,6 +22,7 @@
 [Read more about the parsers](parsers.md)
 
 ## Extra features
+  - `Lark.scan()` for finding non-overlapping grammar matches embedded in arbitrary text (LALR only — see [recipes](recipes.html#extract-grammar-matches-from-arbitrary-text-with-lark-scan))
   - Support for external regex module ([see here](classes.html#using-unicode-character-classes-with-regex))
   - Import grammars from Nearley.js ([read more](tools.html#importing-grammars-from-nearleyjs))
   - CYK parser

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -204,3 +204,44 @@ the `Indenter` class. Take a look at the [indented tree example][indent] as well
 
 [indent]: examples/indented_tree.html
 [python]: https://github.com/lark-parser/lark/blob/master/lark/grammars/python.lark
+
+
+## Extract grammar matches from arbitrary text with `Lark.scan`
+
+Sometimes parsing the entire document isn't feasible. The scan method
+lets you find every instance of a grammar that appears inside arbitrary text.
+Things like dates in prose, JSON payloads in log lines, or configuration placeholders
+in templates.
+
+`Lark.scan()` walks the input from left to right, yielding a match per snippet that matches your grammar.
+Text that doesn't match is silently skipped.
+
+Example:
+```python
+from lark import Lark
+
+parser = Lark(r"""
+    date: MONTH DAY "," YEAR
+    MONTH: "January"|"February"|"March"|"April"|"May"|"June"
+         |"July"|"August"|"September"|"October"|"November"|"December"
+    DAY: /\d+/
+    YEAR: /\d+/
+    %ignore /\s+/
+""", parser="lalr", start="date")
+
+text = "Python 0.9.0 was released on February 20, 1991, and 1.0 on January 26, 1994."
+
+for match in parser.scan(text):
+    print("Found:", match)
+```
+
+Prints:
+
+```
+Found: ScanMatch(range=(29, 46), value=Tree(Token('RULE', 'date'), [Token('MONTH', 'February'), Token('DAY', '20'), Token('YEAR', '1991')]))
+Found: ScanMatch(range=(59, 75), value=Tree(Token('RULE', 'date'), [Token('MONTH', 'January'), Token('DAY', '26'), Token('YEAR', '1994')]))
+```
+
+For an example scanning text for JSON, see [`examples/advanced/scan_json.py`][scan_json].
+
+[scan_json]: examples/advanced/scan_json.html

--- a/examples/advanced/scan_json.py
+++ b/examples/advanced/scan_json.py
@@ -1,0 +1,84 @@
+"""
+Extracting JSON payloads from arbitrary text with ``Lark.scan``
+================================================================
+
+Shows ``Lark.scan`` finding JSON objects and arrays embedded in text.
+JSON has a recursive structure, which makes this task very hard for regex,
+but straightforward for a parser.
+
+The grammar and ``Transformer`` here are essentially the same as in
+``examples/json_parser.py``.
+"""
+
+from lark import Lark, Transformer, v_args
+
+
+example_text = r'''
+[2024-05-10 12:00:01] INFO  login: {"user": "alice", "tags": ["admin", "active"]}
+[2024-05-10 12:00:05] ERROR auth failed: {
+    "user": "bob",
+    "attempt": 3,
+    "blocked": false,
+    "reason": "rate-limited"
+}
+... that was unexpected; checking next event ...
+[2024-05-10 12:00:12] INFO  cart updated: {
+    "cart_id": 42,
+    "items": [
+        {"sku": "X1", "qty": 2, "price": 9.99},
+        {"sku": "Y2", "qty": 1, "price": 14.5e1}
+    ],
+    "promo": null
+}
+[2024-05-10 12:00:18] INFO  batch: ["a", "b", "c"]
+[2024-05-10 12:00:30] DEBUG no payload
+'''
+
+
+json_grammar = r"""
+    ?start: object | array
+
+    ?value: object
+          | array
+          | string
+          | SIGNED_NUMBER      -> number
+          | "true"             -> true
+          | "false"            -> false
+          | "null"             -> null
+
+    array  : "[" (value ("," value)*)? "]"
+    object : "{" (pair ("," pair)*)? "}"
+    pair   : string ":" value
+
+    string : ESCAPED_STRING
+
+    %import common.ESCAPED_STRING
+    %import common.SIGNED_NUMBER
+    %import common.WS
+
+    %ignore WS
+"""
+
+
+class TreeToJson(Transformer):
+    @v_args(inline=True)
+    def string(self, s):
+        return s[1:-1].replace('\\"', '"')
+
+    array = list
+    pair = tuple
+    object = dict
+    number = v_args(inline=True)(float)
+
+    null = lambda self, _: None
+    true = lambda self, _: True
+    false = lambda self, _: False
+
+
+parser = Lark(json_grammar, parser="lalr", transformer=TreeToJson())
+
+
+print(f"{'Range':<14}  Payload")
+print("-" * 90)
+for match in parser.scan(example_text):
+    print(f"{str(match.range):<14}  {match.value!r}")

--- a/lark/__init__.py
+++ b/lark/__init__.py
@@ -10,6 +10,7 @@ from .exceptions import (
 )
 from .lark import Lark
 from .lexer import Token
+from .parser_frontends import ScanMatch
 from .tree import ParseTree, Tree
 from .utils import logger, TextSlice
 from .visitors import Discard, Transformer, Transformer_NonRecursive, Visitor, v_args
@@ -27,6 +28,7 @@ __all__ = (
     "UnexpectedToken",
     "Lark",
     "Token",
+    "ScanMatch",
     "ParseTree",
     "Tree",
     "logger",

--- a/lark/lark.py
+++ b/lark/lark.py
@@ -757,6 +757,8 @@ class Lark(Serialize, Generic[_Return_T]):
 
         Note: ``lexer_callbacks`` may fire while exploring the input, for regions that yield no match.
 
+        Note: While lexer="basic" works, it highly not recommended due to performance liabilities.
+
         Parameters:
             text (TextOrSlice): Text to be scanned, as ``str``, ``bytes``, or a ``TextSlice`` instance.
             start (str, optional): Start symbol. Required if Lark was initialized with multiple start symbols.

--- a/lark/lark.py
+++ b/lark/lark.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from .tree import ParseTree
     from .visitors import Transformer
     from typing import Literal
-    from .parser_frontends import ParsingFrontend
+    from .parser_frontends import ParsingFrontend, ScanMatch
 
 from .exceptions import ConfigurationError, assert_config, UnexpectedInput
 from .utils import Serialize, SerializeMemoizer, FS, logger, TextOrSlice, LarkInput
@@ -735,6 +735,37 @@ class Lark(Serialize, Generic[_Return_T]):
         if on_error is not None and self.options.parser != 'lalr':
             raise NotImplementedError("The on_error option is only implemented for the LALR(1) parser.")
         return self.parser.parse(text, start=start, on_error=on_error)
+
+    def scan(self, text: TextOrSlice, start: Optional[str]=None) -> Iterable['ScanMatch[_Return_T]']:
+        """Scan the input text for non-overlapping matches of this grammar.
+        Only works when ``parser='lalr'`` and without ``postlex``.
+
+        Greedy parsing: Where multiple end positions are valid, the longest is returned.
+
+        Does not raise on lex or parse errors — invalid input is silently skipped.
+        Exceptions from user callbacks may still propagate.
+        When a lexer callback raises ``ValueError``, scan() will treat it as a lex error and abort scanning the match.
+
+        For best performance, ensure the first terminal(s) that can be matched by the grammar are unique
+        in the text and always indicate the start of a match.
+
+        A returned match will never start or end with an ignored terminal.
+
+        User ``lexer_callbacks`` must preserve source positions on returned tokens — use
+        ``Token.update()`` rather than constructing a fresh ``Token``.
+
+        Parameters:
+            text (TextOrSlice): Text to be scanned, as ``str``, ``bytes``, or a ``TextSlice`` instance.
+            start (str, optional): Start symbol. Required if Lark was initialized with multiple start symbols.
+
+        Yields:
+            ``ScanMatch`` instances, each with a ``range`` (a (start, end) tuple)
+            and a ``value`` attribute. ``value`` is a ``Tree`` by default, or
+            whatever the ``transformer`` returns when one was supplied.
+
+        See Also: ``Lark.parse()``
+        """
+        return self.parser.scan(text, start=start)
 
 
 ###}

--- a/lark/lark.py
+++ b/lark/lark.py
@@ -736,23 +736,26 @@ class Lark(Serialize, Generic[_Return_T]):
             raise NotImplementedError("The on_error option is only implemented for the LALR(1) parser.")
         return self.parser.parse(text, start=start, on_error=on_error)
 
-    def scan(self, text: TextOrSlice, start: Optional[str]=None) -> Iterable['ScanMatch[_Return_T]']:
+    def scan(self, text: TextOrSlice, start: Optional[str]=None) -> Iterator['ScanMatch[_Return_T]']:
         """Scan the input text for non-overlapping matches of this grammar.
         Only works when ``parser='lalr'`` and without ``postlex``.
 
-        Greedy parsing: Where multiple end positions are valid, the longest is returned.
+        Greedy parsing: where multiple end positions are valid, the longest is returned.
+        Input that doesn't match the grammar is silently skipped rather than raised.
 
-        Does not raise on lex or parse errors — invalid input is silently skipped.
-        Exceptions from user callbacks may still propagate.
-        When a lexer callback raises ``ValueError``, scan() will treat it as a lex error and abort scanning the match.
-
-        For best performance, ensure the first terminal(s) that can be matched by the grammar are unique
-        in the text and always indicate the start of a match.
+        Performance: scan() runs a parse attempt at every position where a match could begin, so its
+        cost is the sum of those attempts' lengths -- in the worst case O(n*m), with n the input
+        length and m the longest possible parse attempt. For best results, choose leading terminals
+        that are rare in the text and reliably indicate the start of a match.
 
         A returned match will never start or end with an ignored terminal.
 
         User ``lexer_callbacks`` must preserve source positions on returned tokens — use
-        ``Token.update()`` rather than constructing a fresh ``Token``.
+        ``Token.update()`` rather than constructing a fresh ``Token``. A callback that raises
+        ``ValueError`` is treated as a failed lex, skipping the candidate match; any other
+        exception propagates.
+
+        Note: ``lexer_callbacks`` may fire while exploring the input, for regions that yield no match.
 
         Parameters:
             text (TextOrSlice): Text to be scanned, as ``str``, ``bytes``, or a ``TextSlice`` instance.
@@ -763,8 +766,14 @@ class Lark(Serialize, Generic[_Return_T]):
             and a ``value`` attribute. ``value`` is a ``Tree`` by default, or
             whatever the ``transformer`` returns when one was supplied.
 
+        :raises ConfigurationError: If the configuration doesn't support scanning;
+                scan() requires ``parser='lalr'`` without ``postlex`` or a custom lexer.
+        :raises LexError: If a ``lexer_callback`` returns a token without source positions.
+
         See Also: ``Lark.parse()``
         """
+        if self.options.parser != 'lalr':
+            raise ConfigurationError("scan() requires parser='lalr'")
         return self.parser.scan(text, start=start)
 
 

--- a/lark/lark.py
+++ b/lark/lark.py
@@ -757,7 +757,7 @@ class Lark(Serialize, Generic[_Return_T]):
 
         Note: ``lexer_callbacks`` may fire while exploring the input, for regions that yield no match.
 
-        Note: While lexer="basic" works, it highly not recommended due to performance liabilities.
+        Note: While ``lexer='basic'`` works, it can be much slower than the contextual lexer. Use is strongly discouraged.
 
         Parameters:
             text (TextOrSlice): Text to be scanned, as ``str``, ``bytes``, or a ``TextSlice`` instance.

--- a/lark/lexer.py
+++ b/lark/lexer.py
@@ -4,7 +4,7 @@ from abc import abstractmethod, ABC
 import re
 from typing import (
     TypeVar, Type, Dict, Iterator, Collection, Callable, Optional, FrozenSet, Any,
-    ClassVar, TYPE_CHECKING, overload
+    AnyStr, ClassVar, TYPE_CHECKING, overload
 )
 from types import ModuleType
 import warnings
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from .parsers.lalr_parser_state import ParserState
 
 from .utils import classify, get_regexp_width, Serialize, logger, TextSlice, TextOrSlice
-from .exceptions import UnexpectedCharacters, LexError, UnexpectedToken
+from .exceptions import UnexpectedCharacters, ConfigurationError, LexError, UnexpectedToken
 from .grammar import TOKEN_DEFAULT_PRIORITY
 
 
@@ -307,7 +307,7 @@ class LineCounter:
             self.line_start_pos = text_slice.line_start_pos
             self.column = text_slice.start - text_slice.line_start_pos + 1
         elif text_slice.start > 0:
-            self.feed(TextSlice(text_slice.text, 0, text_slice.start))
+            self.advance_to(text_slice.text, text_slice.start)
         return self
 
     def __eq__(self, other):
@@ -316,7 +316,7 @@ class LineCounter:
 
         return self.char_pos == other.char_pos and self.newline_char == other.newline_char
 
-    def feed(self, token: TextOrSlice, test_newline=True):
+    def feed(self, token: AnyStr, test_newline=True):
         """Consume a token and calculate the new line & column.
 
         As an optional optimization, set test_newline=False if token doesn't contain a newline.
@@ -328,6 +328,16 @@ class LineCounter:
                 self.line_start_pos = self.char_pos + token.rindex(self.newline_char) + 1
 
         self.char_pos += len(token)
+        self.column = self.char_pos - self.line_start_pos + 1
+
+    def advance_to(self, text: AnyStr, pos: int):
+        """Advance the counter to absolute offset ``pos`` within ``text``, counting the newlines
+        """
+        newlines = text.count(self.newline_char, self.char_pos, pos)
+        if newlines:
+            self.line += newlines
+            self.line_start_pos = text.rindex(self.newline_char, self.char_pos, pos) + 1
+        self.char_pos = pos
         self.column = self.char_pos - self.line_start_pos + 1
 
 
@@ -423,15 +433,14 @@ class Scanner:
                 return m.lastgroup
         return None
 
-    def search(self, text: TextSlice, pos: int):
-        "Find earliest match, starting at pos"
+    def search(self, text: TextSlice, pos: int) -> Optional[int]:
+        "Find the position of the earliest match, starting at pos"
         best = None
         for mre in self._mres:
             m = mre.search(text.text, pos, text.end)
             if m and (best is None or m.start() < best.start()):
                 best = m
-        if best is not None:
-            return (best.group(0), best.lastgroup), best.start()
+        return best.start() if best is not None else None
 
 def _regexp_has_newline(r: str):
     r"""Expressions that may indicate newlines in a regexp:
@@ -519,7 +528,8 @@ class Lexer(ABC):
         return NotImplemented
 
     def search_start(self, text: TextSlice, start_state: Any, pos: int) -> Optional[int]:
-        raise TypeError("This lexer cannot be used for searching in text")
+        raise ConfigurationError("scan() is not supported by %s; use the built-in 'basic' or 'contextual' lexer"
+                                 % type(self).__name__)
 
     def make_lexer_state(self, text: str):
         "Deprecated"
@@ -693,11 +703,7 @@ class BasicLexer(AbstractBasicLexer):
         raise EOFError(self)
 
     def search_start(self, text: TextSlice, start_state: Any, pos: int) -> Optional[int]:
-        res = self.search_scanner.search(text, pos)
-        if res is None:
-            return None
-        _, actual_pos = res
-        return actual_pos
+        return self.search_scanner.search(text, pos)
 
 
 class ContextualLexer(Lexer):

--- a/lark/lexer.py
+++ b/lark/lexer.py
@@ -518,7 +518,7 @@ class Lexer(ABC):
     def lex(self, lexer_state: LexerState, parser_state: Any) -> Iterator[Token]:
         return NotImplemented
 
-    def search_start(self, text: TextSlice, start_state: Any, pos: int) -> Optional[Token]:
+    def search_start(self, text: TextSlice, start_state: Any, pos: int) -> Optional[int]:
         raise TypeError("This lexer cannot be used for searching in text")
 
     def make_lexer_state(self, text: str):
@@ -624,6 +624,7 @@ class BasicLexer(AbstractBasicLexer):
         self.terminals_by_name = conf.terminals_by_name
 
         self._scanner: Optional[Scanner] = None
+        self._search_scanner: Optional[Scanner] = None
 
     def _build_scanner(self) -> Scanner:
         terminals, self.callback = _create_unless(self.terminals, self.g_regex_flags, self.re, self.use_bytes)
@@ -643,6 +644,16 @@ class BasicLexer(AbstractBasicLexer):
         if self._scanner is None:
             self._scanner = self._build_scanner()
         return self._scanner
+
+    @property
+    def search_scanner(self) -> Scanner:
+        # Used by search_start(): a match can only begin with a non-ignored terminal, so we
+        # search those directly. Searching all terminals and skipping ignores would jump past
+        # a real start hiding inside an ignore's span (e.g. the "a" in an ignored "xxa").
+        if self._search_scanner is None:
+            terminals = [t for t in self.terminals if t.name not in self.ignore_types]
+            self._search_scanner = Scanner(terminals, self.g_regex_flags, self.re, self.use_bytes)
+        return self._search_scanner
 
     def match(self, text, pos):
         return self.scanner.match(text, pos)
@@ -681,16 +692,12 @@ class BasicLexer(AbstractBasicLexer):
         # EOF
         raise EOFError(self)
 
-    def search_start(self, text: TextSlice, start_state: Any, pos: int) -> Optional[Token]:
-        while True:
-            res = self.scanner.search(text, pos)
-            if not res:
-                return None
-            (value, type_), actual_pos = res
-            if type_ in self.ignore_types:
-                pos = actual_pos + len(value)
-                continue
-            return Token(type_, value, actual_pos, end_pos=actual_pos + len(value))
+    def search_start(self, text: TextSlice, start_state: Any, pos: int) -> Optional[int]:
+        res = self.search_scanner.search(text, pos)
+        if res is None:
+            return None
+        _, actual_pos = res
+        return actual_pos
 
 
 class ContextualLexer(Lexer):
@@ -746,7 +753,7 @@ class ContextualLexer(Lexer):
             except UnexpectedCharacters:
                 raise e  # Raise the original UnexpectedCharacters. The root lexer raises it with the wrong expected set.
 
-    def search_start(self, text: TextSlice, start_state: Any, pos: int) -> Optional[Token]:
+    def search_start(self, text: TextSlice, start_state: Any, pos: int) -> Optional[int]:
         return self.lexers[start_state].search_start(text, start_state, pos)
 
 ###}

--- a/lark/lexer.py
+++ b/lark/lexer.py
@@ -254,13 +254,15 @@ class Token(str):
         return cls(type_, value, borrow_t.start_pos, borrow_t.line, borrow_t.column, borrow_t.end_line, borrow_t.end_column, borrow_t.end_pos)
 
     def __reduce__(self):
-        return (self.__class__, (self.type, self.value, self.start_pos, self.line, self.column))
+        return (self.__class__, (self.type, self.value, self.start_pos, self.line, self.column,
+                                 self.end_line, self.end_column, self.end_pos))
 
     def __repr__(self):
         return 'Token(%r, %r)' % (self.type, self.value)
 
     def __deepcopy__(self, memo):
-        return Token(self.type, self.value, self.start_pos, self.line, self.column)
+        return Token(self.type, self.value, self.start_pos, self.line, self.column,
+                     self.end_line, self.end_column, self.end_pos)
 
     def __eq__(self, other):
         if isinstance(other, Token) and self.type != other.type:

--- a/lark/lexer.py
+++ b/lark/lexer.py
@@ -398,6 +398,16 @@ class Scanner:
                 return m.lastgroup
         return None
 
+    def search(self, text: TextSlice, pos: int):
+        "Find earliest match, starting at pos"
+        best = None
+        for mre in self._mres:
+            m = mre.search(text.text, pos, text.end)
+            if m and (best is None or m.start() < best.start()):
+                best = m
+        if best is not None:
+            return (best.group(0), best.lastgroup), best.start()
+
 def _regexp_has_newline(r: str):
     r"""Expressions that may indicate newlines in a regexp:
         - newlines (\n)
@@ -486,6 +496,9 @@ class Lexer(ABC):
     @abstractmethod
     def lex(self, lexer_state: LexerState, parser_state: Any) -> Iterator[Token]:
         return NotImplemented
+
+    def search_start(self, text: TextSlice, start_state: Any, pos: int) -> Optional[Token]:
+        raise TypeError("This lexer cannot be used for searching in text")
 
     def make_lexer_state(self, text: str):
         "Deprecated"
@@ -647,6 +660,17 @@ class BasicLexer(AbstractBasicLexer):
         # EOF
         raise EOFError(self)
 
+    def search_start(self, text: TextSlice, start_state: Any, pos: int) -> Optional[Token]:
+        while True:
+            res = self.scanner.search(text, pos)
+            if not res:
+                return None
+            (value, type_), actual_pos = res
+            if type_ in self.ignore_types:
+                pos = actual_pos + len(value)
+                continue
+            return Token(type_, value, actual_pos, end_pos=actual_pos + len(value))
+
 
 class ContextualLexer(Lexer):
     lexers: Dict[int, AbstractBasicLexer]
@@ -700,5 +724,8 @@ class ContextualLexer(Lexer):
                 raise UnexpectedToken(token, e.allowed, state=parser_state, token_history=[last_token], terminals_by_name=self.root_lexer.terminals_by_name)
             except UnexpectedCharacters:
                 raise e  # Raise the original UnexpectedCharacters. The root lexer raises it with the wrong expected set.
+
+    def search_start(self, text: TextSlice, start_state: Any, pos: int) -> Optional[Token]:
+        return self.lexers[start_state].search_start(text, start_state, pos)
 
 ###}

--- a/lark/lexer.py
+++ b/lark/lexer.py
@@ -24,6 +24,7 @@ from .grammar import TOKEN_DEFAULT_PRIORITY
 ###{standalone
 from contextlib import suppress
 from copy import copy
+from dataclasses import dataclass
 
 try:  # For the standalone parser, we need to make sure that has_interegular is False to avoid NameErrors later on
     has_interegular = bool(interegular)
@@ -273,6 +274,15 @@ class Token(str):
     __hash__ = str.__hash__
 
 
+@dataclass(frozen=True)
+class _TextSlice_WithLineCount(TextSlice):
+    """Internal: a TextSlice carrying the line/column state at its ``start``, so the lexer can
+    resume position tracking without re-counting from offset 0.
+    """
+    line: int
+    line_start_pos: int
+
+
 class LineCounter:
     "A utility class for keeping track of line & column information"
 
@@ -284,6 +294,21 @@ class LineCounter:
         self.line = 1
         self.column = 1
         self.line_start_pos = 0
+
+    @classmethod
+    def from_text_slice(cls, text_slice: TextSlice) -> 'LineCounter':
+        """Build a counter positioned at ``text_slice.start``. Resumes from a snapshot when the
+        slice carries one (``_TextSlice_WithLineCount``); otherwise counts the prefix once.
+        """
+        self = cls(b'\n' if isinstance(text_slice.text, bytes) else '\n')
+        if isinstance(text_slice, _TextSlice_WithLineCount):
+            self.char_pos = text_slice.start
+            self.line = text_slice.line
+            self.line_start_pos = text_slice.line_start_pos
+            self.column = text_slice.start - text_slice.line_start_pos + 1
+        elif text_slice.start > 0:
+            self.feed(TextSlice(text_slice.text, 0, text_slice.start))
+        return self
 
     def __eq__(self, other):
         if not isinstance(other, LineCounter):
@@ -433,11 +458,7 @@ class LexerState:
     def __init__(self, text: TextSlice, line_ctr: Optional[LineCounter] = None, last_token: Optional[Token]=None):
         if isinstance(text, TextSlice):
             if line_ctr is None:
-                line_ctr = LineCounter(b'\n' if isinstance(text.text, bytes) else '\n')
-
-                if text.start > 0:
-                    # Advance the line-count until line_ctr.char_pos == text.start
-                    line_ctr.feed(TextSlice(text.text, 0, text.start))
+                line_ctr = LineCounter.from_text_slice(text)
 
             if not (text.start <= line_ctr.char_pos <= text.end):
                 raise ValueError("LineCounter.char_pos is out of bounds")

--- a/lark/parser_frontends.py
+++ b/lark/parser_frontends.py
@@ -177,17 +177,16 @@ class ParsingFrontend(Serialize):
         line_ctr = LineCounter.from_text_slice(text_slice)
         while True:
             # Search for a plausible start
-            first_token = self.lexer.search_start(text_slice, start_state, pos)
-            if first_token is None:
+            match_start = self.lexer.search_start(text_slice, start_state, pos)
+            if match_start is None:
                 return
-            assert first_token.start_pos is not None and first_token.start_pos >= text_slice.start
-            assert first_token.end_pos is not None and first_token.end_pos <= text_slice.end
+            assert text_slice.start <= match_start <= text_slice.end
 
             # Parse without callbacks, to keep value-stack minimal and avoid expensive deepcopies.
             # Aim for the longest possible match, and save the tokens we lex for later replay.
-            line_ctr.feed(text_slice.text[line_ctr.char_pos:first_token.start_pos])
+            line_ctr.feed(text_slice.text[line_ctr.char_pos:match_start])
             text_slice_wlc = _TextSlice_WithLineCount(
-                text_slice.text, first_token.start_pos, text_slice.end,
+                text_slice.text, match_start, text_slice.end,
                 line_ctr.line, line_ctr.line_start_pos)
             stunted_ip = self.parse_interactive(text_slice_wlc, start=chosen_start)
             stunted_ip.parser_state.parse_conf.callbacks = {}
@@ -228,12 +227,13 @@ class ParsingFrontend(Serialize):
                             f"scan() requires source positions on every token (use Token.update() in callbacks).")
                     replay_ip.feed_token(t)
                 res = replay_ip.feed_eof(matched[-1])
-                yield ScanMatch((first_token.start_pos, matched[-1].end_pos), res)
+                # Range comes from the matched tokens, not match_start (the lexer may skip leading ignores).
+                yield ScanMatch((matched[0].start_pos, matched[-1].end_pos), res)
                 # Resume from end of match (no overlaps)
                 pos = matched[-1].end_pos
             else:
                 # No match found. Scan again from next character
-                pos = first_token.start_pos + 1
+                pos = match_start + 1
 
 
 def _validate_frontend_args(parser, lexer) -> None:

--- a/lark/parser_frontends.py
+++ b/lark/parser_frontends.py
@@ -1,6 +1,5 @@
-from copy import copy
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, Optional, Collection, Union, TYPE_CHECKING, Generic, Iterable, Tuple, TypeVar
+from typing import Any, Callable, Dict, Optional, Collection, Union, TYPE_CHECKING, Generic, Iterator, Tuple, TypeVar
 
 from .exceptions import ConfigurationError, GrammarError, LexError, UnexpectedInput, assert_config
 from .utils import get_regexp_width, Serialize, TextOrSlice, TextSlice, LarkInput
@@ -156,7 +155,7 @@ class ParsingFrontend(Serialize):
         stream = self._make_lexer_thread(text)
         return self.parser.parse_interactive(stream, chosen_start)
 
-    def scan(self, text: TextOrSlice, start: Optional[str]=None) -> Iterable[ScanMatch]:
+    def scan(self, text: TextOrSlice, start: Optional[str]=None) -> Iterator[ScanMatch]:
         """See ``Lark.scan``."""
         if self.parser_conf.parser_type != 'lalr':
             raise ConfigurationError("scan() requires parser='lalr'")
@@ -165,9 +164,14 @@ class ParsingFrontend(Serialize):
         if self.lexer_conf.postlex is not None:
             # postlex carries state across the stream (indent depth, paren nesting); mid-stream parses break it.
             raise ConfigurationError("scan() does not support postlex")
+        if isinstance(self.lexer_conf.lexer_type, type):
+            # A custom lexer class was supplied; scan() relies on the built-in lexers' search_start().
+            raise ConfigurationError("scan() does not support custom lexers")
         chosen_start = self._verify_start(start)
+        return self._scan(TextSlice.cast_from(text), chosen_start)
+
+    def _scan(self, text_slice: TextSlice, chosen_start: str) -> Iterator[ScanMatch]:
         start_state = self.parser._parse_table.start_states[chosen_start]
-        text_slice = TextSlice.cast_from(text)
         pos = text_slice.start
         while True:
             # Search for a plausible start
@@ -180,7 +184,6 @@ class ParsingFrontend(Serialize):
             # Parse without callbacks, to keep value-stack minimal and avoid expensive deepcopies.
             # Aim for the longest possible match, and save the tokens we lex for later replay.
             stunted_ip = self.parse_interactive(text_slice.start_from(first_token.start_pos), start=chosen_start)
-            stunted_ip.parser_state.parse_conf = copy(stunted_ip.parser_state.parse_conf)
             stunted_ip.parser_state.parse_conf.callbacks = {}
             matched_tokens = []
             longest_match = 0  # number of tokens in the longest accepted prefix
@@ -201,24 +204,27 @@ class ParsingFrontend(Serialize):
             except UnexpectedInput:
                 # Parse failed
                 pass
+            except ConfigurationError:
+                # ConfigurationError subclasses ValueError, and must not be swallowed
+                raise
             except ValueError:
                 # A user lexer-callback raised an error
                 pass
 
             if longest_match:
                 # Match found! Replay tokens with real callbacks, and yield the result
-                last = matched_tokens[longest_match - 1]
-                if last.end_pos is None:
-                    raise LexError(
-                        f"Lexer callback for {last.type!r} did not preserve token positions; "
-                        f"scan() requires source positions on every token (use Token.update() in callbacks).")
+                matched = matched_tokens[:longest_match]
                 replay_ip = self.parse_interactive(start=chosen_start)
-                for t in matched_tokens[:longest_match]:
+                for t in matched:
+                    if t.start_pos is None or t.end_pos is None:
+                        raise LexError(
+                            f"Lexer callback for {t.type!r} did not preserve token positions; "
+                            f"scan() requires source positions on every token (use Token.update() in callbacks).")
                     replay_ip.feed_token(t)
-                res = replay_ip.feed_eof(last)
-                yield ScanMatch((first_token.start_pos, last.end_pos), res)
+                res = replay_ip.feed_eof(matched[-1])
+                yield ScanMatch((first_token.start_pos, matched[-1].end_pos), res)
                 # Resume from end of match (no overlaps)
-                pos = last.end_pos
+                pos = matched[-1].end_pos
             else:
                 # No match found. Scan again from next character
                 pos = first_token.start_pos + 1

--- a/lark/parser_frontends.py
+++ b/lark/parser_frontends.py
@@ -1,6 +1,8 @@
-from typing import Any, Callable, Dict, Optional, Collection, Union, TYPE_CHECKING
+from copy import copy
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Optional, Collection, Union, TYPE_CHECKING, Generic, Iterable, Tuple, TypeVar
 
-from .exceptions import ConfigurationError, GrammarError, assert_config
+from .exceptions import ConfigurationError, GrammarError, LexError, UnexpectedInput, assert_config
 from .utils import get_regexp_width, Serialize, TextOrSlice, TextSlice, LarkInput
 from .lexer import LexerThread, BasicLexer, ContextualLexer, Lexer
 from .parsers import earley, xearley, cyk
@@ -13,6 +15,21 @@ if TYPE_CHECKING:
 
 
 ###{standalone
+
+T = TypeVar('T')
+
+@dataclass(frozen=True)
+class ScanMatch(Generic[T]):
+    """A non-overlapping match found by ``Lark.scan()``.
+
+    Attributes:
+        range: A (start, end) tuple of the indices in the input text.
+        value: The parse result. A ``Tree`` by default, or whatever the
+            ``transformer`` returns when one was supplied to Lark.
+    """
+    range: Tuple[int, int]
+    value: T
+
 
 def _wrap_lexer(lexer_class):
     future_interface = getattr(lexer_class, '__future_interface__', 0)
@@ -138,6 +155,73 @@ class ParsingFrontend(Serialize):
             raise ConfigurationError("parse_interactive() currently only works with parser='lalr' ")
         stream = self._make_lexer_thread(text)
         return self.parser.parse_interactive(stream, chosen_start)
+
+    def scan(self, text: TextOrSlice, start: Optional[str]=None) -> Iterable[ScanMatch]:
+        """See ``Lark.scan``."""
+        if self.parser_conf.parser_type != 'lalr':
+            raise ConfigurationError("scan() requires parser='lalr'")
+        if self.skip_lexer:
+            raise ConfigurationError("scan() does not support lexer='dynamic'/'dynamic_complete'")
+        if self.lexer_conf.postlex is not None:
+            # postlex carries state across the stream (indent depth, paren nesting); mid-stream parses break it.
+            raise ConfigurationError("scan() does not support postlex")
+        chosen_start = self._verify_start(start)
+        start_state = self.parser._parse_table.start_states[chosen_start]
+        text_slice = TextSlice.cast_from(text)
+        pos = text_slice.start
+        while True:
+            # Search for a plausible start
+            first_token = self.lexer.search_start(text_slice, start_state, pos)
+            if first_token is None:
+                return
+            assert first_token.start_pos is not None and first_token.start_pos >= text_slice.start
+            assert first_token.end_pos is not None and first_token.end_pos <= text_slice.end
+
+            # Parse without callbacks, to keep value-stack minimal and avoid expensive deepcopies.
+            # Aim for the longest possible match, and save the tokens we lex for later replay.
+            stunted_ip = self.parse_interactive(text_slice.start_from(first_token.start_pos), start=chosen_start)
+            stunted_ip.parser_state.parse_conf = copy(stunted_ip.parser_state.parse_conf)
+            stunted_ip.parser_state.parse_conf.callbacks = {}
+            matched_tokens = []
+            longest_match = 0  # number of tokens in the longest accepted prefix
+            token_stream = stunted_ip.lexer_thread.lex(stunted_ip.parser_state)
+            try:
+                for token in token_stream:
+                    stunted_ip.feed_token(token)
+                    matched_tokens.append(token)
+                    # Test if we reached a possible completed parse
+                    if '$END' in stunted_ip.choices():
+                        tmp_ip = stunted_ip.copy(deepcopy_values=False)
+                        try:
+                            tmp_ip.feed_eof(token)
+                        except UnexpectedInput:
+                            continue
+                        longest_match = len(matched_tokens)
+                        # keep going and testing for candidates, until the parse ends or fails
+            except UnexpectedInput:
+                # Parse failed
+                pass
+            except ValueError:
+                # A user lexer-callback raised an error
+                pass
+
+            if longest_match:
+                # Match found! Replay tokens with real callbacks, and yield the result
+                last = matched_tokens[longest_match - 1]
+                if last.end_pos is None:
+                    raise LexError(
+                        f"Lexer callback for {last.type!r} did not preserve token positions; "
+                        f"scan() requires source positions on every token (use Token.update() in callbacks).")
+                replay_ip = self.parse_interactive(start=chosen_start)
+                for t in matched_tokens[:longest_match]:
+                    replay_ip.feed_token(t)
+                res = replay_ip.feed_eof(last)
+                yield ScanMatch((first_token.start_pos, last.end_pos), res)
+                # Resume from end of match (no overlaps)
+                pos = last.end_pos
+            else:
+                # No match found. Scan again from next character
+                pos = first_token.start_pos + 1
 
 
 def _validate_frontend_args(parser, lexer) -> None:

--- a/lark/parser_frontends.py
+++ b/lark/parser_frontends.py
@@ -3,7 +3,7 @@ from typing import Any, Callable, Dict, Optional, Collection, Union, TYPE_CHECKI
 
 from .exceptions import ConfigurationError, GrammarError, LexError, UnexpectedInput, assert_config
 from .utils import get_regexp_width, Serialize, TextOrSlice, TextSlice, LarkInput
-from .lexer import LexerThread, BasicLexer, ContextualLexer, Lexer
+from .lexer import LexerThread, LineCounter, _TextSlice_WithLineCount, BasicLexer, ContextualLexer, Lexer
 from .parsers import earley, xearley, cyk
 from .parsers.lalr_parser import LALR_Parser
 from .tree import Tree
@@ -173,6 +173,8 @@ class ParsingFrontend(Serialize):
     def _scan(self, text_slice: TextSlice, chosen_start: str) -> Iterator[ScanMatch]:
         start_state = self.parser._parse_table.start_states[chosen_start]
         pos = text_slice.start
+        # We count the lines here, to avoid re-counting them inside each new lexer state
+        line_ctr = LineCounter.from_text_slice(text_slice)
         while True:
             # Search for a plausible start
             first_token = self.lexer.search_start(text_slice, start_state, pos)
@@ -183,7 +185,11 @@ class ParsingFrontend(Serialize):
 
             # Parse without callbacks, to keep value-stack minimal and avoid expensive deepcopies.
             # Aim for the longest possible match, and save the tokens we lex for later replay.
-            stunted_ip = self.parse_interactive(text_slice.start_from(first_token.start_pos), start=chosen_start)
+            line_ctr.feed(text_slice.text[line_ctr.char_pos:first_token.start_pos])
+            text_slice_wlc = _TextSlice_WithLineCount(
+                text_slice.text, first_token.start_pos, text_slice.end,
+                line_ctr.line, line_ctr.line_start_pos)
+            stunted_ip = self.parse_interactive(text_slice_wlc, start=chosen_start)
             stunted_ip.parser_state.parse_conf.callbacks = {}
             matched_tokens = []
             longest_match = 0  # number of tokens in the longest accepted prefix

--- a/lark/parser_frontends.py
+++ b/lark/parser_frontends.py
@@ -3,7 +3,7 @@ from typing import Any, Callable, Dict, Optional, Collection, Union, TYPE_CHECKI
 
 from .exceptions import ConfigurationError, GrammarError, LexError, UnexpectedInput, assert_config
 from .utils import get_regexp_width, Serialize, TextOrSlice, TextSlice, LarkInput
-from .lexer import LexerThread, LineCounter, _TextSlice_WithLineCount, BasicLexer, ContextualLexer, Lexer
+from .lexer import LexerThread, LineCounter, Token, _TextSlice_WithLineCount, BasicLexer, ContextualLexer, Lexer
 from .parsers import earley, xearley, cyk
 from .parsers.lalr_parser import LALR_Parser
 from .tree import Tree
@@ -184,7 +184,7 @@ class ParsingFrontend(Serialize):
 
             # Parse without callbacks, to keep value-stack minimal and avoid expensive deepcopies.
             # Aim for the longest possible match, and save the tokens we lex for later replay.
-            line_ctr.feed(text_slice.text[line_ctr.char_pos:match_start])
+            line_ctr.advance_to(text_slice.text, match_start)
             text_slice_wlc = _TextSlice_WithLineCount(
                 text_slice.text, match_start, text_slice.end,
                 line_ctr.line, line_ctr.line_start_pos)
@@ -199,9 +199,9 @@ class ParsingFrontend(Serialize):
                     matched_tokens.append(token)
                     # Test if we reached a possible completed parse
                     if '$END' in stunted_ip.choices():
-                        tmp_ip = stunted_ip.copy(deepcopy_values=False)
+                        tmp_state = stunted_ip.parser_state.copy(deepcopy_values=False)
                         try:
-                            tmp_ip.feed_eof(token)
+                            tmp_state.feed_token(Token.new_borrow_pos('$END', '', token), is_end=True)
                         except UnexpectedInput:
                             continue
                         longest_match = len(matched_tokens)

--- a/lark/utils.py
+++ b/lark/utils.py
@@ -215,6 +215,9 @@ class TextSlice(Generic[AnyStr]):
     def is_complete_text(self):
         return self.start == 0 and self.end == len(self.text)
 
+    def start_from(self, pos: int) -> 'TextSlice[AnyStr]':
+        return TextSlice(self.text, pos, self.end)
+
     def __len__(self):
         return self.end - self.start
 

--- a/lark/utils.py
+++ b/lark/utils.py
@@ -215,9 +215,6 @@ class TextSlice(Generic[AnyStr]):
     def is_complete_text(self):
         return self.start == 0 and self.end == len(self.text)
 
-    def start_from(self, pos: int) -> 'TextSlice[AnyStr]':
-        return TextSlice(self.text, pos, self.end)
-
     def __len__(self):
         return self.end - self.start
 

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -13,6 +13,7 @@ from .test_reconstructor import TestReconstructor
 from .test_tree_forest_transformer import TestTreeForestTransformer
 from .test_lexer import TestLexer
 from .test_python_grammar import TestPythonParser
+from .test_scan import TestScan
 from .test_tree_templates import *  # We define __all__ to list which TestSuites to run
 
 try:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -26,7 +26,7 @@ import lark
 from lark import logger
 from lark.lark import Lark
 from lark.utils import TextSlice
-from lark.exceptions import GrammarError, ParseError, UnexpectedToken, UnexpectedInput, UnexpectedCharacters
+from lark.exceptions import GrammarError, ParseError, UnexpectedToken, UnexpectedInput, UnexpectedCharacters, ConfigurationError
 from lark.tree import Tree
 from lark.visitors import Transformer, Transformer_InPlace, v_args, Transformer_InPlaceRecursive
 from lark.lexer import Lexer, BasicLexer
@@ -2839,6 +2839,18 @@ def _make_parser_test(LEXER, PARSER):
             parser = _Lark("start: ")
             s = TextSlice("hello", 2, 3)
             self.assertRaises(TypeError, parser.parse, s)
+
+        @unittest.skipIf(PARSER != 'lalr', "scan() only supports the LALR parser")
+        def test_scan_lexer_support(self):
+            # scan() works with the built-in lexers, but rejects custom lexers, which
+            # don't implement search_start().
+            parser = _Lark('start: "a"+')
+            if LEXER.startswith('custom'):
+                with self.assertRaises(ConfigurationError):
+                    list(parser.scan("aa"))
+            else:
+                m, = parser.scan("aa")
+                self.assertEqual((m.range, m.value), ((0, 2), Tree('start', [])))
 
 
     _NAME = "Test" + PARSER.capitalize() + LEXER.capitalize()

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -1,0 +1,247 @@
+import unittest
+
+from lark import Lark, TextSlice, Token, Transformer, Tree
+from lark.exceptions import ConfigurationError, LexError
+from lark.indenter import Indenter
+from lark.parser_frontends import ScanMatch
+
+
+class TestScan(unittest.TestCase):
+    def test_scan_sanity(self):
+        for lexer in ["basic", "contextual"]:
+            parser = Lark(r"""
+            expr: "(" (WORD|expr)* ")"
+            %ignore / +/
+            WORD: /\w+/
+            """, parser='lalr', start="expr", lexer=lexer)
+
+            text = "|() | (a) | ((//)) | (c ((d))) |"
+            finds = list(parser.scan(text))
+            self.assertEqual(finds, [ScanMatch((1, 3), Tree('expr', [])),
+                                    ScanMatch((6, 9), Tree('expr', ['a'])),
+                                    ScanMatch((21, 30), Tree('expr', ['c', Tree('expr', [Tree('expr', ['d'])])])),
+                                    ])
+
+    def test_scan_meta(self):
+        parser = Lark(r"""
+        expr: "(" (WORD|expr)* ")"
+        %ignore /\s+/
+        WORD: /\w+/
+        """, parser='lalr', start="expr", propagate_positions=True)
+
+        text = " (a)\n(b)\n (\n)"
+        finds = list(parser.scan(text))
+        self.assertEqual(finds, [ScanMatch((1, 4), Tree('expr', ['a'])),
+                                 ScanMatch((5, 8), Tree('expr', ['b'])),
+                                 ScanMatch((10, 13), Tree('expr', []))])
+
+        self.assertEqual(1, finds[0].value.meta.start_pos)
+        self.assertEqual(4, finds[0].value.meta.end_pos)
+        self.assertEqual(1, finds[0].value.meta.line)
+        self.assertEqual(1, finds[0].value.meta.end_line)
+        self.assertEqual(2, finds[0].value.meta.column)
+        self.assertEqual(5, finds[0].value.meta.end_column)
+
+        self.assertEqual(5, finds[1].value.meta.start_pos)
+        self.assertEqual(8, finds[1].value.meta.end_pos)
+        self.assertEqual(2, finds[1].value.meta.line)
+        self.assertEqual(2, finds[1].value.meta.end_line)
+        self.assertEqual(1, finds[1].value.meta.column)
+        self.assertEqual(4, finds[1].value.meta.end_column)
+
+        self.assertEqual(10, finds[2].value.meta.start_pos)
+        self.assertEqual(13, finds[2].value.meta.end_pos)
+        self.assertEqual(3, finds[2].value.meta.line)
+        self.assertEqual(4, finds[2].value.meta.end_line)
+        self.assertEqual(2, finds[2].value.meta.column)
+        self.assertEqual(2, finds[2].value.meta.end_column)
+
+    def test_scan_backtrack(self):
+        """Tests that scan() returns the longest valid prefix when intermediate
+        states also accept end-of-input."""
+
+        parser = Lark(r"""
+        start: expr+
+        expr: "(" (WORD|expr)* ")"
+        %ignore /\s+/
+        WORD: /\w+/
+        """, parser='lalr', start="start")
+
+        text = "(a)(b) || (c)(d(e) || (f)"
+        finds = list(parser.scan(text))
+        self.assertEqual(finds, [
+            ScanMatch((0, 6), Tree('start', [Tree('expr', ['a']), Tree('expr', ['b'])])),
+            ScanMatch((10, 13), Tree('start', [Tree('expr', ['c'])])),
+            ScanMatch((15, 18), Tree('start', [Tree('expr', ['e'])])),
+            ScanMatch((22, 25), Tree('start', [Tree('expr', ['f'])])),
+        ])
+
+    def test_scan_subset(self):
+        parser = Lark(r"""
+        expr: "(" (WORD|expr)* ")"
+        %ignore /\s+/
+        WORD: /\w+/
+        """, parser='lalr', start="expr", propagate_positions=True)
+
+        text = "()\n()(a)\n(b)\n (\n) | \n(\n)"
+        finds = list(parser.scan(TextSlice(text, 5, -1)))
+        self.assertEqual(finds, [ScanMatch((5, 8), Tree('expr', ['a'])),
+                                 ScanMatch((9, 12), Tree('expr', ['b'])),
+                                 ScanMatch((14, 17), Tree('expr', []))])
+        self.assertEqual(2, finds[0].value.meta.line)
+
+        text = "()\n()(a)\n(b)\n (\n) | \n(\n)"
+        finds = list(parser.scan(TextSlice(text, 5 - len(text), -1 + len(text))))
+        self.assertEqual(finds, [ScanMatch((5, 8), Tree('expr', ['a'])),
+                                 ScanMatch((9, 12), Tree('expr', ['b'])),
+                                 ScanMatch((14, 17), Tree('expr', []))])
+        self.assertEqual(2, finds[0].value.meta.line)
+
+    def test_scan_requires_lalr(self):
+        parser = Lark(r"""
+        expr: "(" WORD ")"
+        WORD: /\w+/
+        """, parser='earley', start="expr")
+        with self.assertRaises(ConfigurationError):
+            list(parser.scan("(a)"))
+
+    def test_scan_contextual(self):
+        "Ensure a contextual scan works, where a basic scan would fail."
+
+        grammar = r"""
+        stmt: "let" NAME "=" NUMBER
+        NAME: /\w+/
+        NUMBER: /\d+/
+        %ignore /\s+/
+        """
+        # In "let let = 5" the second `let` must lex as NAME, not the keyword.
+        text = "garbage let let = 5 more"
+
+        parser_ctx = Lark(grammar, parser='lalr', start='stmt')  # contextual (default)
+        ctx_matches = list(parser_ctx.scan(text))
+        self.assertEqual(len(ctx_matches), 1)
+        self.assertEqual(ctx_matches[0].range, (8, 19))
+        self.assertEqual(ctx_matches[0].value.children[0].value, 'let')
+
+        # Sanity check: with the basic lexer the same input doesn't match
+        parser_basic = Lark(grammar, parser='lalr', start='stmt', lexer='basic')
+        self.assertEqual(list(parser_basic.scan(text)), [])
+
+    def test_scan_lexer_callback_exception_skips_candidate(self):
+        # A lexer-callback signalling an invalid token via ValueError must not
+        # abort scan() — it should advance past the failing position and keep
+        # searching for valid matches.
+        def cb(t):
+            if t.value == "bad":
+                raise ValueError("user-callback boom")
+            return t
+
+        # Closed token vocabulary so scan can't find partial matches inside "bad".
+        parser = Lark(r"""
+        start: WORD+
+        WORD: "bad" | "ok" | "good" | "pretty"
+        %ignore /\s+/
+        """, parser='lalr', lexer_callbacks={'WORD': cb})
+
+        results = list(parser.scan("bad ok bad pretty good"))
+        results2 = list(parser.scan("bad ok bad pretty good bad"))
+        assert results == results2
+        ranges = [m.range for m in results]
+        values = [' '.join(c.value for c in m.value.children) for m in results]
+        self.assertEqual(ranges, [(4, 6), (11, 22)])
+        self.assertEqual(values, ["ok", "pretty good"])
+
+    def test_scan_callback_dropping_positions_raises_clear_error(self):
+        # If a user lexer_callback returns a fresh Token without copying source
+        # positions, scan() should raise a clear LexError pointing at the cause
+        # — not crash deep inside Scanner.search with an opaque TypeError.
+        def cb(t):
+            return Token(t.type, t.value.upper())  # drops positions
+
+        parser = Lark(r"""
+        start: WORD
+        WORD: /\w+/
+        """, parser='lalr', lexer_callbacks={'WORD': cb})
+
+        with self.assertRaises(LexError) as cm:
+            list(parser.scan("hello"))
+        self.assertIn("did not preserve token positions", str(cm.exception))
+
+    def test_scan_propagates_non_valueerror_callback_exception(self):
+        # Non-ValueError exceptions from user callbacks are programming errors
+        # and must surface — only ValueError is treated as "invalid token".
+        def cb(t):
+            raise RuntimeError("not a token-validity signal")
+
+        parser = Lark(r"""
+        start: WORD
+        WORD: /\w+/
+        """, parser='lalr', lexer_callbacks={'WORD': cb})
+
+        with self.assertRaises(RuntimeError):
+            list(parser.scan("hi"))
+
+    def test_scan_returns_transformer_value(self):
+        # ScanMatch.value is documented as "Tree, or whatever the transformer returns".
+        class T(Transformer):
+            def start(self, children):
+                return sum(int(c) for c in children)
+
+        parser = Lark(r"""
+        start: NUMBER+
+        NUMBER: /\d+/
+        %ignore /\s+/
+        """, parser='lalr', transformer=T())
+
+        match, = parser.scan("1 2 3")
+        self.assertEqual(match.range, (0, 5))
+        self.assertEqual(match.value, 6)
+
+    def test_scan_allows_non_deepcopyable_transformer(self):
+        # scan() defers user callbacks to a single replay pass, so transformer values
+        # that disable deepcopy still work — same constraint as parse().
+        class NoCopy:
+            def __init__(self, v): self.v = v
+            def __deepcopy__(self, memo): raise TypeError("not deepcopyable")
+            def __eq__(self, other): return isinstance(other, NoCopy) and self.v == other.v
+            def __hash__(self): return hash(self.v)
+
+        class T(Transformer):
+            def A(self, t): return NoCopy(t.value)
+
+        parser = Lark(r"""
+        start: A+
+        A: "a"
+        """, parser='lalr', transformer=T())
+
+        results = list(parser.scan("aa"))
+        self.assertEqual(len(results), 1)
+        match = results[0]
+        self.assertEqual(match.range, (0, 2))
+        self.assertEqual(match.value.children, [NoCopy("a"), NoCopy("a")])
+
+    def test_scan_rejects_postlex(self):
+        class MyIndenter(Indenter):
+            NL_type = '_NL'
+            OPEN_PAREN_types = []
+            CLOSE_PAREN_types = []
+            INDENT_type = '_INDENT'
+            DEDENT_type = '_DEDENT'
+            tab_len = 4
+
+        parser = Lark(r"""
+        start: NAME _NL+
+        NAME: /\w+/
+        _NL: /(\r?\n)+/
+        %declare _INDENT _DEDENT
+        """, parser='lalr', postlex=MyIndenter())
+        # parse() should still work
+        parser.parse("hi\n")
+        # scan() must reject postlex with a clear ConfigurationError, not AttributeError.
+        with self.assertRaises(ConfigurationError) as cm:
+            list(parser.scan("hi\n"))
+        self.assertIn("postlex", str(cm.exception).lower())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -21,6 +21,45 @@ class TestScan(unittest.TestCase):
                                     ScanMatch((21, 30), Tree('expr', ['c', Tree('expr', [Tree('expr', ['d'])])])),
                                     ])
 
+    def test_scan_no_matches(self):
+        # Empty, whitespace-only, and all-garbage input yield no matches.
+        parser = Lark(r"""
+        expr: "(" WORD ")"
+        WORD: /\w+/
+        %ignore /\s+/
+        """, parser='lalr', start='expr')
+        for text in ("", "   ", "no parens here"):
+            self.assertEqual(list(parser.scan(text)), [])
+
+    def test_scan_nullable_start(self):
+        # A nullable start rule (the empty string is itself a valid parse) must not emit
+        # zero-length matches, and a grammar with no non-ignored terminal must terminate
+        # cleanly rather than spin.
+        parser = Lark(r"""
+        start: A*
+        A: "a"
+        %ignore /\s+/
+        """, parser='lalr')
+        finds = list(parser.scan("a b a"))
+        self.assertEqual([m.range for m in finds], [(0, 1), (4, 5)])
+        self.assertTrue(all(end > start for start, end in (m.range for m in finds)))
+
+        # Purely nullable: nothing to search for, so no matches (and no infinite loop).
+        parser = Lark("start: empty\nempty:\n%ignore /\\s+/", parser='lalr')
+        self.assertEqual(list(parser.scan("a b a")), [])
+
+    def test_scan_matches_parse_under_tree_options(self):
+        # scan() builds the tree via a separate replay path; check it matches parse().
+        grammar = r"""
+        start: "(" WORD? ")"
+        WORD: /\w+/
+        """
+        for opts in (dict(keep_all_tokens=True), dict(maybe_placeholders=True)):
+            parser = Lark(grammar, parser='lalr', start='start', **opts)
+            for text in ("(a)", "()"):
+                match, = parser.scan(text)
+                self.assertEqual(match.value, parser.parse(text))
+
     def test_scan_meta(self):
         parser = Lark(r"""
         expr: "(" (WORD|expr)* ")"
@@ -73,6 +112,22 @@ class TestScan(unittest.TestCase):
             ScanMatch((10, 13), Tree('start', [Tree('expr', ['c'])])),
             ScanMatch((15, 18), Tree('start', [Tree('expr', ['e'])])),
             ScanMatch((22, 25), Tree('start', [Tree('expr', ['f'])])),
+        ])
+
+    def test_scan_adjacent(self):
+        # Matches that abut with no gap: the resume (pos = last.end_pos) must re-find a
+        # match starting at the exact end offset of the previous one. No %ignore, and each
+        # match is a single expr (not expr+), so the three "(x)" don't collapse into one.
+        parser = Lark(r"""
+        expr: "(" WORD ")"
+        WORD: /\w+/
+        """, parser='lalr', start="expr")
+
+        finds = list(parser.scan("(a)(b)(c)"))
+        self.assertEqual(finds, [
+            ScanMatch((0, 3), Tree('expr', ['a'])),
+            ScanMatch((3, 6), Tree('expr', ['b'])),
+            ScanMatch((6, 9), Tree('expr', ['c'])),
         ])
 
     def test_scan_start_inside_ignored_regex_span(self):
@@ -166,6 +221,22 @@ class TestScan(unittest.TestCase):
         # Sanity check: with the basic lexer the same input doesn't match
         parser_basic = Lark(grammar, parser='lalr', start='stmt', lexer='basic')
         self.assertEqual(list(parser_basic.scan(text)), [])
+
+    def test_scan_keyword_unless(self):
+        # Keyword terminals are folded into NAME by _create_unless and dropped from the
+        # regular scanner; search_start uses a scanner that keeps them. scan() must still
+        # find keyword-led matches and tag them as parse() would.
+        parser = Lark(r"""
+        start: TRUE | NAME
+        TRUE: "true"
+        NAME: /[a-z]+/
+        %ignore /\s+/
+        """, parser='lalr', start='start', lexer='basic')
+
+        finds = list(parser.scan("xx true truly yy"))
+        self.assertEqual([m.range for m in finds], [(0, 2), (3, 7), (8, 13), (14, 16)])
+        self.assertEqual([m.value.children[0].type for m in finds],
+                         ['NAME', 'TRUE', 'NAME', 'NAME'])
 
     def test_scan_lexer_callback_exception_skips_candidate(self):
         # A lexer-callback signalling an invalid token via ValueError must not
@@ -291,6 +362,39 @@ class TestScan(unittest.TestCase):
         match = results[0]
         self.assertEqual(match.range, (0, 2))
         self.assertEqual(match.value.children, [NoCopy("a"), NoCopy("a")])
+
+    def test_scan_bytes(self):
+        # scan() must work on bytes input, yielding byte-offset ranges and bytes-valued tokens.
+        parser = Lark(r"""
+        expr: "(" (WORD|expr)* ")"
+        %ignore / +/
+        WORD: /\w+/
+        """, parser='lalr', start="expr", use_bytes=True)
+
+        finds = list(parser.scan(b"|() | (a) | ((x)) |"))
+        self.assertEqual(finds, [
+            ScanMatch((1, 3), Tree('expr', [])),
+            ScanMatch((6, 9), Tree('expr', [Token('WORD', b'a')])),
+            ScanMatch((12, 17), Tree('expr', [Tree('expr', [Token('WORD', b'x')])])),
+        ])
+
+    def test_scan_multiple_start(self):
+        # With multiple start symbols, scan() requires an explicit start, and an
+        # explicit start scopes the scan to that rule only.
+        parser = Lark(r"""
+        a: "(" WORD ")"
+        b: "[" WORD "]"
+        WORD: /\w+/
+        %ignore /\s+/
+        """, parser='lalr', start=["a", "b"])
+
+        with self.assertRaises(ConfigurationError):
+            list(parser.scan("(x) [y]"))
+
+        self.assertEqual(list(parser.scan("(x) [y]", start="a")),
+                         [ScanMatch((0, 3), Tree('a', ['x']))])
+        self.assertEqual(list(parser.scan("(x) [y]", start="b")),
+                         [ScanMatch((4, 7), Tree('b', ['y']))])
 
     def test_scan_rejects_postlex(self):
         class MyIndenter(Indenter):

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -75,6 +75,28 @@ class TestScan(unittest.TestCase):
             ScanMatch((22, 25), Tree('start', [Tree('expr', ['f'])])),
         ])
 
+    def test_scan_start_inside_ignored_regex_span(self):
+        # search_start() should search real start terminals directly, not skip over
+        # the full extent of an ignore regex that happens to contain one.
+        parser = Lark(r"""
+        start: "a"
+        %ignore /x+a/
+        """, parser='lalr')
+
+        self.assertEqual([m.range for m in parser.scan("xxa a")], [(2, 3), (4, 5)])
+
+    def test_scan_range_starts_after_ignored_prefix(self):
+        # Search may find a candidate inside/under an ignore match, but the reported
+        # range should still describe the non-ignored parse result.
+        parser = Lark(r"""
+        start: A? C
+        A: "a"
+        C: "c"
+        %ignore /ab/
+        """, parser='lalr')
+
+        self.assertEqual([m.range for m in parser.scan("abc")], [(2, 3)])
+
     def test_scan_subset(self):
         parser = Lark(r"""
         expr: "(" (WORD|expr)* ")"

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -104,6 +104,25 @@ class TestScan(unittest.TestCase):
         with self.assertRaises(ConfigurationError):
             list(parser.scan("(a)"))
 
+    def test_scan_rejects_lexer_only(self):
+        # A lexer-only Lark (parser=None) has no .parser; scan() must raise a clear
+        # ConfigurationError, not leak an AttributeError.
+        parser = Lark(r"""
+        start: WORD
+        WORD: /\w+/
+        """, parser=None, lexer='basic')
+        with self.assertRaises(ConfigurationError):
+            list(parser.scan("a b c"))
+
+    def test_scan_validates_eagerly(self):
+        # scan() validates its configuration on the call itself, not lazily on first iteration.
+        parser = Lark(r"""
+        expr: "(" WORD ")"
+        WORD: /\w+/
+        """, parser='earley', start="expr")
+        with self.assertRaises(ConfigurationError):
+            parser.scan("(a)")  # not iterated — must still raise
+
     def test_scan_contextual(self):
         "Ensure a contextual scan works, where a basic scan would fail."
 
@@ -166,6 +185,24 @@ class TestScan(unittest.TestCase):
             list(parser.scan("hello"))
         self.assertIn("did not preserve token positions", str(cm.exception))
 
+    def test_scan_callback_dropping_positions_on_earlier_token_raises_clear_error(self):
+        # The final token is enough to compute ScanMatch.range, but earlier tokens
+        # still need positions for propagate_positions metadata.
+        def cb(t):
+            if t.value == "a":
+                return Token(t.type, t.value)  # drops positions
+            return t
+
+        parser = Lark(r"""
+        start: WORD WORD
+        WORD: /[ab]/
+        %ignore / +/
+        """, parser='lalr', lexer_callbacks={'WORD': cb}, propagate_positions=True)
+
+        with self.assertRaises(LexError) as cm:
+            list(parser.scan("a b"))
+        self.assertIn("did not preserve token positions", str(cm.exception))
+
     def test_scan_propagates_non_valueerror_callback_exception(self):
         # Non-ValueError exceptions from user callbacks are programming errors
         # and must surface — only ValueError is treated as "invalid token".
@@ -179,6 +216,20 @@ class TestScan(unittest.TestCase):
 
         with self.assertRaises(RuntimeError):
             list(parser.scan("hi"))
+
+    def test_scan_does_not_swallow_configuration_error(self):
+        # ConfigurationError subclasses ValueError, which scan() catches to skip a failed
+        # lex. It must still propagate rather than being silently treated as "no match".
+        def cb(t):
+            raise ConfigurationError("boom")
+
+        parser = Lark(r"""
+        start: WORD
+        WORD: /\w+/
+        """, parser='lalr', lexer_callbacks={'WORD': cb})
+
+        with self.assertRaises(ConfigurationError):
+            list(parser.scan("hello"))
 
     def test_scan_returns_transformer_value(self):
         # ScanMatch.value is documented as "Tree, or whatever the transformer returns".

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -1,9 +1,8 @@
 import unittest
 
-from lark import Lark, TextSlice, Token, Transformer, Tree
+from lark import Lark, TextSlice, Token, Transformer, Tree, ScanMatch
 from lark.exceptions import ConfigurationError, LexError
 from lark.indenter import Indenter
-from lark.parser_frontends import ScanMatch
 
 
 class TestScan(unittest.TestCase):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -91,6 +91,12 @@ class TestStandalone(TestCase):
         res = ip_copy.feed_eof()
         self.assertEqual(res, Tree('start', ['a', 'b', 'b']))
 
+    def test_scan(self):
+        context = self._create_standalone('start: "a"+')
+        parser = context['Lark_StandAlone']()
+
+        self.assertEqual([m.range for m in parser.scan('xxaa yy a')], [(2, 4), (8, 9)])
+
     def test_contextual(self):
         grammar = """
         start: a b

--- a/tests/test_trees.py
+++ b/tests/test_trees.py
@@ -38,6 +38,15 @@ class TestTrees(TestCase):
         data = pickle.dumps(s, protocol=pickle.HIGHEST_PROTOCOL)
         assert pickle.loads(data) == s
 
+    def test_token_deepcopy_and_pickle_preserve_positions(self):
+        # Token.__eq__ ignores positions, so a copy that drops end_line/end_column/end_pos
+        # would still compare equal. Assert the positions survive deepcopy and pickling.
+        t = Token('A', 'abc', start_pos=10, line=1, column=3, end_line=2, end_column=6, end_pos=13)
+        copies = [copy.deepcopy(t), pickle.loads(pickle.dumps(t, protocol=pickle.HIGHEST_PROTOCOL))]
+        for t2 in copies:
+            self.assertEqual((t2.start_pos, t2.line, t2.column), (10, 1, 3))
+            self.assertEqual((t2.end_line, t2.end_column, t2.end_pos), (2, 6, 13))
+
     def test_repr_runnable(self):
         assert self.tree1 == eval(repr(self.tree1))
 

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -3,7 +3,10 @@
 This file is never executed — it is checked by mypy only.
 Wrong type annotations here will cause a mypy error.
 """
+from typing import Iterable, Tuple
+
 from lark import Lark, Token, ParseTree, Transformer
+from lark.parser_frontends import ScanMatch
 
 
 class _ToInt(Transformer[Token, int]):
@@ -39,3 +42,18 @@ _r6: int = _p6.parse("42")
 
 # untyped transformer
 _p7: Lark[int] = Lark(r'start: /\d+/', parser='lalr', transformer=_Untyped())
+
+
+# scan() preserves the generic type:
+# Lark[T].scan(...) -> Iterable[ScanMatch[T]]
+_s1: Iterable[ScanMatch[ParseTree]] = _p1.scan("42")
+_s2: Iterable[ScanMatch[int]]       = _p2.scan("42")
+
+# Iterating yields ScanMatch[T] whose .range is (int, int) and .value is T
+for _m1 in _p1.scan("42"):
+    _m1_range: Tuple[int, int] = _m1.range
+    _m1_value: ParseTree       = _m1.value
+
+for _m2 in _p2.scan("42"):
+    _m2_range: Tuple[int, int] = _m2.range
+    _m2_value: int             = _m2.value

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -5,8 +5,7 @@ Wrong type annotations here will cause a mypy error.
 """
 from typing import Iterable, Tuple
 
-from lark import Lark, Token, ParseTree, Transformer
-from lark.parser_frontends import ScanMatch
+from lark import Lark, Token, ParseTree, Transformer, ScanMatch
 
 
 class _ToInt(Transformer[Token, int]):


### PR DESCRIPTION
It finds and parses each non-overlapping match, yielding the longest possible match.

Reimplementation of the long-standing #1429 PR by @MegaIng  on top of the merged TextSlice support, with some modifications.

Works in 2 steps. First parses without callbacks, for cheap cloning. Then finally replays the chosen match with user callbacks.