### PR TITLE
Raise GrammarError for non-terminal names in %declare

### DIFF
--- a/lark/load_grammar.py
+++ b/lark/load_grammar.py
@@ -1274,6 +1274,8 @@ class GrammarBuilder:
                 for symbol in stmt.children:
                     assert isinstance(symbol, Symbol), symbol
                     is_term = isinstance(symbol, Terminal)
+                    if not is_term:
+                        raise GrammarError("Expecting terminal name to follow %%declare, but got rule name %r" % symbol.name)
                     if mangle is None:
                         name = symbol.name
                     else:

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -138,6 +138,12 @@ class TestGrammar(TestCase):
     def test_undefined_term(self):
         self.assertRaises(GrammarError, Lark, """start: A""")
 
+    def test_declare_rule_name(self):
+        # %declare is for terminals only; a rule (lowercase) name used to crash
+        # the compiler with AttributeError instead of a clean GrammarError.
+        self.assertRaises(GrammarError, Lark, """start: "a"\n%declare foo""")
+        self.assertRaises(GrammarError, Lark, """start: "a"\n%declare FOO bar""")
+
     def test_token_multiline_only_works_with_x_flag(self):
         g = r"""start: ABC
                 ABC: /  a      b c


### PR DESCRIPTION
`%declare` is meant for terminals, but the grammar accepts any symbol, so a lowercase (rule) name slips through and crashes the compiler:

```python
from lark import Lark
Lark('%declare foo')
# AttributeError: 'NoneType' object has no attribute 'iter_subtrees'
```

A declared rule name gets defined as an abstract rule with no tree (only declared *terminals* are handled that way), and the transform step later calls `iter_subtrees()` on the missing tree. All-uppercase `%declare X Y` is fine; it's only non-terminal names that hit this.

This rejects non-terminal names in `%declare` with a clear `GrammarError` instead of crashing. Added a regression test next to the existing `test_undefined_*` cases.
