### PR TITLE
Fix misaligned error pointer for full-width characters

### DIFF
--- a/lark/exceptions.py
+++ b/lark/exceptions.py
@@ -21,10 +21,22 @@ def assert_config(value, options: Collection, msg='Got %r, expected one of %s'):
     if value not in options:
         raise ConfigurationError(msg % (value, options))
 def _padding_for(before):
-    return ''.join(
-        '\u3000' if unicodedata.east_asian_width(ch) in ('W' ,'F') else ' '
-        for ch in before.expandtabs()
-    )
+    col = 0
+    result = []
+    for ch in before:
+        if ch == '\t':
+           spaces = 8 - (col % 8)
+           result.append(' ' * spaces)
+           col += spaces
+        else:
+           if unicodedata.east_asian_width(ch) in ('W' ,'F') 
+               result.append('\u3000')
+               col += 2
+        else:   
+             result.append(' ')
+             col += 1
+    return ''.join(result)   
+    
 
 
 

--- a/lark/exceptions.py
+++ b/lark/exceptions.py
@@ -1,4 +1,5 @@
 from .utils import logger, NO_VALUE
+import unicodedata
 from typing import Mapping, Iterable, Callable, Union, TypeVar, Tuple, Any, List, Set, Optional, Collection, TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -19,6 +20,12 @@ class ConfigurationError(LarkError, ValueError):
 def assert_config(value, options: Collection, msg='Got %r, expected one of %s'):
     if value not in options:
         raise ConfigurationError(msg % (value, options))
+def _padding_for(before):
+    return ''.join(
+        '\u3000' if unicodedata.east_asian_width(ch) in ('W' ,'F') else ' '
+        for ch in before.expandtabs()
+    )
+
 
 
 class GrammarError(LarkError):
@@ -66,7 +73,7 @@ class UnexpectedInput(LarkError):
         if not isinstance(text, bytes):
             before = text[start:pos].rsplit('\n', 1)[-1]
             after = text[pos:end].split('\n', 1)[0]
-            return before + after + '\n' + ' ' * len(before.expandtabs()) + '^\n'
+            return before + after + '\n' + _padding_for(before) + '^\n'
         else:
             before = text[start:pos].rsplit(b'\n', 1)[-1]
             after = text[pos:end].split(b'\n', 1)[0]

--- a/lark/exceptions.py
+++ b/lark/exceptions.py
@@ -20,22 +20,24 @@ class ConfigurationError(LarkError, ValueError):
 def assert_config(value, options: Collection, msg='Got %r, expected one of %s'):
     if value not in options:
         raise ConfigurationError(msg % (value, options))
+
+
 def _padding_for(before):
     col = 0
     result = []
     for ch in before:
         if ch == '\t':
-           spaces = 8 - (col % 8)
-           result.append(' ' * spaces)
-           col += spaces
+            spaces = 8 - (col % 8)
+            result.append(' ' * spaces)
+            col += spaces
         else:
-           if unicodedata.east_asian_width(ch) in ('W' ,'F') 
-               result.append('\u3000')
-               col += 2
-        else:   
-             result.append(' ')
-             col += 1
-    return ''.join(result)   
+            if unicodedata.east_asian_width(ch) in ('W', 'F'):
+                result.append('\u3000')
+                col += 2
+            else:
+                result.append(' ')
+                col += 1
+    return ''.join(result)
     
 
 


### PR DESCRIPTION
Fixes #1530

`get_context()` pads the `^` error pointer using one regular space
per preceding character. This assumes every character has the same
visual width, which breaks down for full-width (CJK) characters,
causing the pointer to land on the wrong column.

This PR adds a `_padding_for()` helper that checks each character's
Unicode east-asian-width property and substitutes a full-width space
(U+3000) for wide/full-width characters, keeping the pointer aligned
regardless of character width.