### PR TITLE
Fix terminal priorities ignored in dynamic Earley lexer for recursive rules

### DIFF
--- a/lark/parsers/xearley.py
+++ b/lark/parsers/xearley.py
@@ -56,24 +56,65 @@ class Parser(BaseParser):
             # they complete, we push all tokens into a buffer (delayed_matches), to
             # be held possibly for a later parse step when we reach the point in the
             # input stream at which they complete.
+            #
+            # When terminal priorities are in use, we apply the traditional
+            # "longest match, then highest priority" filter so that a higher-
+            # priority terminal suppresses lower-priority matches at the same
+            # position that are not longer.  This mirrors the behavior of the
+            # basic/standard lexer and prevents spurious ambiguities that the
+            # ForestSumVisitor cannot resolve by priority sum alone (see #1441).
+            matched_items = []
             for item in self.Set(to_scan):
                 m = match(item.expect, stream, i)
                 if m:
-                    t = Token(item.expect.name, m.group(0), i, text_line, text_column)
-                    delayed_matches[m.end()].append( (item, i, t) )
+                    matched_items.append((item, m))
 
-                    if self.complete_lex:
-                        s = m.group(0)
-                        for j in range(1, len(s)):
-                            m = match(item.expect, s[:-j])
-                            if m:
-                                t = Token(item.expect.name, m.group(0), i, text_line, text_column)
-                                delayed_matches[i+m.end()].append( (item, i, t) )
+            # Determine the best (longest length, highest priority) match at
+            # this position so we can filter out dominated alternatives.
+            # We only filter when:
+            #  - priorities are in use (forest_sum_visitor is set)
+            #  - complete_lex is False (dynamic_complete intentionally explores
+            #    all sub-match lengths for full ambiguity)
+            #  - the matched terminals have differing priorities
+            if matched_items and self.forest_sum_visitor is not None and not self.complete_lex:
+                def _term_priority(item):
+                    term = terminals.get(item.expect.name)
+                    return term.priority if term is not None else 0
 
-                    # XXX The following 3 lines were commented out for causing a bug. See issue #768
-                    # # Remove any items that successfully matched in this pass from the to_scan buffer.
-                    # # This ensures we don't carry over tokens that already matched, if we're ignoring below.
-                    # to_scan.remove(item)
+                best_priority = max(_term_priority(item) for item, m in matched_items)
+                min_priority = min(_term_priority(item) for item, m in matched_items)
+                # Only filter when priorities actually differ among matched terminals
+                if best_priority > min_priority:
+                    best_len_at_priority = max(
+                        m.end() - i
+                        for item, m in matched_items
+                        if _term_priority(item) == best_priority
+                    )
+                    filtered = []
+                    for item, m in matched_items:
+                        match_len = m.end() - i
+                        # Keep if: this IS the highest-priority terminal, OR
+                        # it matches longer than the best high-priority match
+                        if _term_priority(item) >= best_priority or match_len > best_len_at_priority:
+                            filtered.append((item, m))
+                    matched_items = filtered
+
+            for item, m in matched_items:
+                t = Token(item.expect.name, m.group(0), i, text_line, text_column)
+                delayed_matches[m.end()].append( (item, i, t) )
+
+                if self.complete_lex:
+                    s = m.group(0)
+                    for j in range(1, len(s)):
+                        m = match(item.expect, s[:-j])
+                        if m:
+                            t = Token(item.expect.name, m.group(0), i, text_line, text_column)
+                            delayed_matches[i+m.end()].append( (item, i, t) )
+
+                # XXX The following 3 lines were commented out for causing a bug. See issue #768
+                # # Remove any items that successfully matched in this pass from the to_scan buffer.
+                # # This ensures we don't carry over tokens that already matched, if we're ignoring below.
+                # to_scan.remove(item)
 
             # 3) Process any ignores. This is typically used for e.g. whitespace.
             # We carry over any unmatched items from the to_scan buffer to be matched again after

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2395,6 +2395,26 @@ def _make_parser_test(LEXER, PARSER):
             self.assertEqual(t.children, ['a', 'bc'])
             self.assertEqual(t.children[0].type, 'A')
 
