### PR TITLE
fix: raise GrammarError for template usage inside terminals

### DIFF
--- a/lark/load_grammar.py
+++ b/lark/load_grammar.py
@@ -704,6 +704,8 @@ class Grammar(Serialize):
         for name, (term_tree, priority) in term_defs:
             if term_tree is None:  # Terminal added through %declare
                 continue
+            if next(term_tree.find_data('template_usage'), None) is not None:
+                raise GrammarError("Templates cannot be used inside terminals (%s)" % name)
             expansions = list(term_tree.find_data('expansion'))
             if len(expansions) == 1 and not expansions[0].children:
                 raise GrammarError("Terminals cannot be empty (%s)" % name)

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -125,6 +125,13 @@ class TestGrammar(TestCase):
             """
         self.assertRaises( GrammarError, Lark, g)
 
+    def test_template_in_terminal(self):
+        g = """start: TERM
+            TERM: _quoted{"'"}
+            _quoted{q}: q /.*?/ q
+            """
+        self.assertRaises(GrammarError, Lark, g)
+
     def test_undefined_rule(self):
         self.assertRaises(GrammarError, Lark, """start: a""")
 


### PR DESCRIPTION
Using a template inside a terminal definition currently crashes with an internal `AssertionError` instead of a clear error.

```
STRCONST_SQ: _string{"'"}
_string{quot}: quot /.*?/s quot
```

raises:

```
AssertionError: Tree('template_usage', [NonTerminal('_string'), "'"])
```

Terminal templates are not supported (see the `# TODO terminal templates` note in load_grammar.py). This detects a `template_usage` node while compiling terminals and raises a `GrammarError` with the offending terminal name, matching how other invalid terminal constructs are reported.

Fixes #1382.

Added a regression test in tests/test_grammar.py.