### PR TITLE
Bugfix: maybe_placeholders pads shorter alternatives of an optional (#1078)

### DIFF
--- a/lark/load_grammar.py
+++ b/lark/load_grammar.py
@@ -223,6 +223,45 @@ class FindRuleSize(Transformer):
         return max(self._args_as_int(args))
 
 
+def _balance_optional_arity(rule: Tree, keep_all_tokens: bool) -> None:
+    """Pad shorter alternatives of an optional so the whole group has fixed arity.
+
+    ``maybe_placeholders`` promises a ``[...]`` group a constant number of children.
+    When the group's alternatives differ in width (``["a" | "b" "c"]``), the shorter
+    ones must be trailing-padded with placeholders to match the widest (Issue #1078).
+    """
+    def arity(node) -> int:
+        # Number of tree children the node yields: kept symbols and placeholders count one each.
+        if node is _EMPTY:
+            return 1
+        if isinstance(node, Terminal):
+            return 1 if keep_all_tokens or not node.filter_out else 0
+        if isinstance(node, NonTerminal):
+            return 0 if node.name.startswith('_') else 1
+        if isinstance(node, Tree):
+            if node.data == 'expansion':
+                return sum(arity(c) for c in node.children)
+            if node.data == 'expansions':
+                return max(arity(c) for c in node.children)
+        return 1
+
+    if not isinstance(rule, Tree):
+        return
+    for child in rule.children:
+        _balance_optional_arity(child, keep_all_tokens)
+    if rule.data == 'expansions':
+        widths = [arity(b) for b in rule.children]
+        width = max(widths)
+        for i, (branch, w) in enumerate(zip(list(rule.children), widths)):
+            if w >= width:
+                continue
+            pad = [_EMPTY] * (width - w)
+            if isinstance(branch, Tree) and branch.data == 'expansion':
+                branch.children += pad
+            else:
+                rule.children[i] = ST('expansion', [branch, *pad])
+
+
 @inline_args
 class EBNF_to_BNF(Transformer_InPlace):
     def __init__(self):
@@ -374,6 +413,7 @@ class EBNF_to_BNF(Transformer_InPlace):
 
     def maybe(self, rule: Tree):
         keep_all_tokens = self.rule_options and self.rule_options.keep_all_tokens
+        _balance_optional_arity(rule, keep_all_tokens)
         rule_size = FindRuleSize(keep_all_tokens).transform(rule)
         empty = ST('expansion', [_EMPTY] * rule_size)
         return ST('expansions', [rule, empty])

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2484,7 +2484,32 @@ def _make_parser_test(LEXER, PARSER):
 
             p = _Lark(r"""!start: "a" ["b" | "c" "d"] """, maybe_placeholders=True)
             self.assertEqual(p.parse("a").children, ['a', None, None])
-            # self.assertEqual(p.parse("ab").children, ['a', 'b', None])        # Not implemented; current behavior is incorrect
+            self.assertEqual(p.parse("ab").children, ['a', 'b', None])
+            self.assertEqual(p.parse("acd").children, ['a', 'c', 'd'])
+
+            # Shorter branches of an optional alternation pad to the widest branch (#1078)
+            p = _Lark(r"""!start: "a" ["b" | "c" "d" | "e" "f" "g"] """, maybe_placeholders=True)
+            self.assertEqual(p.parse("a").children, ['a', None, None, None])
+            self.assertEqual(p.parse("ab").children, ['a', 'b', None, None])
+            self.assertEqual(p.parse("acd").children, ['a', 'c', 'd', None])
+            self.assertEqual(p.parse("aefg").children, ['a', 'e', 'f', 'g'])
+
+            # The optional keeps fixed arity regardless of where the alternation sits
+            p = _Lark(r"""!start: ["a" | "b" "c"] "z" """, maybe_placeholders=True)
+            self.assertEqual(p.parse("z").children, [None, None, 'z'])
+            self.assertEqual(p.parse("az").children, ['a', None, 'z'])
+            self.assertEqual(p.parse("bcz").children, ['b', 'c', 'z'])
+
+            # Alternation nested in a group inside the optional pads too
+            p = _Lark(r"""!start: [ ("a" | "b" "c") "d" ] """, maybe_placeholders=True)
+            self.assertEqual(p.parse("").children, [None, None, None])
+            self.assertEqual(p.parse("ad").children, ['a', None, 'd'])
+            self.assertEqual(p.parse("bcd").children, ['b', 'c', 'd'])
+
+            # maybe_placeholders=False stays unpadded (arity varies, no None inserted)
+            p = _Lark(r"""!start: "a" ["b" | "c" "d"] """, maybe_placeholders=False)
+            self.assertEqual(p.parse("a").children, ['a'])
+            self.assertEqual(p.parse("ab").children, ['a', 'b'])
             self.assertEqual(p.parse("acd").children, ['a', 'c', 'd'])
 
 


### PR DESCRIPTION
`maybe_placeholders` promises an optional `[...]` group a fixed number of children so consumers can index positionally. When the group's alternatives differ in width, the arity varied per input:

```
!start: "a" ["b" | "c" "d"]
"a"   -> ['a', None, None]
"ab"  -> ['a', 'b']          # arity 2 -> children[2] raises IndexError
"acd" -> ['a', 'c', 'd']
```

`maybe()` padded only the absent case up to the widest branch; a matched narrower branch was left short. This is the case flagged `# Not implemented; current behavior is incorrect` in `test_maybe_placeholders`, and issue #1078 ("the argument count must remain the same whether or not there is a match").

The fix pads each shorter alternative with trailing placeholders during EBNF expansion, so every derivation of the optional has the same arity — `"ab"` now yields `['a', 'b', None]`. It also handles nested and non-leading alternations (`[("a" | "b" "c") "d"]`, `["a" | "b" "c"] "z"`), and leaves `maybe_placeholders=False` untouched. Same result on earley and lalr.

Re-enables the maintainer's own commented expectation and adds the sibling cases as regression tests.
