### PR TITLE
fix(grammar): drop unit self-loop rules to prevent LALR/CYK infinite loop

### DIFF
--- a/lark/load_grammar.py
+++ b/lark/load_grammar.py
@@ -766,6 +766,9 @@ class Grammar(Serialize):
                 else:
                     exp_options = options
 
+                if len(expansion) == 1 and expansion[0] == NonTerminal(name):
+                    continue
+
                 for sym in expansion:
                     assert isinstance(sym, Symbol)
                     if sym.is_term and exp_options and exp_options.keep_all_tokens:

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -302,6 +302,11 @@ class TestGrammar(TestCase):
 
         self.assertNotEqual(a, b)
 
+    def test_issue_1585_cyk(self):
+        l = Lark('start.1: "a" | start start*', parser='cyk')
+        for s in ('aa', 'aaaa'):
+            self.assertEqual(l.parse(s).data, 'start')
+
 
 if __name__ == '__main__':
     main()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -72,11 +72,15 @@ class TestParsers(unittest.TestCase):
                a: a | "a"
             """
 
-        self.assertRaises(GrammarError, Lark, g, parser='lalr')
+        for parser in ('lalr', 'earley'):
+            l = Lark(g, parser=parser)
+            tree = l.parse('a')
+            self.assertEqual(tree, Tree('start', [Tree('a', [])]))
 
-        # TODO: should it? shouldn't it?
-        # l = Lark(g, parser='earley', lexer='dynamic')
-        # self.assertRaises(ParseError, l.parse, 'a')
+        g = """start: a
+               a: a
+            """
+        self.assertRaises(GrammarError, Lark, g, parser='lalr')
 
     def test_propagate_positions(self):
         g = Lark("""start: a
@@ -2255,6 +2259,11 @@ def _make_parser_test(LEXER, PARSER):
             res = l.parse('abba')
             self.assertEqual(''.join(child.data for child in res.children), 'indirection')
 
+
+        def test_issue_1585_priority_recursive_star(self):
+            l = _Lark('start.1: "a" | start start*')
+            for s in ('a', 'aa', 'aaaa'):
+                self.assertEqual(l.parse(s).data, 'start')
 
         def test_utf8(self):
             g = u"""start: a


### PR DESCRIPTION
Fixes #1585.

## Summary

`Lark('start.1: \"a\" | start start*', parser='lalr').parse('aa')` (and the same with `parser='cyk'`) hangs in an infinite loop. EBNF expansion of `X*` inside an `X` rule produces a bare `X : X` alternative once the empty branch is folded in. That rule never consumes input — when LALR's priority-based conflict resolution selects it, the reduce/shift loop spins forever; CYK's unit-rule elimination loops for the same reason. Without the priority annotation the same grammar surfaces as a `Reduce/Reduce GrammarError` instead.

This PR filters such non-progressing self-references at rule construction so no backend ever sees them.

## Reproduction / verification

Reproduced and verified fixed via [vivarium](https://aletheia-works.github.io/vivarium/repro/lark/1585/).

## Test plan

- [x] New regression test `test_issue_1585_priority_recursive_star` (Earley + LALR matrix in `test_parser.py`)
- [x] New regression test `test_issue_1585_cyk` in `test_grammar.py`
- [x] Existing `test_alias_in_terminal` updated: `a: a | \"a\"` now parses cleanly under `lalr` and `earley` instead of raising `GrammarError`; the pure non-progressing case `a: a` is preserved as the `GrammarError` example.

<details>
<summary>Implementation notes</summary>

The single-line fix lives in `lark/load_grammar.py` inside `_compile_rule` (around the expansion loop):

```python
if len(expansion) == 1 and expansion[0] == NonTerminal(name):
    continue
```

We skip the alternative entirely rather than try to rewrite it, because such an alternative is semantically equivalent to \"match nothing extra and recurse,\" which contributes no language. Dropping it preserves all other alternatives, including the recursive cases produced by `X*` once the empty branch is removed.

Why this surfaces only for LALR and CYK:

- **LALR**: with `start.1`, priority-based conflict resolution picks the unit self-rule on shift/reduce ambiguity and the parser loops. Without the priority, the conflict is unresolved and the grammar is rejected at construction time (the old `GrammarError`).
- **CYK**: the unit-production elimination pass treats `X → X` as a self-edge and never terminates.
- **Earley** happens to tolerate it because its chart bookkeeping deduplicates items, so the issue was previously masked there.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)