### PR TITLE
Fix end_line/end_column in the dynamic Earley lexer

### DIFF
--- a/lark/parsers/xearley.py
+++ b/lark/parsers/xearley.py
@@ -98,10 +98,14 @@ class Parser(BaseParser):
             # and create the symbol node in the SPPF tree. Advance the item that completed,
             # and add the resulting new item to either the Earley set (for processing by the
             # completer/predictor) or the to_scan buffer for the next parse step.
+            # Tokens in delayed_matches[i+1] end just past stream[i], so their end
+            # position is the position of stream[i+1], not that of stream[i].
+            end_line, end_column = position_after(i)
+
             for item, start, token in delayed_matches[i+1]:
                 if token is not None:
-                    token.end_line = text_line
-                    token.end_column = text_column + 1
+                    token.end_line = end_line
+                    token.end_column = end_column
                     token.end_pos = i + 1
 
                     new_item = item.advance()
@@ -148,6 +152,16 @@ class Parser(BaseParser):
         text_line = 1
         text_column = 1
 
+        # Iterating over bytes yields ints, so slice the stream instead of indexing it
+        # to get a value comparable to the newline. Same approach as LineCounter.
+        newline = b'\n' if isinstance(stream, bytes) else '\n'
+
+        def position_after(i):
+            """Line & column of stream[i+1], i.e. of the position just past stream[i]."""
+            if stream[i:i+1] == newline:
+                return text_line + 1, 1
+            return text_line, text_column + 1
+
         ## The main Earley loop.
         # Run the Prediction/Completion cycle for any Items in the current Earley set.
         # Completions will be added to the SPPF tree, and predictions will be recursively
@@ -155,16 +169,12 @@ class Parser(BaseParser):
         # step.
         i = 0
         node_cache = {}
-        for token in stream:
+        for _ in stream:
             self.predict_and_complete(i, to_scan, columns, transitives, node_cache)
 
             to_scan, node_cache = scan(i, to_scan)
 
-            if token == '\n':
-                text_line += 1
-                text_column = 1
-            else:
-                text_column += 1
+            text_line, text_column = position_after(i)
             i += 1
 
         self.predict_and_complete(i, to_scan, columns, transitives, node_cache)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2408,6 +2408,32 @@ def _make_parser_test(LEXER, PARSER):
             self.assertEqual(tok.end_line, 2)
             self.assertEqual(tok.end_column, 6)
 
+        def test_line_counting_newline_at_end(self):
+            # A token whose last character is a newline ends at the start of the
+            # next line, not one column further along its own line.
+            p = _Lark("start: /[^x]+/")
+
+            text = 'hello\nworld\n'
+            t = p.parse(text)
+            tok = t.children[0]
+            self.assertEqual(tok, text)
+            self.assertEqual(tok.line, 1)
+            self.assertEqual(tok.column, 1)
+            self.assertEqual(tok.end_pos, len(text))
+            self.assertEqual(tok.end_line, 3)
+            self.assertEqual(tok.end_column, 1)
+
+        def test_line_counting_bytes(self):
+            p = _Lark("start: /[^x]+/", use_bytes=True)
+
+            text = b'hello\nworld'
+            t = p.parse(text)
+            tok = t.children[0]
+            self.assertEqual(tok.line, 1)
+            self.assertEqual(tok.column, 1)
+            self.assertEqual(tok.end_line, 2)
+            self.assertEqual(tok.end_column, 6)
+
         @unittest.skipIf(PARSER=='cyk', "Empty rules")
         def test_empty_end(self):
             p = _Lark("""


### PR DESCRIPTION
With the dynamic lexer, a token whose last character is a newline reports the wrong end position.

```python
from lark import Lark
p = Lark("start: /[^x]+/")          # parser='earley', lexer='dynamic'
tok = p.parse("hello\nworld\n").children[0]
tok.end_pos     # 12
tok.end_line    # 2, should be 3
tok.end_column  # 7, should be 1
```

`end_pos` 12 is one past the end of a two-line text, so the position at that offset is the start of line 3. Every other parser and lexer combination reports `(3, 1)`. The wrong value propagates into `tree.meta` under `propagate_positions`, and `earley` with `dynamic` is what a plain `Lark(grammar)` gives you.

`test_line_counting` is the test aimed at this, and it parses `'hello\nworld'`, where the token ends on `d`. The last character of the token is never a newline there, so the case cannot arise.

`xearley.py` derives the end from the line and column counters for `stream[i]`, while `end_pos` is `i + 1`. 3a04f49 fixed `end_pos` from `i` to `i + 1` back in 2020 and left the two lines above it on the old convention.

Those counters were also dead under `use_bytes=True`: iterating `bytes` yields ints, so `token == '\n'` was never true and the line number never advanced. `LineCounter` in `lark/lexer.py` handles that by selecting `b'\n'` for bytes input, and this change does the same.

I added two tests beside `test_line_counting`. They run under all ten parser and lexer combinations, fail on `dynamic` and `dynamic_complete` before the change, and pass elsewhere, so they pin the behaviour of the other lexers too.
