### PR TITLE
Documentation tweaks to address Sphinx build errors and warnings

### DIFF
--- a/lark/lark.py
+++ b/lark/lark.py
@@ -89,8 +89,8 @@ class LarkOptions(Serialize):
             Applies the transformer to every parse tree (equivalent to applying it after the parse, but faster)
     propagate_positions
             Propagates positional attributes into the 'meta' attribute of all tree branches.
-            Sets attributes: (line, column, end_line, end_column, start_pos, end_pos,
-                              container_line, container_column, container_end_line, container_end_column)
+            Sets attributes: line, column, end_line, end_column, start_pos, end_pos,
+            container_line, container_column, container_end_line, container_end_column
             Accepts ``False``, ``True``, or a callable, which will filter which nodes to ignore when propagating.
     maybe_placeholders
             When ``True``, the ``[]`` operator returns ``None`` when not matched.
@@ -154,6 +154,7 @@ class LarkOptions(Serialize):
             A List of either paths or loader functions to specify from where grammars are imported
     source_path
             Override the source of from where the grammar was loaded. Useful for relative imports and unconventional grammar loading
+
     **=== End of Options ===**
     """
     if __doc__:

--- a/lark/tree.py
+++ b/lark/tree.py
@@ -45,8 +45,8 @@ class Tree(Generic[_Leaf_T]):
         data: The name of the rule or alias
         children: List of matched sub-rules and terminals
         meta: Line & Column numbers (if ``propagate_positions`` is enabled).
-            meta attributes: (line, column, end_line, end_column, start_pos, end_pos,
-                              container_line, container_column, container_end_line, container_end_column)
+            Attributes: line, column, end_line, end_column, start_pos, end_pos,
+            container_line, container_column, container_end_line, container_end_column.
             container_* attributes consider all symbols, including those that have been inlined in the tree.
             For example, in the rule 'a: _A B _C', the regular attributes will mark the start and end of B,
             but the container_* attributes will also include _A and _C in the range. However, rules that


### PR DESCRIPTION
I see this when I build the docs locally using `make html`:

```
.../lark/lark.py:docstring of lark.lark.Lark:29: ERROR: Unexpected indentation.
.../lark/lark.py:docstring of lark.lark.Lark:30: WARNING: Block quote ends without a blank line; unexpected unindent.
.../lark/lark.py:docstring of lark.lark.Lark:93: WARNING: Definition list ends without a blank line; unexpected unindent.
.../lark/tree.py:docstring of lark.tree.Tree:10: ERROR: Unexpected indentation.
.../lark/tree.py:docstring of lark.tree.Tree:11: WARNING: Block quote ends without a blank line; unexpected unindent.
```

This PR address all of these errors and warnings.

I'm running Sphinx 7.3.7.