### PR TITLE
Make generated regexps deterministic across processes

### DIFF
--- a/lark/lexer.py
+++ b/lark/lexer.py
@@ -69,8 +69,7 @@ class Pattern(Serialize, ABC):
         raise NotImplementedError()
 
     def _get_flags(self, value):
-        # Sorted: flags is a frozenset, so iterating it directly makes the result depend
-        # on hash randomization and differ between processes.
+        # Sorted to remove the hash randomization in sets, that differs between processes
         for f in sorted(self.flags):
             value = ('(?%s:%s)' % (f, value))
         return value

--- a/lark/lexer.py
+++ b/lark/lexer.py
@@ -69,7 +69,9 @@ class Pattern(Serialize, ABC):
         raise NotImplementedError()
 
     def _get_flags(self, value):
-        for f in self.flags:
+        # Sorted: flags is a frozenset, so iterating it directly makes the result depend
+        # on hash randomization and differ between processes.
+        for f in sorted(self.flags):
             value = ('(?%s:%s)' % (f, value))
         return value
 

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -40,7 +40,5 @@ class TestLexer(TestCase):
         assert res == list('abccbadd')
 
 
-
-
 if __name__ == '__main__':
     main()

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -19,6 +19,14 @@ class TestLexer(TestCase):
         res = list(p.lex("abc cba dd", dont_ignore=True))
         assert res == list('abc cba dd')
 
+    def test_flag_order_is_deterministic(self):
+        # Two or more flags on one terminal is the only case where order exists; the
+        # other flag tests all use a single flag. Without sorting, the frozenset is
+        # iterated in hash order and the regexp differs between processes.
+        p = Lark('start: A+\nA: /x/imsu\n', parser='lalr')
+        self.assertEqual([t.pattern.to_regexp() for t in p.terminals],
+                         ['(?u:(?s:(?m:(?i:x))))'])
+
     def test_subset_lex(self):
         p = Lark("""
             start: "a" "b" "c" "d"
@@ -30,6 +38,8 @@ class TestLexer(TestCase):
 
         res = list(p.lex(TextSlice("aaaabc cba dddd", 3, -2)))
         assert res == list('abccbadd')
+
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Problem

`Pattern.flags` is a `frozenset`, and `_get_flags` iterates it directly to wrap the value in `(?f:...)` groups. Python randomizes string hashing per process, so a terminal with more than one flag renders to a **different regexp in every process**:

```console
$ for s in 0 1 2; do PYTHONHASHSEED=$s python -c "
from lark import Lark
print([t.pattern.to_regexp() for t in Lark('start: A+\nA: /x/imsu\n', parser='lalr').terminals])"; done
['(?i:(?u:(?s:(?m:x))))']
['(?m:(?u:(?i:(?s:x))))']
['(?u:(?i:(?m:(?s:x))))']
```

Matching is unaffected — every flag applies whatever the nesting order — but the rendered string is user-visible: `Pattern.__repr__` is `repr(self.to_regexp())`, so it appears in `LexError("Cannot compile token %s: %s")`, in `TerminalDef.user_repr()`, and in the collision warnings.

### Fix

Iterate `sorted(self.flags)`. `flags` stays a `frozenset`, so the subset check in `_create_unless` is unchanged.

This is one source of hash-order dependence, not all of them — it does **not** make the standalone generator or `serialize()` reproducible (I measured: still 5 distinct outputs over `PYTHONHASHSEED=0..4`, same as before). #584 and #1194 have further causes.

### Test

One test. It uses **two or more flags on a single terminal**, which as far as I can tell nothing else does — `test_token_flags` and `test_join_regex_flags` are single-flag-per-terminal, and with one flag there is no order to get wrong. Against unpatched `master` it fails on 10 of 10 `PYTHONHASHSEED` values; with the patch, 0 of 10.

It lives on the existing `TestLexer` class rather than a new one, since `tests/__main__.py` imports specific classes — a new `TestCase` would never be collected. Happy to move it to `test_parser.py` alongside the other flag tests if you'd prefer it there.

Full suite: 1313 tests, 0 failures.
