### PR TITLE
Make recursive cache grammar raw

### DIFF
--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -150,7 +150,7 @@ class TestCache(TestCase):
 
     @skipIf(regex is None, "'regex' lib not installed")
     def test_recursive_pattern(self):
-        g = """
+        g = r"""
         start: recursive+
         recursive: /\w{3}\d{3}(?R)?/
         """


### PR DESCRIPTION
### Summary

Mark the recursive-pattern grammar in `tests/test_cache.py` as a raw triple-quoted string.

Python 3.14 warns about the `\w` and `\d` escapes in that test grammar before Lark sees the text. The grammar itself is intended to pass those backslashes through to Lark, so using a raw string removes the warning without changing the grammar content.

Fixes #1564.

### Validation

Not run locally.

Static validation run:

- `git diff --check HEAD~1..HEAD`

I opened this as a draft so the repository's GitHub Actions matrix can provide remote validation.