### PR TITLE
Support zero-width terminals in dynamic Earley

### DIFF
--- a/lark/parser_frontends.py
+++ b/lark/parser_frontends.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import Any, Callable, Dict, Optional, Collection, Union, TYPE_CHECKING, Generic, Iterator, Tuple, TypeVar
 
 from .exceptions import ConfigurationError, GrammarError, LexError, UnexpectedInput, assert_config
-from .utils import get_regexp_width, Serialize, TextOrSlice, TextSlice, LarkInput
+from .utils import Serialize, TextOrSlice, TextSlice, LarkInput
 from .lexer import LexerThread, LineCounter, Token, _TextSlice_WithLineCount, BasicLexer, ContextualLexer, Lexer
 from .parsers import earley, xearley, cyk
 from .parsers.lalr_parser import LALR_Parser
@@ -292,13 +292,6 @@ class EarleyRegexpMatcher:
         self.regexps = {}
         for t in lexer_conf.terminals:
             regexp = t.pattern.to_regexp()
-            try:
-                width = get_regexp_width(regexp)[0]
-            except ValueError:
-                raise GrammarError("Bad regexp in token %s: %s" % (t.name, regexp))
-            else:
-                if width == 0:
-                    raise GrammarError("Dynamic Earley doesn't allow zero-width regexps", t)
             if lexer_conf.use_bytes:
                 regexp = regexp.encode('utf-8')
 

--- a/lark/parsers/xearley.py
+++ b/lark/parsers/xearley.py
@@ -39,6 +39,46 @@ class Parser(BaseParser):
 
     def _parse(self, stream, columns, to_scan, start_symbol=None):
 
+        def scan_zero_width(i, to_scan, node_cache):
+            """Advance zero-width terminals in the current Earley column.
+
+            Dynamic lexing normally delays each match until the input position at
+            which it ends. A zero-width match ends in the current column instead,
+            so it must be advanced before the regular scanner moves on. Each item
+            is considered once to prevent nullable terminal cycles from looping.
+            """
+            matched = self.Set()
+            while True:
+                self.predict_and_complete(i, to_scan, columns, transitives, node_cache)
+                zero_width_items = []
+                for item in self.Set(to_scan):
+                    if item in matched:
+                        continue
+                    m = match(item.expect, stream, i)
+                    if m and m.end() == i:
+                        zero_width_items.append((item, m))
+                    matched.add(item)
+
+                if not zero_width_items:
+                    return
+
+                for item, m in zero_width_items:
+                    t = Token(item.expect.name, m.group(0), i, text_line, text_column)
+                    t.end_line = text_line
+                    t.end_column = text_column
+                    t.end_pos = i
+
+                    new_item = item.advance()
+                    label = (new_item.s, new_item.start, i)
+                    token_node = TokenNode(t, terminals[t.type])
+                    new_item.node = node_cache[label] if label in node_cache else node_cache.setdefault(label, self.SymbolNode(*label))
+                    new_item.node.add_family(new_item.s, item.rule, new_item.start, item.node, token_node)
+
+                    if new_item.expect in self.TERMINALS:
+                        to_scan.add(new_item)
+                    else:
+                        columns[i].add(new_item)
+
         def scan(i, to_scan):
             """The core Earley Scanner.
 
@@ -156,7 +196,7 @@ class Parser(BaseParser):
         i = 0
         node_cache = {}
         for token in stream:
-            self.predict_and_complete(i, to_scan, columns, transitives, node_cache)
+            scan_zero_width(i, to_scan, node_cache)
 
             to_scan, node_cache = scan(i, to_scan)
 
@@ -167,7 +207,7 @@ class Parser(BaseParser):
                 text_column += 1
             i += 1
 
-        self.predict_and_complete(i, to_scan, columns, transitives, node_cache)
+        scan_zero_width(i, to_scan, node_cache)
 
         ## Column is now the final column in the parse.
         assert i == len(columns)-1

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -505,6 +505,17 @@ def _make_full_earley_test(LEXER):
             empty_tree = Tree('empty', [Tree('empty2', [])])
             self.assertSequenceEqual(res.children, ['a', empty_tree, empty_tree, 'b'])
 
+        @unittest.skipIf(LEXER == 'basic', "Requires dynamic lexer")
+        def test_earley_zero_width_terminals(self):
+            grammar = r'''
+                !start: BEFORE "a" AFTER
+                BEFORE: /(?=a)/
+                AFTER: /(?=$)/
+            '''
+
+            parser = Lark(grammar, parser='earley', lexer=LEXER)
+            self.assertSequenceEqual(parser.parse('a').children, ['', 'a', ''])
+
         @unittest.skipIf(LEXER=='basic', "Requires dynamic lexer")
         def test_earley_explicit_ambiguity(self):
             # This was a sneaky bug!
@@ -2632,7 +2643,11 @@ def _make_parser_test(LEXER, PARSER):
                 start: NAME NAME?
                 NAME: /(?(?=\d)\d+|\w*)/
             """
-            self.assertRaises((GrammarError, LexError, re.error), _Lark, g, regex=True)
+            if PARSER == 'earley' and LEXER in ('dynamic', 'dynamic_complete'):
+                p = _Lark(g, regex=True)
+                self.assertEqual(p.parse("").children, ["", ""])
+            else:
+                self.assertRaises((GrammarError, LexError, re.error), _Lark, g, regex=True)
 
         @unittest.skipIf(PARSER != 'lalr', "interactive_parser is only implemented for LALR at the moment")
         def test_parser_interactive_parser(self):


