### PR TITLE
Fix lexer_callbacks silently dropped for keyword terminals (#1618)

### DIFF
--- a/lark/lexer.py
+++ b/lark/lexer.py
@@ -595,8 +595,13 @@ class BasicLexer(AbstractBasicLexer):
 
         for type_, f in self.user_callbacks.items():
             if type_ in self.callback:
-                # Already a callback there, probably UnlessCallback
-                self.callback[type_] = CallChain(self.callback[type_], f, lambda t: t.type == type_)
+                # Already a callback there, probably UnlessCallback.
+                # Bind ``type_`` per iteration; otherwise every CallChain's
+                # condition closes over the loop variable and checks the last
+                # terminal's name, silently skipping the other callbacks.
+                self.callback[type_] = CallChain(
+                    self.callback[type_], f, lambda t, type_=type_: t.type == type_
+                )
             else:
                 self.callback[type_] = f
 

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -36,6 +36,25 @@ class TestGrammar(TestCase):
         assert p.parse("a b") == p.parse("a    b")
         assert len(spaces) == 5
 
+    def test_lexer_callbacks_with_keyword_terminals(self):
+        # Issue #1618: when several terminals both absorb a keyword
+        # (UnlessCallback) and have a lexer_callbacks entry, every callback but
+        # the last used to be silently skipped because the CallChain condition
+        # closed over the loop variable.
+        fired = []
+        p = Lark(r"""
+            start: (A | B | AKW | BKW)+
+            A: /[a-z]+/
+            B: /[0-9]+/
+            AKW: "foo"
+            BKW: "123"
+            %ignore " "
+        """, parser='lalr', lexer='basic',
+            lexer_callbacks={'A': lambda t: fired.append('A') or t,
+                             'B': lambda t: fired.append('B') or t})
+        list(p.lex("abc 456"))
+        assert sorted(set(fired)) == ['A', 'B']
+
 
     def test_override_rule(self):
         # Overrides the 'sep' template in existing grammar to add an optional terminating delimiter


### PR DESCRIPTION
## Summary

Fixes #1618. When two or more terminals each absorb a same-priority keyword literal (so they get an `UnlessCallback`) **and** have a `lexer_callbacks` entry, every user callback except the last silently never fires.

```python
fired = []
p = Lark(r'''
    start: (A | B | AKW | BKW)+
    A: /[a-z]+/
    B: /[0-9]+/
    AKW: "foo"
    BKW: "123"
    %ignore " "
''', parser='lalr', lexer='basic',
    lexer_callbacks={'A': lambda t: fired.append('A') or t,
                     'B': lambda t: fired.append('B') or t})
list(p.lex("abc 456"))
# before: fired == ['B']   (A dropped)
# after:  fired == ['A', 'B']
```

## Root cause

`BasicLexer` chains an existing `UnlessCallback` with the user callback:

```python
self.callback[type_] = CallChain(self.callback[type_], f, lambda t: t.type == type_)
```

The `lambda t: t.type == type_` closes over the loop variable `type_`, so after the loop **every** `CallChain` condition compares against the last terminal's name. For all but the last terminal the condition is never true, so the user callback is skipped.

## Fix

Bind `type_` per iteration via a default argument (`lambda t, type_=type_: ...`).

## Verification

- Added `TestGrammar.test_lexer_callbacks_with_keyword_terminals`; it fails on `master` (only the last callback fires) and passes here.
- Full test suite: **1107 passed, 167 skipped** (no regressions).
- Keyword absorption still works (the `UnlessCallback` continues to convert `foo`/`123` to `AKW`/`BKW`, which correctly do *not* trigger the `A`/`B` callbacks).
