### PR TITLE
Add template support to Reconstructor

### DIFF
--- a/lark/reconstruct.py
+++ b/lark/reconstruct.py
@@ -57,7 +57,7 @@ class WriteTokensTransformer(Transformer_InPlace):
                     else:
                         name, _args = parse_rulename(sym.name)
                         assert x.data == name, (sym, x)
-                        x.meta.original_rulename = sym.name
+                        x.meta.orig_rulename = sym.name
                     to_write.append(x)
 
         assert is_iter_empty(iter_args)
@@ -84,13 +84,13 @@ class Reconstructor(TreeMatcher):
 
         self.write_tokens = WriteTokensTransformer({t.name:t for t in self.tokens}, term_subs or {})
 
-    def _reconstruct(self, tree, original_rulename=None):
-        unreduced_tree = self.match_tree(tree, original_rulename or tree.data)
+    def _reconstruct(self, tree, orig_rulename=None):
+        unreduced_tree = self.match_tree(tree, orig_rulename or tree.data)
 
         res = self.write_tokens.transform(unreduced_tree)
         for item in res:
             if isinstance(item, Tree):
-                child_rulename = getattr(item.meta, "original_rulename", None)
+                child_rulename = getattr(item.meta, "orig_rulename", None)
                 yield from self._reconstruct(item, child_rulename)
             else:
                 yield item

--- a/lark/reconstruct.py
+++ b/lark/reconstruct.py
@@ -7,9 +7,9 @@ from .lark import Lark
 from .tree import Tree, ParseTree
 from .visitors import Transformer_InPlace
 from .lexer import Token, PatternStr, TerminalDef
-from .grammar import Terminal, NonTerminal, Symbol
+from .grammar import Terminal, Symbol
 
-from .tree_matcher import TreeMatcher, is_discarded_terminal
+from .tree_matcher import TreeMatcher, is_discarded_terminal, parse_rulename
 from .utils import is_id_continue
 
 def is_iter_empty(i):
@@ -55,7 +55,9 @@ class WriteTokensTransformer(Transformer_InPlace):
                     if isinstance(x, Token):
                         assert Terminal(x.type) == sym, x
                     else:
-                        assert NonTerminal(x.data) == sym, (sym, x)
+                        name, _args = parse_rulename(sym.name)
+                        assert x.data == name, (sym, x)
+                        x.meta.original_rulename = sym.name
                     to_write.append(x)
 
         assert is_iter_empty(iter_args)
@@ -82,14 +84,14 @@ class Reconstructor(TreeMatcher):
 
         self.write_tokens = WriteTokensTransformer({t.name:t for t in self.tokens}, term_subs or {})
 
-    def _reconstruct(self, tree):
-        unreduced_tree = self.match_tree(tree, tree.data)
+    def _reconstruct(self, tree, original_rulename=None):
+        unreduced_tree = self.match_tree(tree, original_rulename or tree.data)
 
         res = self.write_tokens.transform(unreduced_tree)
         for item in res:
             if isinstance(item, Tree):
-                # TODO use orig_expansion.rulename to support templates
-                yield from self._reconstruct(item)
+                child_rulename = getattr(item.meta, "original_rulename", None)
+                yield from self._reconstruct(item, child_rulename)
             else:
                 yield item
 

--- a/tests/test_reconstructor.py
+++ b/tests/test_reconstructor.py
@@ -101,6 +101,20 @@ class TestReconstructor(TestCase):
         for c in code:
             self.assert_reconstruct(g, c)
 
+    def test_template_rule(self):
+        g = """
+        start: (NL | binfunc)*
+        binfunc: WORD "(" binarg{WORD} ")"
+        binarg{arg}: arg "," arg
+        NL: /(\\r?\\n)+\\s*/
+        """ + common
+
+        code = """
+        func(a, b)
+        """
+
+        self.assert_reconstruct(g, code)
+
     def test_json_example(self):
         test_json = '''
             {


### PR DESCRIPTION
Trees generated by the parser don't retain template information in their token names, so Reconstructor was trying to match the tree using the non-templated name, which caused an error.

Add the full template name from the children matched by the tree matcher as a meta attribute for the given child so it can be read when recursing into that child.

This fixes #1500