### PR TITLE
Add support for a (ASCII) and L (locale) regex flags

### DIFF
--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -122,7 +122,7 @@ SIGNED_INTEGER: /
  /x
 ```
 
-Supported flags are one of: `imslux`. See Python's regex documentation for more details on each one.
+Supported flags are one of: `imsluxaL`. See Python's regex documentation for more details on each one.
 
 Regexps/strings of different flags can only be concatenated in Python 3.6+
 

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -122,7 +122,7 @@ SIGNED_INTEGER: /
  /x
 ```
 
-Supported flags are one of: `imsluxaL`. See Python's regex documentation for more details on each one.
+Supported flags are one of: `aiLmsux`. See Python's regex documentation for more details on each one.
 
 Regexps/strings of different flags can only be concatenated in Python 3.6+
 

--- a/examples/advanced/template_lark.lark
+++ b/examples/advanced/template_lark.lark
@@ -43,7 +43,7 @@ OP: /[+*]|[?](?![a-z])/
 RULE: /!?[_?]?[a-z][_a-z0-9]*/
 TOKEN: /_?[A-Z][_A-Z0-9]*/
 STRING: _STRING "i"?
-REGEXP: /\/(?!\/)(\\\/|\\\\|[^\/\n])*?\/[imslux]*/
+REGEXP: /\/(?!\/)(\\\/|\\\\|[^\/\n])*?\/[aimsLux]*/
 _NL: /(\r?\n)+\s*/
 
 %import common.ESCAPED_STRING -> _STRING

--- a/examples/advanced/template_lark.lark
+++ b/examples/advanced/template_lark.lark
@@ -43,7 +43,7 @@ OP: /[+*]|[?](?![a-z])/
 RULE: /!?[_?]?[a-z][_a-z0-9]*/
 TOKEN: /_?[A-Z][_A-Z0-9]*/
 STRING: _STRING "i"?
-REGEXP: /\/(?!\/)(\\\/|\\\\|[^\/\n])*?\/[aimsLux]*/
+REGEXP: /\/(?!\/)(\\\/|\\\\|[^\/\n])*?\/[aiLmsux]*/
 _NL: /(\r?\n)+\s*/
 
 %import common.ESCAPED_STRING -> _STRING

--- a/lark/grammars/lark.lark
+++ b/lark/grammars/lark.lark
@@ -49,7 +49,7 @@ OP: /[+*]|[?](?![a-z])/
 RULE: /!?[_?]?[a-z][_a-z0-9]*/
 TOKEN: /_?[A-Z][_A-Z0-9]*/
 STRING: _STRING "i"?
-REGEXP: /\/(?!\/)(\\\/|\\\\|[^\/])*?\/[aimsLux]*/
+REGEXP: /\/(?!\/)(\\\/|\\\\|[^\/])*?\/[aiLmsux]*/
 _NL: /(\r?\n)+\s*/
 
 %import common.ESCAPED_STRING -> _STRING

--- a/lark/grammars/lark.lark
+++ b/lark/grammars/lark.lark
@@ -49,7 +49,7 @@ OP: /[+*]|[?](?![a-z])/
 RULE: /!?[_?]?[a-z][_a-z0-9]*/
 TOKEN: /_?[A-Z][_A-Z0-9]*/
 STRING: _STRING "i"?
-REGEXP: /\/(?!\/)(\\\/|\\\\|[^\/])*?\/[imslux]*/
+REGEXP: /\/(?!\/)(\\\/|\\\\|[^\/])*?\/[aimsLux]*/
 _NL: /(\r?\n)+\s*/
 
 %import common.ESCAPED_STRING -> _STRING

--- a/lark/lexer.py
+++ b/lark/lexer.py
@@ -604,8 +604,9 @@ class BasicLexer(AbstractBasicLexer):
             terminal_to_regexp = {}
             for t in terminals:
                 regexp = t.pattern.to_regexp()
+                regexp_for_validation = regexp.encode('latin-1') if conf.use_bytes else regexp
                 try:
-                    self.re.compile(regexp, conf.g_regex_flags)
+                    self.re.compile(regexp_for_validation, conf.g_regex_flags)
                 except self.re.error:
                     raise LexError("Cannot compile token %s: %s" % (t.name, t.pattern))
 

--- a/lark/load_grammar.py
+++ b/lark/load_grammar.py
@@ -29,7 +29,7 @@ IMPORT_PATHS = ['grammars']
 
 EXT = '.lark'
 
-_RE_FLAGS = 'aimsLux'
+_RE_FLAGS = 'aiLmsux'
 
 _EMPTY = Symbol('__empty__')
 

--- a/lark/load_grammar.py
+++ b/lark/load_grammar.py
@@ -29,7 +29,7 @@ IMPORT_PATHS = ['grammars']
 
 EXT = '.lark'
 
-_RE_FLAGS = 'imslux'
+_RE_FLAGS = 'aimsLux'
 
 _EMPTY = Symbol('__empty__')
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1808,6 +1808,19 @@ def _make_parser_test(LEXER, PARSER):
             x = g.parse('abcdef')
             self.assertEqual(x.children, ['abcdef'])
 
+        def test_token_flags_ascii(self):
+            g = _Lark(r"""start: ASCII_WORD
+                          ASCII_WORD: /\w+/a
+                      """)
+            self.assertEqual(g.parse('abc').children, ['abc'])
+            self.assertRaises(UnexpectedCharacters, g.parse, 'é')
+
+        def test_token_flags_locale_bytes(self):
+            g = _Lark(r"""start: WORD
+                          WORD: /\w+/L
+                      """, use_bytes=True)
+            self.assertEqual(g.parse(b'abc').children[0].value, b'abc')
+
         @unittest.skipIf(PARSER == 'cyk', "No empty rules")
         def test_twice_empty(self):
             g = """!start: ("A"?)?


### PR DESCRIPTION
Closes #1527

Adds \\ (re.ASCII) and \L\ (re.LOCALE) to the supported regex flags in Lark grammar patterns.