### PR TITLE
Update Python versions and add a windows run for tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,17 +3,21 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13-dev", "pypy-3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.15-dev", "pypy-3.10"]
+        os: [ubuntu-latest]
+        include:
+          - os: windows-latest
+            python-version: "3.14"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies


### PR DESCRIPTION
This updates the versions on which we run to include 3.14 and the preview version of 3.15. It also runs a proper test run on windows which was a signal I was missing from #1628.


It may also make sense to run codecov on pull_request instead of on push so that we see the changes done by external PRs, @erezsh.