### PR TITLE
fix: pad narrower alternatives in maybe_placeholders mode

### DIFF
--- a/lark/parse_tree_builder.py
+++ b/lark/parse_tree_builder.py
@@ -340,14 +340,44 @@ class ParseTreeBuilder:
     def _init_builders(self, rules):
         propagate_positions = make_propagate_positions(self.propagate_positions)
 
+        # When maybe_placeholders is enabled, compute target width per rule origin
+        # so narrower alternatives within the same optional group get padded to match
+        # the widest alternative. We detect this by looking at rules with empty_indices
+        # that have trailing Nones (empty_indices after the last expansion element),
+        # which indicates an optional group was absent at the end.
+        target_width_by_origin = {}
+        if self.maybe_placeholders:
+            for rule in rules:
+                origin_name = rule.origin.name
+                ei = rule.options.empty_indices
+                if ei and len(rule.expansion) > 0:
+                    s = ''.join(str(int(b)) for b in ei)
+                    processed = [len(ones) for ones in s.split('0')]
+                    trailing = processed[len(rule.expansion)]
+                    if trailing > 0:
+                        target = len(rule.expansion) + trailing
+                        if origin_name not in target_width_by_origin or target > target_width_by_origin[origin_name]:
+                            target_width_by_origin[origin_name] = target
+
         for rule in rules:
             options = rule.options
             keep_all_tokens = options.keep_all_tokens
             expand_single_child = options.expand1
 
+            empty_indices = options.empty_indices if self.maybe_placeholders else None
+
+            # Pad narrower alternatives that have no empty_indices with trailing Nones
+            if self.maybe_placeholders and rule.origin.name in target_width_by_origin and not empty_indices:
+                target = target_width_by_origin[rule.origin.name]
+                visible = sum(1 for sym in rule.expansion
+                              if keep_all_tokens or not (sym.is_term and sym.filter_out))
+                trailing_nones = target - visible
+                if trailing_nones > 0:
+                    empty_indices = (False,) * len(rule.expansion) + (True,) * trailing_nones
+
             wrapper_chain = list(filter(None, [
                 (expand_single_child and not rule.alias) and ExpandSingleChild,
-                maybe_create_child_filter(rule.expansion, keep_all_tokens, self.ambiguous, options.empty_indices if self.maybe_placeholders else None),
+                maybe_create_child_filter(rule.expansion, keep_all_tokens, self.ambiguous, empty_indices),
                 propagate_positions,
                 self.ambiguous and maybe_create_ambiguous_expander(self.tree_class, rule.expansion, keep_all_tokens),
                 self.ambiguous and partial(AmbiguousIntermediateExpander, self.tree_class)


### PR DESCRIPTION
Fixes #1629

When `maybe_placeholders` is enabled and an alternative within an optional group matches fewer symbols than the widest alternative in the same group, the children list is left short.

For example, with `!start: "a" ["b" | "c" "d"]`:

```python
Lark('!start: "a" ["b" | "c" "d"]', maybe_placeholders=True).parse("ab")
# Before: Tree('start', ['a', 'b'])
# After:  Tree('start', ['a', 'b', None])
```

The absent case (`parse("a")`) already returned 3 elements (`['a', None, None]`) because `empty_indices` padded it correctly. However, matched narrower alternatives like `parse("ab")` were left short at 2 elements.

**Root cause:** Rules without `empty_indices` (representing matched alternatives) were not being padded to match the widest alternative's width.

**Fix:** In `ParseTreeBuilder._init_builders`, detect the target width from rules whose `empty_indices` contain trailing Nones (indicating an optional group was absent at the end). Then pad narrower alternatives that have no `empty_indices` with trailing Nones to match that target width.

All existing tests pass (Earley, LALR, standalone, etc.).

Co-authored-by: opencode <opencode@opencode.ai>