### PR TITLE
Bugfix: call __default_token__ from an embedded transformer (Issue #1582)

### DIFF
--- a/lark/parser_frontends.py
+++ b/lark/parser_frontends.py
@@ -7,6 +7,7 @@ from .parsers import earley, xearley, cyk
 from .parsers.lalr_parser import LALR_Parser
 from .tree import Tree
 from .common import LexerConf, ParserConf, _ParserArgType, _LexerArgType
+from .visitors import Transformer
 
 if TYPE_CHECKING:
     from .parsers.lalr_analysis import ParseTableBase
@@ -153,8 +154,15 @@ def _validate_frontend_args(parser, lexer) -> None:
 
 def _get_lexer_callbacks(transformer, terminals):
     result = {}
+    # Tokens without a dedicated transformer method fall back to
+    # __default_token__, mirroring Transformer.transform(). The base
+    # implementation is a no-op, so it's only wired up when overridden,
+    # to avoid a needless call per token (see issue #1582).
+    default_token = getattr(transformer, '__default_token__', None)
+    if getattr(type(transformer), '__default_token__', None) is Transformer.__default_token__:
+        default_token = None
     for terminal in terminals:
-        callback = getattr(transformer, terminal.name, None)
+        callback = getattr(transformer, terminal.name, default_token)
         if callback is not None:
             result[terminal.name] = callback
     return result

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2770,6 +2770,34 @@ def _make_parser_test(LEXER, PARSER):
             b = parser.parse(s)
             assert a == b
 
+        @unittest.skipIf(PARSER != 'lalr', "Embedded token callbacks are only applied by the lalr parser")
+        def test_default_token_in_treeless_mode(self):
+            # Regression test for issue #1582: an embedded transformer did not
+            # call __default_token__ on tokens, unlike Transformer.transform().
+            grammar = r"""
+                start: expr
+
+                expr: A B
+                    | A expr B
+
+                A: "a"
+                B: "b"
+
+                %import common.WS
+                %ignore WS
+            """
+            s = 'a a a b b b'
+
+            class AbTransformer(Transformer):
+                def __default_token__(self, token):
+                    return token.update(value=str(token).upper())
+
+            parser = _Lark(grammar)
+            a = AbTransformer().transform(parser.parse(s))
+            parser = _Lark(grammar, transformer=AbTransformer())
+            b = parser.parse(s)
+            assert a == b
+
         @unittest.skipIf(PARSER != 'lalr', "strict mode is only supported in lalr for now")
         def test_strict(self):
             # Test regex collision


### PR DESCRIPTION
Fixes #1582.

`Transformer.__default_token__` is called for tokens without a dedicated method when running `transformer.transform(tree)`, but it was never invoked by the embedded transformer (`Lark(transformer=...)`). As confirmed by @erezsh in the issue, `__default_token__` *"was never implemented for the internal transformer"*.

`_get_lexer_callbacks` only registered a token callback when the transformer defined a method named after the terminal. It now falls back to an overridden `__default_token__` for the remaining terminals, mirroring `Transformer.transform()`. The base no-op implementation is skipped, so transformers that don't override `__default_token__` keep the existing fast path (no extra call per token), and specific token methods still take precedence.

### Example
```python
from lark import Lark, Transformer

class T(Transformer):
    def __default_token__(self, token):
        return token.update(value=token.upper())

parser = Lark("start: WORD+\n%import common.WORD\n%import common.WS\n%ignore WS",
              parser="lalr", transformer=T())
print(parser.parse("foo bar baz"))
# before: Tree('start', [Token('WORD', 'foo'), Token('WORD', 'bar'), Token('WORD', 'baz')])
# after:  Tree('start', [Token('WORD', 'FOO'), Token('WORD', 'BAR'), Token('WORD', 'BAZ')])
```

### Notes
- Added a regression test (`test_default_token_in_treeless_mode`) asserting the embedded transformer matches `transform()`.
- Scoped to the `lalr` parser, the only one that applies embedded token callbacks. The `cyk` parser does not apply embedded token callbacks at all (not even specific token methods) — a separate, pre-existing limitation.
- `python -m tests` passes (1283 tests) and `mypy` is clean.