### PR TITLE
Fix Python comprehension filters after each for clause

### DIFF
--- a/lark/grammars/python.lark
+++ b/lark/grammars/python.lark
@@ -252,7 +252,8 @@ kwargs: "**" test ("," argvalue)*
 
 comprehension{comp_result}: comp_result comp_fors
 comp_fors: comp_for+
-comp_for: [ASYNC] "for" exprlist "in" or_test comp_if*
+comp_for: [ASYNC] "for" exprlist "in" or_test comp_ifs
+comp_ifs: comp_if*
 ASYNC: "async"
 ?comp_if: "if" test_nocond
 

--- a/lark/grammars/python.lark
+++ b/lark/grammars/python.lark
@@ -250,9 +250,9 @@ kwargs: "**" test ("," argvalue)*
 ?argvalue: test ("=" test)?
 
 
-comprehension{comp_result}: comp_result comp_fors [comp_if]
+comprehension{comp_result}: comp_result comp_fors
 comp_fors: comp_for+
-comp_for: [ASYNC] "for" exprlist "in" or_test
+comp_for: [ASYNC] "for" exprlist "in" or_test comp_if*
 ASYNC: "async"
 ?comp_if: "if" test_nocond
 

--- a/tests/test_python_grammar.py
+++ b/tests/test_python_grammar.py
@@ -293,6 +293,27 @@ class TestPythonParser(TestCase):
             with self.assertRaises(ParseError):
                 self.python_parser.parse(case, start="file_input")
 
+    def test_comprehensions_with_interleaved_filters(self):
+        clauses = (
+            "for i in range(3) if i > 0 if i < 3 "
+            "for j in range(5) if j % 2 == 0 if j < 4"
+        )
+        cases = [
+            f"[(i, j) {clauses}]",
+            f"{{(i, j) {clauses}}}",
+            f"{{i: j {clauses}}}",
+            f"((i, j) {clauses})",
+        ]
+        for case in cases:
+            with self.subTest(case=case):
+                self.python_parser.parse(case + "\n", start="file_input")
+
+        async_comprehension = textwrap.dedent("""
+        async def collect():
+            return [(i, j) async for i in first() if i async for j in second() if j]
+        """)
+        self.python_parser.parse(async_comprehension, start="file_input")
+
     def test_assign_to_variable_named_match(self):
         text = textwrap.dedent("""
         match = re.match(pattern, string)


### PR DESCRIPTION
## Summary

- attach zero or more `comp_if` clauses to each `comp_for`
- allow filters to appear between multiple comprehension `for` clauses
- add regression coverage for list, set, dict, generator, and async comprehensions

## Why

Python permits every comprehension `for` clause to have its own sequence of `if` filters. Lark's grammar instead placed one optional filter after the entire `comp_fors` sequence, so valid expressions such as:

```python
[(i, j) for i in range(3) if i > 0 for j in range(5) if j % 2 == 0]
```

failed when the parser reached the second `for`.

This change mirrors CPython's `for_if_clause` structure by keeping each clause's filters with that clause.

Fixes #1525.

## Validation

- `python3 -m tests TestPythonParser`
- `python3 -m tests` (`1311` tests passed, `174` skipped)
- `pre-commit run --all-files --show-diff-on-failure`
- parsed 51 real Python files from `lark/` and `tests/`
- verified the regression with both LALR/contextual and Earley/basic parsers
- verified the synchronous examples are accepted by both CPython and Lark
