### PR TITLE
Show Indenter property docs + add working links

### DIFF
--- a/docs/classes.rst
+++ b/docs/classes.rst
@@ -95,6 +95,7 @@ Indenter
 --------
 
 .. autoclass:: lark.indenter.Indenter
+   :members: NL_type, OPEN_PAREN_types, CLOSE_PAREN_types, INDENT_type, DEDENT_type, tab_len
 .. autoclass:: lark.indenter.PythonIndenter
 
 TextSlice

--- a/examples/indented_tree.py
+++ b/examples/indented_tree.py
@@ -3,7 +3,7 @@ Parsing Indentation
 ===================
 
 A demonstration of parsing indentation (“whitespace significant” language)
-and the usage of the ``Indenter`` class.
+and the usage of :class:`lark.indenter.Indenter`.
 
 Since indentation is context-sensitive, a postlex stage is introduced to
 manufacture ``INDENT``/``DEDENT`` tokens.

--- a/lark/indenter.py
+++ b/lark/indenter.py
@@ -18,13 +18,9 @@ class Indenter(PostLex, ABC):
     It keeps track of the current indentation, as well as the current level of parentheses.
     Inside parentheses, the indentation is ignored, and no indent/dedent tokens get generated.
 
-    Note: This is an abstract class. To use it, inherit and implement all its abstract methods:
-        - tab_len
-        - NL_type
-        - OPEN_PAREN_types, CLOSE_PAREN_types
-        - INDENT_type, DEDENT_type
+    Note: This is an abstract class. To use it, inherit and implement all its abstract properties.
 
-    See also: the ``postlex`` option in `Lark`.
+    See also: the ``postlex`` option in :class:`lark.Lark`, and the :doc:`/examples/indented_tree` example.
     """
     paren_level: int
     indent_level: List[int]
@@ -108,7 +104,7 @@ class Indenter(PostLex, ABC):
     def INDENT_type(self) -> str:
         """The name of the token that starts an indentation in the grammar.
 
-        See also: %declare
+        See also: `%declare <grammar.html#declare>`_
         """
         raise NotImplementedError()
 
@@ -117,7 +113,7 @@ class Indenter(PostLex, ABC):
     def DEDENT_type(self) -> str:
         """The name of the token that end an indentation in the grammar.
 
-        See also: %declare
+        See also: `%declare <grammar.html#declare>`_
         """
         raise NotImplementedError()
 
@@ -129,9 +125,10 @@ class Indenter(PostLex, ABC):
 
 
 class PythonIndenter(Indenter):
-    """A postlexer that "injects" _INDENT/_DEDENT tokens based on indentation, according to the Python syntax.
+    """A postlexer that "injects" _INDENT/_DEDENT tokens based on indentation, according to the
+    `Python syntax <https://docs.python.org/3/reference/lexical_analysis.html#indentation>`_.
 
-    See also: the ``postlex`` option in `Lark`.
+    See also: the ``postlex`` option in :class:`lark.Lark`.
     """
 
     NL_type = '_NEWLINE'


### PR DESCRIPTION
The `Indenter` class has abstract properties that the user needs to implement. They are all documented in code, but the documentation does not show up in the built docs. This PR fixes that, and also adds several links (confirmed to be working locally) to make it easier for the reader to jump to relevant references.

[Current rendered docs.][1] Screenshot from my local build:

[1]: https://lark-parser.readthedocs.io/en/stable/classes.html#indenter

<img width="566" height="933" alt="Screenshot 2026-06-05 at 2 07 32 PM" src="https://github.com/user-attachments/assets/2c4d9525-bb2f-4b58-afd2-ad89d46fe614" />
