### PR TITLE
Fix Transformer_NonRecursive crashing when root node is discarded

### DIFF
--- a/lark/visitors.py
+++ b/lark/visitors.py
@@ -326,6 +326,8 @@ class Transformer_NonRecursive(Transformer[_Leaf_T, _Return_T]):
             else:
                 stack.append(x)
 
+        if not stack:
+            return None     # type: ignore[return-value]
         result, = stack  # We should have only one tree remaining
         # There are no guarantees on the type of the value produced by calling a user func for a
         # child will produce. This means type system can't statically know that the final result is

--- a/tests/test_trees.py
+++ b/tests/test_trees.py
@@ -415,6 +415,17 @@ class TestTrees(TestCase):
             result = T().transform(copied)
             self.assertEqual(result, Tree('start', [3, 7]))
 
+    def test_transformer_discard_root(self):
+        """Transformer_NonRecursive should return None (not crash) when the root node is discarded."""
+        for base in (Transformer, Transformer_NonRecursive):
+            class T(base):
+                def start(self, children):
+                    return Discard
+
+            tree = Tree('start', [Token('A', 'x')])
+            result = T().transform(tree)
+            self.assertIsNone(result)
+
     def test_merge_transformers(self):
         tree = Tree('start', [
             Tree('main', [


### PR DESCRIPTION
## Bug

`Transformer_NonRecursive.transform()` raises `ValueError: not enough values to unpack (expected 1, got 0)` when the root tree node's callback returns `Discard`.

```python
from lark import Lark
from lark.visitors import Transformer_NonRecursive, Discard

class T(Transformer_NonRecursive):
    def start(self, children):
        return Discard

g = Lark('start: A+\nA: /[a-z]+/', lexer='basic')
tree = g.parse('hello')
T().transform(tree)  # ValueError: not enough values to unpack (expected 1, got 0)
```

The regular `Transformer` handles this correctly by returning `None` when the root is discarded (see `Transformer.transform()` lines 161–163).

## Fix

Add the same empty-stack guard to `Transformer_NonRecursive.transform()` before the destructuring assignment.

Two-line change in `lark/visitors.py` + a regression test in `tests/test_trees.py`.