### PR TITLE
Support backslash line continuations in lark.lark

### DIFF
--- a/lark/grammars/lark.lark
+++ b/lark/grammars/lark.lark
@@ -58,5 +58,8 @@ _NL: /(\r?\n)+\s*/
 
 COMMENT: /\s*/ "//" /[^\n]/* | /\s*/ "#" /[^\n]/*
 
+BACKSLASH: /\\[ ]*\n/
+
 %ignore WS_INLINE
 %ignore COMMENT
+%ignore BACKSLASH

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -328,6 +328,14 @@ class TestGrammar(TestCase):
         p.parse('ab')
 
 
+    def test_line_breaks_in_lark_lark(self):
+        # The `lark.lark` meta-grammar must accept line continuations too
+        lark_lark = Lark.open_from_package('lark', 'lark.lark', ('grammars',), parser='lalr')
+        lark_lark.parse(r"""start: "a" \
+                       "b"
+""")
+
+
     def test_symbol_eq(self):
         a = None
         b = Symbol("abc")


### PR DESCRIPTION
Fixes #1620.

`lark.lark` (the meta-grammar used to parse Lark grammars) does not accept backslash-newline line continuations, even though grammars parsed by Lark support them. Loading a grammar that uses a line continuation via `Lark.open_from_package('lark', 'lark.lark', ...)` raises `UnexpectedCharacters`.

```
start: "a" \\
       "b"
```

### Change
- Add a `BACKSLASH` terminal matching `\\[ ]*\n` and `%ignore` it, mirroring how `WS_INLINE` and `COMMENT` are handled.
- Add `test_line_breaks_in_lark_lark` covering the case.

### Verification
Run against the new test:
- without the `lark.lark` change: fails with `UnexpectedCharacters`
- with the change: passes