+        @unittest.skipIf(LEXER=='basic', "This scenario only occurs with the dynamic lexers")
+        @unittest.skipIf(LEXER=='dynamic_complete', "dynamic_complete intentionally generates all sub-matches")
+        @unittest.skipIf(PARSER=='cyk', "Not applicable to CYK")
+        def test_terminal_priority_in_recursive_rule(self):
+            """Terminal priorities should be respected in recursive rules (issue #1441)."""
+            g = r"""
+            %import common.SIGNED_INT
+            %import common.SIGNED_FLOAT
+            %import common.WS
+            %ignore WS
+            FLOAT.1: SIGNED_FLOAT
+            INT: SIGNED_INT
+            start: FLOAT | INT | "[" start* "]"
+            """
+            l = _Lark(g)
+            t = l.parse("[1 2.0 3]")
+            # "2.0" must be matched as a single FLOAT, not split into INT "2" + FLOAT ".0"
+            self.assertEqual(len(t.children), 3)
+            self.assertEqual(t.children[1].children[0], '2.0')
+
         def test_line_counting(self):
             p = _Lark("start: /[^x]+/")
 


### PR DESCRIPTION
## Summary

Fixes #1441

Terminal priorities (e.g. `FLOAT.1`) were not being respected in recursive rules when using the dynamic Earley lexer (the default for `parser='earley'`).

## Reproduction

```python
from lark import Lark

parser = Lark(r"""
%import common.SIGNED_INT
%import common.SIGNED_FLOAT
%import common.WS
%ignore WS
FLOAT.1: SIGNED_FLOAT
INT: SIGNED_INT
start: FLOAT | INT | "[" start* "]"
""")
print(parser.parse('[1 2.0 3]').pretty())
```

**Before fix (on master):**
```
start
  start  1
  start  2
  start  .0
  start  3
```
"2.0" is split into INT("2") + FLOAT(".0") = 4 children.

**After fix:**
```
start
  start  1
  start  2.0
  start  3
```
"2.0" is correctly matched as FLOAT("2.0") = 3 children. Matches LALR and earley/basic behavior.

## Root Cause

The dynamic Earley scanner (`xearley.py`) explores ALL possible terminal matches at each position, building an SPPF forest. Disambiguation is then handled by `ForestSumVisitor` which **sums** terminal priorities across packed nodes. However, for this grammar both derivations accumulate an identical priority sum of 1:

- Wrong: INT("1",p=0) + INT("2",p=0) + FLOAT(".0",p=1) + INT("3",p=0) = 1
- Correct: INT("1",p=0) + FLOAT("2.0",p=1) + INT("3",p=0) = 1

So the visitor cannot distinguish them and the wrong derivation wins by insertion order.

## Fix

Apply traditional "longest match + highest priority" filtering in the scan phase of `xearley.py`:
- At each position `i`, collect all terminal matches.
- Find the highest priority among them and the longest match at that priority.
- Suppress any match from a lower-priority terminal whose length does not exceed the best high-priority match length.

**Filtering rule in words:** a lower-priority terminal's match is suppressed if and only if a higher-priority terminal also matches at the same position with length >= the lower-priority match. This mirrors the standard lexer behavior.

**Conditions for filtering (to avoid breaking existing behavior):**
1. Terminal priorities are in use (`forest_sum_visitor` is set)
2. `complete_lex` is False (`dynamic_complete` mode intentionally explores all sub-match lengths for full ambiguity)
3. The matched terminals have **differing** priorities (`best_priority > min_priority`). This correctly handles the negative-priority idiom: `INT.-1` to de-prioritize a terminal also triggers filtering.

**Safe fallback:** If a terminal name is missing from `terminals_by_name` (e.g. `%declare`), its priority defaults to 0 via a helper function, avoiding `AttributeError`.

## Validation

**Per-permutation test results (all green):**
| Class | Result |
|-------|--------|
| TestEarleyDynamic | 89 passed, 16 skipped |
| TestEarleyDynamic_complete | 88 passed, 17 skipped |
| TestEarleyBasic | 88 passed, 17 skipped |
| TestLalrContextual | 98 passed, 7 skipped |
| TestFullEarleyDynamic | 31 passed, 2 skipped |
| TestFullEarleyBasic | 22 passed, 11 skipped |
| TestParsers | 17 passed |
| **Total** | **990 passed, 176 skipped, 0 failed** |

**Priority-specific tests:** 17 passed, 6 skipped (including `test_priority_vs_embedded`, `test_ignore_carryover_with_priority`)

**Regression test added:** `test_terminal_priority_in_recursive_rule` — skipped for `basic` (already works) and `dynamic_complete` (different semantics).

## Compatibility

- Grammars without terminal priorities: unaffected (no `forest_sum_visitor` or all priorities equal).
- `dynamic_complete` lexer mode: unaffected (filtering disabled).
- Negative priority idiom (`TERM.-1`): works correctly, triggers filtering when priorities differ.
- `%declare` terminals: handled gracefully (default priority 0).