### PR TITLE
Validate literal ranges with GrammarError instead of assert

### DIFF
--- a/lark/load_grammar.py
+++ b/lark/load_grammar.py
@@ -605,7 +605,10 @@ class PrepareLiterals(Transformer_InPlace):
         assert start.type == end.type == 'STRING'
         start = start.value[1:-1]
         end = end.value[1:-1]
-        assert len(eval_escaping(start)) == len(eval_escaping(end)) == 1
+        # Not an assert: -O strips it, silently accepting "ab".."z" as the class [ab-z].
+        if len(eval_escaping(start)) != 1 or len(eval_escaping(end)) != 1:
+            raise GrammarError("Literal range must be defined by single characters, "
+                               "not \"%s\"..\"%s\"" % (start, end))
         regexp = '[%s-%s]' % (start, end)
         return ST('pattern', [PatternRE(regexp)])
 

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -151,6 +151,14 @@ class TestGrammar(TestCase):
             """
         self.assertRaises(GrammarError, Lark, g)
 
+    def test_literal_range_multichar(self):
+        # Under `python -O` the old assert was stripped and the range silently compiled
+        # to the class [ab-z], which is not what the grammar says.
+        g = """start: A
+            A: "ab".."z"
+            """
+        self.assertRaises(GrammarError, Lark, g)
+
     def test_undefined_rule(self):
         self.assertRaises(GrammarError, Lark, """start: a""")
 


### PR DESCRIPTION
### Problem

`PrepareLiterals.range` validates literal ranges with bare `assert`s:

```python
assert start.type == end.type == 'STRING'
assert len(eval_escaping(start)) == len(eval_escaping(end)) == 1
```

Normally a bad range surfaces as `VisitError` wrapping a message-less `AssertionError`. More importantly, **`-O` strips asserts**, so the check disappears and the grammar is silently accepted:

```console
$ python -O -c "
from lark import Lark
p = Lark('start: A\nA: \"ab\"..\"z\"\n')
print([t.pattern.to_regexp() for t in p.terminals])"
['[ab-z]']
```

`[ab-z]` matches `a` plus the range `b`–`z` — not what the grammar says, and no error is raised. Input validation can't live in an `assert`.

### Fix

Raise `GrammarError`, following #1596.

```
GrammarError: Literal range must be defined by single characters, not "ab".."z"
```

### Tests

Two, both regression tests — a multi-character endpoint and an escaped one (`"\x41\x42".."z"`, so the check is on the *unescaped* length). Against unpatched `master` they **error** under normal execution and **fail** under `-O`, for different reasons: the wrong exception type escapes, versus no exception at all.

I dropped the valid-range test from the first revision — `test_unicode_literal_range_escape` and `test_hex_literal_range_escape` already cover that.

Full suite: 1314 tests, 0 failures, in both modes.
