### PR TITLE
group alternations and escape range endpoints in terminal patterns

### DIFF
--- a/lark/load_grammar.py
+++ b/lark/load_grammar.py
@@ -605,7 +605,7 @@ def _char_to_regexp(char: str) -> str:
     codepoint = ord(char)
     if char.isascii():
         return re.escape(char)
-    return '\\x%02x' % codepoint if codepoint <= 0xff else '\\U%08x' % codepoint
+    return f'\\x{codepoint:02x}' if codepoint <= 0xff else f'\\U{codepoint:08x}'
 
 
 @inline_args
@@ -626,28 +626,6 @@ def _make_joined_pattern(regexp, flags_set) -> PatternRE:
     return PatternRE(regexp, ())
 
 
-def _has_bare_alternation(regexp: str) -> bool:
-    """Whether ``regexp`` has a ``|`` outside of any group, i.e. one that isn't already
-    bound by surrounding parentheses.
-    """
-    depth = 0
-    in_class = False
-    chars = iter(regexp)
-    for c in chars:
-        if c == '\\':
-            next(chars, None)
-        elif in_class:
-            in_class = c != ']'
-        elif c == '[':
-            in_class = True
-        elif c == '(':
-            depth += 1
-        elif c == ')':
-            depth -= 1
-        elif c == '|' and not depth:
-            return True
-    return False
-
 class TerminalTreeToPattern(Transformer_NonRecursive):
     def pattern(self, ps):
         p ,= ps
@@ -660,10 +638,9 @@ class TerminalTreeToPattern(Transformer_NonRecursive):
         if len(items) == 1:
             return items[0]
 
-        # A bare '|' binds looser than concatenation, so an item carrying one has to be grouped
-        # before it's joined, or it swallows its neighbors: /a|b/ "c" must not become 'a|bc'.
-        regexps = [i.to_regexp() for i in items]
-        pattern = ''.join('(?:%s)' % r if _has_bare_alternation(r) else r for r in regexps)
+        # A bare '|' binds looser than concatenation, so each item is grouped before
+        # it's joined, or it swallows its neighbors: /a|b/ "c" must not become 'a|bc'.
+        pattern = ''.join(f'(?:{i.to_regexp()})' for i in items)
         return _make_joined_pattern(pattern, {i.flags for i in items})
 
     def expansions(self, exps: List[Pattern]) -> Pattern:

--- a/lark/load_grammar.py
+++ b/lark/load_grammar.py
@@ -3,6 +3,7 @@
 
 import hashlib
 import os.path
+import re
 import sys
 from collections import namedtuple
 from copy import copy, deepcopy
@@ -596,6 +597,17 @@ def _literal_to_pattern(literal):
         assert False, 'Invariant failed: literal.type not in ["STRING", "REGEXP"]'
 
 
+def _char_to_regexp(char: str) -> str:
+    """Escape a single character for use inside a regexp character class.
+
+    The result stays ascii, because the pattern may later be encoded to bytes (``use_bytes``).
+    """
+    codepoint = ord(char)
+    if char.isascii():
+        return re.escape(char)
+    return '\\x%02x' % codepoint if codepoint <= 0xff else '\\U%08x' % codepoint
+
+
 @inline_args
 class PrepareLiterals(Transformer_InPlace):
     def literal(self, literal):
@@ -603,15 +615,38 @@ class PrepareLiterals(Transformer_InPlace):
 
     def range(self, start, end):
         assert start.type == end.type == 'STRING'
-        start = start.value[1:-1]
-        end = end.value[1:-1]
-        assert len(eval_escaping(start)) == len(eval_escaping(end)) == 1
-        regexp = '[%s-%s]' % (start, end)
+        start = eval_escaping(start.value[1:-1])
+        end = eval_escaping(end.value[1:-1])
+        assert len(start) == len(end) == 1
+        regexp = '[%s-%s]' % (_char_to_regexp(start), _char_to_regexp(end))
         return ST('pattern', [PatternRE(regexp)])
 
 
 def _make_joined_pattern(regexp, flags_set) -> PatternRE:
     return PatternRE(regexp, ())
+
+
+def _has_bare_alternation(regexp: str) -> bool:
+    """Whether ``regexp`` has a ``|`` outside of any group, i.e. one that isn't already
+    bound by surrounding parentheses.
+    """
+    depth = 0
+    in_class = False
+    chars = iter(regexp)
+    for c in chars:
+        if c == '\\':
+            next(chars, None)
+        elif in_class:
+            in_class = c != ']'
+        elif c == '[':
+            in_class = True
+        elif c == '(':
+            depth += 1
+        elif c == ')':
+            depth -= 1
+        elif c == '|' and not depth:
+            return True
+    return False
 
 class TerminalTreeToPattern(Transformer_NonRecursive):
     def pattern(self, ps):
@@ -625,7 +660,10 @@ class TerminalTreeToPattern(Transformer_NonRecursive):
         if len(items) == 1:
             return items[0]
 
-        pattern = ''.join(i.to_regexp() for i in items)
+        # A bare '|' binds looser than concatenation, so an item carrying one has to be grouped
+        # before it's joined, or it swallows its neighbors: /a|b/ "c" must not become 'a|bc'.
+        regexps = [i.to_regexp() for i in items]
+        pattern = ''.join('(?:%s)' % r if _has_bare_alternation(r) else r for r in regexps)
         return _make_joined_pattern(pattern, {i.flags for i in items})
 
     def expansions(self, exps: List[Pattern]) -> Pattern:

