### PR TITLE
Preserve end_line/end_column/end_pos when copying or pickling a Token

### DIFF
--- a/lark/lexer.py
+++ b/lark/lexer.py
@@ -254,13 +254,13 @@ class Token(str):
         return cls(type_, value, borrow_t.start_pos, borrow_t.line, borrow_t.column, borrow_t.end_line, borrow_t.end_column, borrow_t.end_pos)
 
     def __reduce__(self):
-        return (self.__class__, (self.type, self.value, self.start_pos, self.line, self.column))
+        return (self.__class__, (self.type, self.value, self.start_pos, self.line, self.column, self.end_line, self.end_column, self.end_pos))
 
     def __repr__(self):
         return 'Token(%r, %r)' % (self.type, self.value)
 
     def __deepcopy__(self, memo):
-        return Token(self.type, self.value, self.start_pos, self.line, self.column)
+        return Token(self.type, self.value, self.start_pos, self.line, self.column, self.end_line, self.end_column, self.end_pos)
 
     def __eq__(self, other):
         if isinstance(other, Token) and self.type != other.type:

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -1,11 +1,25 @@
+import copy
+import pickle
 from unittest import TestCase, main
 
 from lark import Lark, Tree, TextSlice
+from lark.lexer import Token
 
 
 class TestLexer(TestCase):
     def setUp(self):
         pass
+
+    def test_token_copy_preserves_end_position(self):
+        # deepcopy/copy/pickle round-trips must keep the end_* position
+        # attributes, like new_borrow_pos does, instead of dropping them.
+        t = Token("WORD", "hello", start_pos=0, line=1, column=1,
+                  end_line=2, end_column=6, end_pos=5)
+        attrs = ("type", "value", "start_pos", "line", "column",
+                 "end_line", "end_column", "end_pos")
+        expected = [getattr(t, a) for a in attrs]
+        for copied in (copy.deepcopy(t), copy.copy(t), pickle.loads(pickle.dumps(t))):
+            self.assertEqual([getattr(copied, a) for a in attrs], expected)
 
     def test_basic(self):
         p = Lark("""


### PR DESCRIPTION
## Summary

`Token.__reduce__` (used by `copy.copy` and `pickle`) and `Token.__deepcopy__` only forward the first five positional attributes to the constructor:

```python
def __reduce__(self):
    return (self.__class__, (self.type, self.value, self.start_pos, self.line, self.column))

def __deepcopy__(self, memo):
    return Token(self.type, self.value, self.start_pos, self.line, self.column)
```

The constructor signature is `(type, value, start_pos, line, column, end_line, end_column, end_pos)`, so `end_line`, `end_column` and `end_pos` are silently reset to `None` on every `copy.copy`, `copy.deepcopy`, and `pickle` round-trip:

```python
>>> from lark.lexer import Token
>>> import copy
>>> t = Token("WORD", "hello", start_pos=0, line=1, column=1, end_line=2, end_column=6, end_pos=5)
>>> copy.deepcopy(t).end_pos
None          # expected 5
```

This is inconsistent with `Token.new_borrow_pos` (and therefore `update`), which already carries all eight attributes. These two methods predate the `end_*` attributes and were never updated to match.

## Fix

Forward the three trailing position attributes in both methods, matching `new_borrow_pos` and the constructor's positional order. Four characters of behavior change, two lines.

## Verification

- Reproduced on `master` (`c169b26`): `deepcopy`/`copy`/`pickle` reset `end_*` to `None`; with the fix all eight attributes survive.
- Added `test_token_copy_preserves_end_position` to `tests/test_lexer.py`; it fails before the fix and passes after.
- Full suite: **1107 passed, 167 skipped**, no regressions (baseline 1106 + the new test).
- `mypy lark/lexer.py` is identical before and after (no new errors).

---

This pull request was prepared with the assistance of AI, under my direction and review.