### PR DESCRIPTION
Dynamic Earley previously rejected all nullable regular-expression terminals because its scanner only processed delayed matches at subsequent input positions. This advances zero-width matches in their current Earley column, using a fixed-point pass that processes each item once to avoid nullable-terminal cycles.\n\nAdds coverage for zero-width lookahead terminals and updates the regex-width fallback test.\n\nTests: ........................................................................ [  5%]
........................................................................ [ 10%]
.............................s..s.....s...........ss..............ss...s [ 16%]
....................sss...s..............s......................sssssss. [ 21%]
......s...ss......sss.....ss..ss....................sss.s.s............. [ 27%]
.s...s..................s...............................s.s....s........ [ 32%]
.................................s...................s........s......... [ 38%]
..ss...s.........s.sss......................sss...s..................... [ 43%]
.............s........s...........ss...s.........s.sss.................. [ 49%]
....sss...s.....................................s....................... [ 54%]
........s.s....s........................................................ [ 60%]
........s...............................s.s....s........................ [ 65%]
.................s......................sssssss.......s...ss......sss... [ 71%]
..ss..ss....................sss.s.s..............s...s...............s.. [ 76%]
s.....s...........ss......s......s.s...s....................sss...s..... [ 82%]
.........s...................s..s.....s...........ss.............s.s...s [ 87%]
....................sss...s..............s.............sss............s. [ 93%]
s.s.ssss..s....s..................s....s................................ [ 98%]
...................                                                      [100%]
=========================== short test summary info ============================
SKIPPED [5] tests/test_parser.py:2762: Tree-less mode is not supported in earley
SKIPPED [8] tests/test_parser.py:1929: dynamic lexer prioritization differs from basic lexer prioritization
SKIPPED [7] tests/test_parser.py:2689: interactive_parser error handling only works with LALR for now
SKIPPED [7] tests/test_parser.py:2740: interactive_parser is only implemented for LALR at the moment
SKIPPED [7] tests/test_parser.py:2729: interactive_parser error handling only works with LALR for now
SKIPPED [6] tests/test_parser.py:2851: start_pos and end_pos not compatible with old style custom/dynamic lexer
SKIPPED [7] tests/test_parser.py:2652: interactive_parser is only implemented for LALR at the moment
SKIPPED [8] tests/test_parser.py:2228: Currently only Earley supports priority sum in rules
SKIPPED [7] tests/test_parser.py:2858: scan() only supports the LALR parser
SKIPPED [7] tests/test_parser.py:2529: Serialize currently only works for LALR parsers without custom lexers (though it should be easy to extend)
SKIPPED [7] tests/test_parser.py:2543: Serialize currently only works for LALR parsers without custom lexers (though it should be easy to extend)
SKIPPED [7] tests/test_parser.py:2788: strict mode is only supported in lalr for now
SKIPPED [7] tests/test_parser.py:1770: Requires context sensitive terminal selection
SKIPPED [2] tests/test_parser.py:1679: No empty rules
SKIPPED [2] tests/test_parser.py:2422: Empty rules
SKIPPED [2] tests/test_parser.py:1425: No empty rules
SKIPPED [2] tests/test_parser.py:1444: No empty rules
SKIPPED [2] tests/test_parser.py:1464: No empty rules
SKIPPED [2] tests/test_parser.py:2300: No empty rules
SKIPPED [3] tests/test_parser.py:2589: match_examples() not supported for CYK/old custom lexer
SKIPPED [2] tests/test_parser.py:1625: No empty rules
SKIPPED [2] tests/test_parser.py:2433: Empty rules
SKIPPED [2] tests/test_parser.py:2184: Doesn't work for CYK
SKIPPED [2] tests/test_parser.py:1351: Takes forever
SKIPPED [2] tests/test_parser.py:1822: No empty rules
SKIPPED [3] tests/test_parser.py:2724: test on_error only works with lalr
SKIPPED [2] tests/test_parser.py:1877: basic lexer prioritization differs from dynamic lexer prioritization
SKIPPED [4] tests/test_parser.py:2807: start_pos and end_pos not compatible with old style custom/dynamic lexer
SKIPPED [2] tests/test_parser.py:2138: %declare/postlex doesn't work with dynamic
SKIPPED [2] tests/test_parser.py:2161: %declare/postlex doesn't work with dynamic
SKIPPED [1] tests/test_parser.py:535: Requires dynamic lexer
SKIPPED [1] tests/test_parser.py:551: Requires dynamic lexer
SKIPPED [1] tests/test_parser.py:809: This ambiguity only occurs with the dynamic lexers
SKIPPED [1] tests/test_parser.py:439: Requires dynamic lexer
SKIPPED [2] tests/test_parser.py:462: Only relevant for the dynamic_complete parser
SKIPPED [1] tests/test_parser.py:519: Requires dynamic lexer
SKIPPED [1] tests/test_parser.py:508: Requires dynamic lexer
SKIPPED [2] tests/test_parser.py:866: Only relevant for the dynamic_complete parser
SKIPPED [1] tests/test_parser.py:828: Requires dynamic lexer
SKIPPED [1] tests/test_parser.py:919: Ignore carry-over is dynamic-lexer-specific
SKIPPED [1] tests/test_parser.py:934: This scenario only occurs with the dynamic lexers
SKIPPED [1] tests/test_parser.py:1044: start/end values work differently for the basic lexer