--- a/lark/load_grammar.py
+++ b/lark/load_grammar.py
@@ -600,12 +600,14 @@ def _literal_to_pattern(literal):
 def _char_to_regexp(char: str) -> str:
     """Escape a single character for use inside a regexp character class.
 
-    The result stays ascii, because the pattern may later be encoded to bytes (``use_bytes``).
+    Characters in 0x80-0xff are written as ``\\xNN`` escapes: under ``use_bytes`` the
+    pattern is later encoded (utf-8 by the dynamic lexer), which would split a literal
+    character into two bytes. Anything else is left to ``re.escape``, which keeps
+    non-ascii characters literal.
     """
-    codepoint = ord(char)
-    if char.isascii():
-        return re.escape(char)
-    return f'\\x{codepoint:02x}' if codepoint <= 0xff else f'\\U{codepoint:08x}'
+    if '\x80' <= char <= '\xff':
+        return f'\\x{ord(char):02x}'
+    return re.escape(char)
 
 
 @inline_args
@@ -638,9 +640,9 @@ class TerminalTreeToPattern(Transformer_NonRecursive):
         if len(items) == 1:
             return items[0]
 
-        # A bare '|' binds looser than concatenation, so each item is grouped before
-        # it's joined, or it swallows its neighbors: /a|b/ "c" must not become 'a|bc'.
-        pattern = ''.join(f'(?:{i.to_regexp()})' for i in items)
+        # A bare '|' binds looser than concatenation, so an item containing one is grouped
+        # before it's joined, or it swallows its neighbors: /a|b/ "c" must not become 'a|bc'.
+        pattern = ''.join(f'(?:{r})' if '|' in r else r for r in (i.to_regexp() for i in items))
         return _make_joined_pattern(pattern, {i.flags for i in items})
 
     def expansions(self, exps: List[Pattern]) -> Pattern:

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -322,6 +322,11 @@ class TestGrammar(TestCase):
         for s in ('!', '0', '\t'):
             self.assertRaises(UnexpectedInput, l.parse, s)
 
+        # Non-ascii endpoints stay literal, so the pattern is the same string as /[а-я]/
+        # (interegular and anonymous-terminal dedup both compare pattern strings)
+        l = Lark('start: T\nT: "а".."я"', parser='lalr')
+        self.assertEqual(l.get_terminal('T').pattern.to_regexp(), '[а-я]')
+
     def test_list_grammar_imports(self):
             grammar = """
             %import .test_templates_import (start, sep)

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -299,6 +299,29 @@ class TestGrammar(TestCase):
         for i in (-1, 1000):
             self.assertRaises(UnexpectedInput, l.parse, str(i))
 
+    def test_concat_regexp_with_alternation(self):
+        # A '|' outside a group binds looser than concatenation, so it used to swallow
+        # whatever was concatenated after it: /admin|user/ "_id" compiled to 'admin|user_id'.
+        l = Lark('start: T\nT: /admin|user/ "_id"', parser='lalr')
+        for s in ('admin_id', 'user_id'):
+            self.assertEqual(l.parse(s), Tree('start', [s]))
+        for s in ('admin', 'user'):
+            self.assertRaises(UnexpectedInput, l.parse, s)
+
+        # A '|' that is escaped, inside a character class, or already grouped keeps its meaning
+        for term, matches in [(r'/a\|b/', 'a|bc'), ('/[a|b]/', 'ac'), ('/(a|b)/', 'ac')]:
+            l = Lark('start: T\nT: %s "c"' % term, parser='lalr')
+            self.assertEqual(l.parse(matches), Tree('start', [matches]))
+
+    def test_literal_range_escapes_endpoints(self):
+        # Endpoints were spliced into the character class as written, so a metacharacter
+        # escaped it: "^".."z" became '[^-z]', a negated class matching almost everything.
+        l = Lark('start: T\nT: "^".."z"', parser='lalr')
+        for s in ('^', 'a', 'z'):
+            self.assertEqual(l.parse(s), Tree('start', [s]))
+        for s in ('!', '0', '\t'):
+            self.assertRaises(UnexpectedInput, l.parse, s)
+
     def test_list_grammar_imports(self):
             grammar = """
             %import .test_templates_import (start, sep)


### PR DESCRIPTION
1. `TerminalTreeToPattern.expansion` joins sub-patterns by plain concatenation, so a regexp literal holding a top-level `|` binds looser than the join: `T: /admin|user/ "_id"` compiles to `admin|user_id`, which rejects `admin_id` and accepts a bare `admin`.
2. `PrepareLiterals.range` splices the endpoints' raw source text into the character class, so an endpoint that is itself a metacharacter escapes it: `T: "^".."z"` compiles to `[^-z]`, a negated class matching tab and digits while rejecting `z`.

Either way a terminal written as a restriction matches outside the language it declares, which is the part that worries me when the grammar is what validates untrusted input.

Grouping is applied only when the item carries a `|` outside any group, so an escaped `\|`, one inside a character class, and an already-parenthesized one are left alone. Range endpoints are unescaped and then re-escaped for a class, kept ascii because the pattern may still be encoded to bytes under `use_bytes` (the dynamic lexer encodes utf-8, the basic one latin-1). The other two spellings of that alternation, `/a|b/i` and `("a"|"b")`, already went through `(?:...)`, so only the third one changes.

Compiled patterns for `common.lark`, `python.lark` and `lark.lark` come out identical to master. Full suite green, mypy clean, and the two tests added in `tests/test_grammar.py` fail on master and pass here.
